### PR TITLE
docs: correct @cursor/sdk patterns from API spike

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,25 +50,46 @@ plugins/cursor/
 
 ## @cursor/sdk Key Patterns
 
-```typescript
-import { Agent } from "@cursor/sdk/agent";
+Verified against `@cursor/sdk@1.0.9` (public beta).
 
-// Create local agent scoped to working directory
-const agent = Agent.create({
-  apiKey: process.env.CURSOR_API_KEY!,
-  model: { id: "composer-2" },
+```typescript
+import { Agent, Cursor } from "@cursor/sdk";
+import type { SDKMessage, ModelSelection } from "@cursor/sdk";
+
+// Agent.create / Agent.resume / Agent.prompt are all async — must await.
+const agent = await Agent.create({
+  apiKey: process.env.CURSOR_API_KEY,
+  model: { id: "composer-2" } satisfies ModelSelection,
   local: { cwd: "/path/to/repo" },
 });
 
-// Send prompt and stream results
 const run = await agent.send("task description");
 for await (const event of run.stream()) {
-  // event.type: "assistant" | "thinking" | "tool_call" | "status" | "task"
+  // event is SDKMessage — discriminated union of 8 variants:
+  // "system" | "user" | "assistant" | "thinking" | "tool_call"
+  //   | "status" | "task" | "request"
 }
 
-// Resume durable agent by ID
-const resumed = Agent.resume("agent-<uuid>", { ...opts });
+const result = await run.wait();   // RunResult: { status, result?, durationMs?, ... }
+// status is lowercase: "finished" | "error" | "cancelled"
+
+// Resume durable agent by ID (also async).
+const resumed = await Agent.resume("agent-<uuid>", { local: { cwd } });
+
+// One-shot helper: create + send + close, returns RunResult.
+const oneShot = await Agent.prompt("ping", { apiKey, model, local: { cwd } });
+
+// Account / catalog operations (used by /cursor:setup):
+await Cursor.me();              // verifies CURSOR_API_KEY
+await Cursor.models.list();     // discovers valid ModelSelection ids
+
+// Cleanup: agents implement Symbol.asyncDispose.
+await agent[Symbol.asyncDispose]();
 ```
+
+Status messages from `run.stream()` use uppercase + an extra `EXPIRED` state:
+`"CREATING" | "RUNNING" | "FINISHED" | "ERROR" | "CANCELLED" | "EXPIRED"`.
+The wrapper in `lib/cursor-agent.mts` normalizes these.
 
 ## Conventions
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -103,27 +103,41 @@ Wraps `@cursor/sdk` Agent with project-specific defaults and error handling.
 // - Cleanup/dispose agents
 // - Structured output support (for reviews)
 
+import type { ModelSelection, McpServerConfig } from "@cursor/sdk";
+
 interface CursorAgentOptions {
   cwd: string;
   apiKey: string;
-  model?: string;          // default: "composer-2"
+  model?: ModelSelection;   // default: { id: "composer-2" }
   mcpServers?: Record<string, McpServerConfig>;
+  settingSources?: Array<"project" | "user" | "team" | "mdm" | "plugins">;
 }
 
 interface CursorRunResult {
-  status: "FINISHED" | "ERROR";
+  // Mirrors SDK RunResult.status (lowercase) + "expired" for stale local runs
+  // surfaced via SDKStatusMessage.
+  status: "finished" | "error" | "cancelled" | "expired";
   output: string;           // aggregated text output
   toolCalls: ToolCallEvent[];
   agentId: string;          // for resume
+  durationMs?: number;
 }
 ```
 
 Key behaviors:
-- [ ] `createAgent(opts)` — create local agent, validate API key
+- [ ] `createAgent(opts)` — `await Agent.create(...)` (async), validate API key
 - [ ] `sendTask(agent, prompt)` — send prompt, stream events, aggregate output
-- [ ] `streamEvents(run)` — async generator yielding typed events for real-time display
-- [ ] `resumeAgent(agentId, opts)` — resume durable session
-- [ ] `disposeAgent(agent)` — cleanup resources
+- [ ] `streamEvents(run)` — async generator over `SDKMessage` (8 variants:
+      `system | user | assistant | thinking | tool_call | status | task | request`)
+- [ ] `resumeAgent(agentId, opts)` — `await Agent.resume(...)` (async)
+- [ ] `oneShot(prompt, opts)` — thin wrapper over `Agent.prompt()` for setup
+      smoke test and short stateless calls (review can use this)
+- [ ] `disposeAgent(agent)` — `await agent[Symbol.asyncDispose]()`
+- [ ] `listArtifacts(agent)` / `downloadArtifact(agent, path)` — expose SDK
+      artifact API for `/cursor:result` to retrieve generated files
+- [ ] Status normalization: SDK `RunResult.status` is lowercase; status-message
+      stream uses uppercase + extra `EXPIRED` state — wrapper presents one
+      consistent enum to callers
 - [ ] API key validation: check `CURSOR_API_KEY` env var, clear error message if missing
 - [ ] Model validation: call `Cursor.models.list()` to verify model exists
 - [ ] Timeout handling: cancel run if it exceeds configurable timeout


### PR DESCRIPTION
Verified against @cursor/sdk@1.0.9. Fixes:
- Agent.create / Agent.resume are async (must be awaited)
- Stream events are an 8-variant SDKMessage union, not 5
- Model option is ModelSelection, not string
- RunResult.status is lowercase; SDKStatusMessage adds EXPIRED
- Note Agent.prompt one-shot, listArtifacts, settingSources