### PR TITLE
feat(cursor-agent): wrap @cursor/sdk Agent with normalized run results

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -128,22 +128,23 @@ interface CursorRunResult {
 ```
 
 Key behaviors:
-- [ ] `createAgent(opts)` — `await Agent.create(...)` (async), validate API key
-- [ ] `sendTask(agent, prompt)` — send prompt, stream events, aggregate output
-- [ ] `streamEvents(run)` — async generator over `SDKMessage` (8 variants:
+- [x] `createAgent(opts)` — `await Agent.create(...)` (async), validate API key
+- [x] `sendTask(agent, prompt)` — send prompt, stream events, aggregate output
+- [x] `streamEvents(run)` — async generator over `SDKMessage` (8 variants:
       `system | user | assistant | thinking | tool_call | status | task | request`)
-- [ ] `resumeAgent(agentId, opts)` — `await Agent.resume(...)` (async)
-- [ ] `oneShot(prompt, opts)` — thin wrapper over `Agent.prompt()` for setup
+- [x] `resumeAgent(agentId, opts)` — `await Agent.resume(...)` (async)
+- [x] `oneShot(prompt, opts)` — thin wrapper over `Agent.prompt()` for setup
       smoke test and short stateless calls (review can use this)
-- [ ] `disposeAgent(agent)` — `await agent[Symbol.asyncDispose]()`
-- [ ] `listArtifacts(agent)` / `downloadArtifact(agent, path)` — expose SDK
+- [x] `disposeAgent(agent)` — `await agent[Symbol.asyncDispose]()`
+- [x] `listArtifacts(agent)` / `downloadArtifact(agent, path)` — expose SDK
       artifact API for `/cursor:result` to retrieve generated files
-- [ ] Status normalization: SDK `RunResult.status` is lowercase; status-message
+- [x] Status normalization: SDK `RunResult.status` is lowercase; status-message
       stream uses uppercase + extra `EXPIRED` state — wrapper presents one
-      consistent enum to callers
-- [ ] API key validation: check `CURSOR_API_KEY` env var, clear error message if missing
-- [ ] Model validation: call `Cursor.models.list()` to verify model exists
-- [ ] Timeout handling: cancel run if it exceeds configurable timeout
+      consistent enum to callers (`normalizeStreamStatus`)
+- [x] API key validation: check `CURSOR_API_KEY` env var, clear error message if missing (`resolveApiKey`)
+- [x] Model validation: call `Cursor.models.list()` to verify model exists (`validateModel`)
+- [x] Timeout handling: cancel run if it exceeds configurable timeout (`SendTaskOptions.timeoutMs`)
+- [x] Account helpers: `whoami` / `listModels` for `/cursor:setup`
 
 ### 2.2 `lib/workspace.mts` — Workspace Resolution
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -130,8 +130,9 @@ interface CursorRunResult {
 Key behaviors:
 - [x] `createAgent(opts)` — `await Agent.create(...)` (async), validate API key
 - [x] `sendTask(agent, prompt)` — send prompt, stream events, aggregate output
-- [x] `streamEvents(run)` — async generator over `SDKMessage` (8 variants:
-      `system | user | assistant | thinking | tool_call | status | task | request`)
+- ~~`streamEvents(run)` — async generator over `SDKMessage` (8 variants:
+      `system | user | assistant | thinking | tool_call | status | task | request`)~~
+      Dropped: a thin re-export added no value over `Run.stream()` directly. Callers that need raw events use the SDK iterator; consumers that want aggregated text/tool calls use `sendTask`.
 - [x] `resumeAgent(agentId, opts)` — `await Agent.resume(...)` (async)
 - [x] `oneShot(prompt, opts)` — thin wrapper over `Agent.prompt()` for setup
       smoke test and short stateless calls (review can use this)

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -56,6 +56,7 @@ export interface SendTaskOptions {
 
 export interface OneShotOptions extends CursorAgentOptions {
   timeoutMs?: number;
+  onEvent?: (event: SDKMessage) => void;
 }
 
 interface RequestOptions {
@@ -81,11 +82,11 @@ function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
   return {
     apiKey: resolveApiKey(opts.apiKey),
     model: opts.model ?? DEFAULT_MODEL,
-    name: opts.name,
     local: {
       cwd: opts.cwd,
       ...(opts.settingSources ? { settingSources: opts.settingSources } : {}),
     },
+    ...(opts.name ? { name: opts.name } : {}),
     ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
   };
 }
@@ -102,10 +103,6 @@ export async function disposeAgent(agent: SDKAgent): Promise<void> {
   await agent[Symbol.asyncDispose]();
 }
 
-export function streamEvents(run: Run): AsyncGenerator<SDKMessage, void> {
-  return run.stream();
-}
-
 /** Send a prompt, stream events, and resolve to a normalized result. */
 export async function sendTask(
   agent: SDKAgent,
@@ -116,19 +113,25 @@ export async function sendTask(
   return collectRunResult(run, options);
 }
 
-/** One-shot helper: create + send + close. Mirrors Agent.prompt(). */
+/**
+ * One-shot helper: create + send + dispose. Built on the same pipeline as
+ * `sendTask` so streaming, tool-call aggregation, and timeoutMs all apply.
+ * Disposal failures are swallowed so the run's result remains the primary
+ * signal to callers.
+ */
 export async function oneShot(prompt: string, opts: OneShotOptions): Promise<CursorRunResult> {
-  const { timeoutMs: _timeoutMs, ...agentOpts } = opts;
-  const agentOptions = buildAgentOptions(agentOpts);
-  const result = await Agent.prompt(prompt, agentOptions);
-  return {
-    status: normalizeRunResultStatus(result.status),
-    output: result.result ?? "",
-    toolCalls: [],
-    agentId: "",
-    runId: result.id,
-    durationMs: result.durationMs,
-  };
+  const { timeoutMs, onEvent, ...agentOpts } = opts;
+  const agent = await createAgent(agentOpts);
+  try {
+    const sendOpts: SendTaskOptions = {};
+    if (timeoutMs !== undefined) sendOpts.timeoutMs = timeoutMs;
+    if (onEvent !== undefined) sendOpts.onEvent = onEvent;
+    return await sendTask(agent, prompt, sendOpts);
+  } finally {
+    await disposeAgent(agent).catch(() => {
+      /* dispose is best-effort; primary result is what callers care about */
+    });
+  }
 }
 
 export async function listArtifacts(agent: SDKAgent): Promise<SDKArtifact[]> {
@@ -171,10 +174,6 @@ export function normalizeStreamStatus(
   return status.toLowerCase() as CursorAgentStatus | "creating" | "running";
 }
 
-function normalizeRunResultStatus(status: "finished" | "error" | "cancelled"): CursorAgentStatus {
-  return status;
-}
-
 async function collectRunResult(run: Run, options: SendTaskOptions): Promise<CursorRunResult> {
   const toolCalls = new Map<string, ToolCallEvent>();
   const textParts: string[] = [];
@@ -210,7 +209,7 @@ async function collectRunResult(run: Run, options: SendTaskOptions): Promise<Cur
     const result = await run.wait();
     const status: CursorAgentStatus = timedOut
       ? "cancelled"
-      : (observedTerminalStatus ?? normalizeRunResultStatus(result.status));
+      : (observedTerminalStatus ?? result.status);
     return {
       status,
       output: result.result ?? textParts.join(""),

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -1,0 +1,248 @@
+import {
+  Agent,
+  type AgentOptions,
+  ConfigurationError,
+  Cursor,
+  type McpServerConfig,
+  type ModelSelection,
+  type Run,
+  type SDKAgent,
+  type SDKArtifact,
+  type SDKMessage,
+  type SDKModel,
+  type SDKStatusMessage,
+  type SDKUser,
+  type SettingSource,
+} from "@cursor/sdk";
+
+export const DEFAULT_MODEL: ModelSelection = { id: "composer-2" };
+
+export type CursorAgentStatus = "finished" | "error" | "cancelled" | "expired";
+
+export interface ToolCallEvent {
+  callId: string;
+  name: string;
+  status: "running" | "completed" | "error";
+  args?: unknown;
+  result?: unknown;
+}
+
+export interface CursorRunResult {
+  status: CursorAgentStatus;
+  output: string;
+  toolCalls: ToolCallEvent[];
+  agentId: string;
+  runId: string;
+  durationMs?: number;
+  /** Set when the run was terminated by our local timeout. */
+  timedOut?: boolean;
+}
+
+export interface CursorAgentOptions {
+  cwd: string;
+  apiKey?: string;
+  model?: ModelSelection;
+  mcpServers?: Record<string, McpServerConfig>;
+  settingSources?: SettingSource[];
+  name?: string;
+}
+
+export interface SendTaskOptions {
+  /** Cancel the run if it does not complete within this many milliseconds. */
+  timeoutMs?: number;
+  /** Invoked once for every SDKMessage emitted while the run streams. */
+  onEvent?: (event: SDKMessage) => void;
+}
+
+export interface OneShotOptions extends CursorAgentOptions {
+  timeoutMs?: number;
+}
+
+interface RequestOptions {
+  apiKey?: string;
+}
+
+/**
+ * Resolve a Cursor API key from the supplied option or `CURSOR_API_KEY`.
+ * Throws a ConfigurationError when neither is set so callers fail fast with
+ * a clear message instead of a generic 401 from the SDK.
+ */
+export function resolveApiKey(apiKey?: string): string {
+  const resolved = apiKey ?? process.env.CURSOR_API_KEY;
+  if (!resolved || resolved.trim() === "") {
+    throw new ConfigurationError(
+      "CURSOR_API_KEY is not set. Export your Cursor API key or pass apiKey explicitly.",
+    );
+  }
+  return resolved;
+}
+
+function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
+  return {
+    apiKey: resolveApiKey(opts.apiKey),
+    model: opts.model ?? DEFAULT_MODEL,
+    name: opts.name,
+    local: {
+      cwd: opts.cwd,
+      ...(opts.settingSources ? { settingSources: opts.settingSources } : {}),
+    },
+    ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
+  };
+}
+
+export async function createAgent(opts: CursorAgentOptions): Promise<SDKAgent> {
+  return Agent.create(buildAgentOptions(opts));
+}
+
+export async function resumeAgent(agentId: string, opts: CursorAgentOptions): Promise<SDKAgent> {
+  return Agent.resume(agentId, buildAgentOptions(opts));
+}
+
+export async function disposeAgent(agent: SDKAgent): Promise<void> {
+  await agent[Symbol.asyncDispose]();
+}
+
+export function streamEvents(run: Run): AsyncGenerator<SDKMessage, void> {
+  return run.stream();
+}
+
+/** Send a prompt, stream events, and resolve to a normalized result. */
+export async function sendTask(
+  agent: SDKAgent,
+  prompt: string,
+  options: SendTaskOptions = {},
+): Promise<CursorRunResult> {
+  const run = await agent.send(prompt);
+  return collectRunResult(run, options);
+}
+
+/** One-shot helper: create + send + close. Mirrors Agent.prompt(). */
+export async function oneShot(prompt: string, opts: OneShotOptions): Promise<CursorRunResult> {
+  const { timeoutMs: _timeoutMs, ...agentOpts } = opts;
+  const agentOptions = buildAgentOptions(agentOpts);
+  const result = await Agent.prompt(prompt, agentOptions);
+  return {
+    status: normalizeRunResultStatus(result.status),
+    output: result.result ?? "",
+    toolCalls: [],
+    agentId: "",
+    runId: result.id,
+    durationMs: result.durationMs,
+  };
+}
+
+export async function listArtifacts(agent: SDKAgent): Promise<SDKArtifact[]> {
+  return agent.listArtifacts();
+}
+
+export async function downloadArtifact(agent: SDKAgent, path: string): Promise<Buffer> {
+  return agent.downloadArtifact(path);
+}
+
+/** Verify CURSOR_API_KEY by hitting the account endpoint. */
+export async function whoami(opts: RequestOptions = {}): Promise<SDKUser> {
+  return Cursor.me({ apiKey: resolveApiKey(opts.apiKey) });
+}
+
+export async function listModels(opts: RequestOptions = {}): Promise<SDKModel[]> {
+  return Cursor.models.list({ apiKey: resolveApiKey(opts.apiKey) });
+}
+
+/** Confirm a ModelSelection.id is in the catalog. Throws on miss. */
+export async function validateModel(
+  model: ModelSelection,
+  opts: RequestOptions = {},
+): Promise<SDKModel> {
+  const models = await listModels(opts);
+  const match = models.find((m) => m.id === model.id);
+  if (!match) {
+    const known = models.map((m) => m.id).join(", ") || "(none)";
+    throw new ConfigurationError(
+      `Model '${model.id}' is not available for this API key. Known models: ${known}`,
+    );
+  }
+  return match;
+}
+
+/** Normalize the uppercase status emitted on SDKStatusMessage to our enum. */
+export function normalizeStreamStatus(
+  status: SDKStatusMessage["status"],
+): CursorAgentStatus | "creating" | "running" {
+  return status.toLowerCase() as CursorAgentStatus | "creating" | "running";
+}
+
+function normalizeRunResultStatus(status: "finished" | "error" | "cancelled"): CursorAgentStatus {
+  return status;
+}
+
+async function collectRunResult(run: Run, options: SendTaskOptions): Promise<CursorRunResult> {
+  const toolCalls = new Map<string, ToolCallEvent>();
+  const textParts: string[] = [];
+  let observedTerminalStatus: CursorAgentStatus | undefined;
+  let timedOut = false;
+
+  const timeout =
+    options.timeoutMs !== undefined && options.timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true;
+          run.cancel().catch(() => {
+            /* run may already be terminal; swallow */
+          });
+        }, options.timeoutMs)
+      : undefined;
+
+  try {
+    for await (const event of run.stream()) {
+      options.onEvent?.(event);
+      ingestEvent(event, textParts, toolCalls);
+      if (event.type === "status") {
+        const normalized = normalizeStreamStatus(event.status);
+        if (
+          normalized === "finished" ||
+          normalized === "error" ||
+          normalized === "cancelled" ||
+          normalized === "expired"
+        ) {
+          observedTerminalStatus = normalized;
+        }
+      }
+    }
+    const result = await run.wait();
+    const status: CursorAgentStatus = timedOut
+      ? "cancelled"
+      : (observedTerminalStatus ?? normalizeRunResultStatus(result.status));
+    return {
+      status,
+      output: result.result ?? textParts.join(""),
+      toolCalls: [...toolCalls.values()],
+      agentId: run.agentId,
+      runId: run.id,
+      durationMs: result.durationMs,
+      ...(timedOut ? { timedOut: true } : {}),
+    };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function ingestEvent(
+  event: SDKMessage,
+  textParts: string[],
+  toolCalls: Map<string, ToolCallEvent>,
+): void {
+  if (event.type === "assistant") {
+    for (const block of event.message.content) {
+      if (block.type === "text") textParts.push(block.text);
+    }
+    return;
+  }
+  if (event.type === "tool_call") {
+    toolCalls.set(event.call_id, {
+      callId: event.call_id,
+      name: event.name,
+      status: event.status,
+      args: event.args,
+      result: event.result,
+    });
+  }
+}

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -54,10 +54,7 @@ export interface SendTaskOptions {
   onEvent?: (event: SDKMessage) => void;
 }
 
-export interface OneShotOptions extends CursorAgentOptions {
-  timeoutMs?: number;
-  onEvent?: (event: SDKMessage) => void;
-}
+export type OneShotOptions = CursorAgentOptions & SendTaskOptions;
 
 interface RequestOptions {
   apiKey?: string;
@@ -206,6 +203,9 @@ async function collectRunResult(run: Run, options: SendTaskOptions): Promise<Cur
         }
       }
     }
+    // Stream is drained — clear the timer before awaiting wait() so a
+    // late-firing timeout can't flip a naturally-finished run to cancelled.
+    if (timeout) clearTimeout(timeout);
     const result = await run.wait();
     const status: CursorAgentStatus = timedOut
       ? "cancelled"

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -50,7 +50,9 @@ function makeRun(events: SDKMessage[], result: RunResult): Run {
   return {
     id: result.id,
     agentId: "agent-test",
-    status,
+    get status() {
+      return status;
+    },
     get result() {
       return result.result;
     },

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -12,7 +12,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const sdkMocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
   agentResume: vi.fn(),
-  agentPrompt: vi.fn(),
   cursorMe: vi.fn(),
   modelsList: vi.fn(),
 }));
@@ -24,7 +23,6 @@ vi.mock("@cursor/sdk", async () => {
     Agent: {
       create: sdkMocks.agentCreate,
       resume: sdkMocks.agentResume,
-      prompt: sdkMocks.agentPrompt,
     },
     Cursor: {
       me: sdkMocks.cursorMe,
@@ -172,6 +170,29 @@ describe("createAgent / resumeAgent", () => {
     const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
     expect(call?.model).toEqual({ id: "gpt-5" });
     expect(call?.local).toEqual({ cwd: "/tmp/repo", settingSources: ["project", "user"] });
+  });
+
+  it("createAgent forwards mcpServers", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await createAgent({
+      cwd: "/tmp/repo",
+      mcpServers: { fs: { command: "mcp-fs" } },
+    });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.mcpServers).toEqual({ fs: { command: "mcp-fs" } });
+  });
+
+  it("createAgent omits 'name' when not provided", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await createAgent({ cwd: "/tmp/repo" });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call).not.toHaveProperty("name");
   });
 
   it("resumeAgent passes the agentId through", async () => {
@@ -335,31 +356,91 @@ describe("sendTask", () => {
 });
 
 describe("oneShot", () => {
-  it("calls Agent.prompt and normalizes the result", async () => {
-    const sdkResult: RunResult = {
-      id: "run-5",
-      status: "finished",
-      result: "done",
-      durationMs: 5,
-    };
-    sdkMocks.agentPrompt.mockResolvedValue(sdkResult);
+  it("creates an agent, runs the prompt, and disposes the agent", async () => {
+    const events: SDKMessage[] = [
+      {
+        type: "assistant",
+        agent_id: "agent-test",
+        run_id: "run-5",
+        message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+      },
+    ];
+    const run = makeRun(events, { id: "run-5", status: "finished", durationMs: 5 });
+    const fake = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(fake);
 
     const result = await oneShot("ping", { cwd: "/tmp/repo" });
 
-    expect(sdkMocks.agentPrompt).toHaveBeenCalledWith(
-      "ping",
+    expect(sdkMocks.agentCreate).toHaveBeenCalledWith(
       expect.objectContaining({
         apiKey: "test-key",
         model: DEFAULT_MODEL,
         local: { cwd: "/tmp/repo" },
       }),
     );
+    expect(fake.send).toHaveBeenCalledWith("ping");
+    expect(fake[Symbol.asyncDispose]).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({
       status: "finished",
       output: "done",
+      agentId: "agent-test",
       runId: "run-5",
       durationMs: 5,
     });
+  });
+
+  it("disposes the agent even when the run errors", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r", status: "finished" }));
+    fake.send = vi.fn(async () => {
+      throw new Error("send-blew-up");
+    });
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await expect(oneShot("ping", { cwd: "/tmp/repo" })).rejects.toThrow("send-blew-up");
+    expect(fake[Symbol.asyncDispose]).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors timeoutMs and reports cancellation", async () => {
+    vi.useFakeTimers();
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slowEvents: SDKMessage[] = [];
+    async function* slowStream(): AsyncGenerator<SDKMessage, void> {
+      await blocker;
+      for (const e of slowEvents) yield e;
+    }
+    const run: Run = {
+      id: "run-6",
+      agentId: "agent-test",
+      status: "running",
+      result: undefined,
+      model: undefined,
+      durationMs: undefined,
+      git: undefined,
+      supports: () => true,
+      unsupportedReason: () => undefined,
+      stream: slowStream,
+      conversation: async () => [],
+      wait: async () => ({ id: "run-6", status: "cancelled" }),
+      cancel: vi.fn(async () => {
+        release();
+      }),
+      onDidChangeStatus: () => () => undefined,
+    };
+    const fake = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    const promise = oneShot("ping", { cwd: "/tmp/repo", timeoutMs: 10 });
+    await vi.advanceTimersByTimeAsync(20);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(run.cancel).toHaveBeenCalled();
+    expect(result.status).toBe("cancelled");
+    expect(result.timedOut).toBe(true);
+    expect(fake[Symbol.asyncDispose]).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -1,0 +1,393 @@
+import type {
+  Run,
+  RunOperation,
+  RunResult,
+  RunStatus,
+  SDKAgent,
+  SDKMessage,
+  SDKModel,
+} from "@cursor/sdk";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkMocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  agentResume: vi.fn(),
+  agentPrompt: vi.fn(),
+  cursorMe: vi.fn(),
+  modelsList: vi.fn(),
+}));
+
+vi.mock("@cursor/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@cursor/sdk")>("@cursor/sdk");
+  return {
+    ...actual,
+    Agent: {
+      create: sdkMocks.agentCreate,
+      resume: sdkMocks.agentResume,
+      prompt: sdkMocks.agentPrompt,
+    },
+    Cursor: {
+      me: sdkMocks.cursorMe,
+      models: { list: sdkMocks.modelsList },
+    },
+  };
+});
+
+import {
+  createAgent,
+  DEFAULT_MODEL,
+  disposeAgent,
+  listModels,
+  normalizeStreamStatus,
+  oneShot,
+  resolveApiKey,
+  resumeAgent,
+  sendTask,
+  validateModel,
+  whoami,
+} from "../../../plugins/cursor/scripts/lib/cursor-agent.mjs";
+
+function makeRun(events: SDKMessage[], result: RunResult): Run {
+  let status: RunStatus = "running";
+  return {
+    id: result.id,
+    agentId: "agent-test",
+    status,
+    get result() {
+      return result.result;
+    },
+    get model() {
+      return result.model;
+    },
+    get durationMs() {
+      return result.durationMs;
+    },
+    get git() {
+      return result.git;
+    },
+    supports(_op: RunOperation) {
+      return true;
+    },
+    unsupportedReason() {
+      return undefined;
+    },
+    async *stream() {
+      for (const event of events) yield event;
+    },
+    async conversation() {
+      return [];
+    },
+    async wait() {
+      status = result.status;
+      return result;
+    },
+    async cancel() {
+      status = "cancelled";
+    },
+    onDidChangeStatus() {
+      return () => undefined;
+    },
+  };
+}
+
+function fakeAgent(run: Run): SDKAgent {
+  return {
+    agentId: run.agentId,
+    model: undefined,
+    send: vi.fn(async () => run),
+    close: vi.fn(),
+    reload: vi.fn(),
+    listArtifacts: vi.fn(async () => []),
+    downloadArtifact: vi.fn(async () => Buffer.alloc(0)),
+    [Symbol.asyncDispose]: vi.fn(async () => undefined),
+  };
+}
+
+beforeEach(() => {
+  process.env.CURSOR_API_KEY = "test-key";
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+  delete process.env.CURSOR_API_KEY;
+});
+
+describe("resolveApiKey", () => {
+  it("returns the explicit value when provided", () => {
+    expect(resolveApiKey("explicit")).toBe("explicit");
+  });
+
+  it("falls back to CURSOR_API_KEY", () => {
+    process.env.CURSOR_API_KEY = "from-env";
+    expect(resolveApiKey()).toBe("from-env");
+  });
+
+  it("throws ConfigurationError when neither is set", () => {
+    delete process.env.CURSOR_API_KEY;
+    expect(() => resolveApiKey()).toThrow(/CURSOR_API_KEY/);
+  });
+
+  it("treats whitespace-only keys as missing", () => {
+    expect(() => resolveApiKey("   ")).toThrow(/CURSOR_API_KEY/);
+  });
+});
+
+describe("normalizeStreamStatus", () => {
+  it("lowercases all SDK status-message values", () => {
+    expect(normalizeStreamStatus("CREATING")).toBe("creating");
+    expect(normalizeStreamStatus("RUNNING")).toBe("running");
+    expect(normalizeStreamStatus("FINISHED")).toBe("finished");
+    expect(normalizeStreamStatus("ERROR")).toBe("error");
+    expect(normalizeStreamStatus("CANCELLED")).toBe("cancelled");
+    expect(normalizeStreamStatus("EXPIRED")).toBe("expired");
+  });
+});
+
+describe("createAgent / resumeAgent", () => {
+  it("createAgent forwards cwd, default model, and resolved apiKey", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await createAgent({ cwd: "/tmp/repo" });
+
+    expect(sdkMocks.agentCreate).toHaveBeenCalledTimes(1);
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      apiKey: "test-key",
+      model: DEFAULT_MODEL,
+      local: { cwd: "/tmp/repo" },
+    });
+  });
+
+  it("createAgent honors model override and settingSources", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await createAgent({
+      cwd: "/tmp/repo",
+      model: { id: "gpt-5" },
+      settingSources: ["project", "user"],
+    });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.model).toEqual({ id: "gpt-5" });
+    expect(call?.local).toEqual({ cwd: "/tmp/repo", settingSources: ["project", "user"] });
+  });
+
+  it("resumeAgent passes the agentId through", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentResume.mockResolvedValue(fake);
+
+    await resumeAgent("agent-xyz", { cwd: "/tmp/repo" });
+
+    expect(sdkMocks.agentResume).toHaveBeenCalledWith(
+      "agent-xyz",
+      expect.objectContaining({ apiKey: "test-key", local: { cwd: "/tmp/repo" } }),
+    );
+  });
+
+  it("disposeAgent calls Symbol.asyncDispose", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    await disposeAgent(fake);
+    expect(fake[Symbol.asyncDispose]).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("sendTask", () => {
+  it("aggregates assistant text and tool calls, returns the SDK result status", async () => {
+    const events: SDKMessage[] = [
+      {
+        type: "assistant",
+        agent_id: "agent-test",
+        run_id: "run-1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "text", text: "hello " },
+            { type: "text", text: "world" },
+          ],
+        },
+      },
+      {
+        type: "tool_call",
+        agent_id: "agent-test",
+        run_id: "run-1",
+        call_id: "c1",
+        name: "edit",
+        status: "running",
+      },
+      {
+        type: "tool_call",
+        agent_id: "agent-test",
+        run_id: "run-1",
+        call_id: "c1",
+        name: "edit",
+        status: "completed",
+        result: { ok: true },
+      },
+    ];
+    const run = makeRun(events, {
+      id: "run-1",
+      status: "finished",
+      durationMs: 42,
+    });
+    const agent = fakeAgent(run);
+    const seen: SDKMessage[] = [];
+
+    const result = await sendTask(agent, "do thing", {
+      onEvent: (e) => seen.push(e),
+    });
+
+    expect(result.status).toBe("finished");
+    expect(result.output).toBe("hello world");
+    expect(result.toolCalls).toEqual([
+      {
+        callId: "c1",
+        name: "edit",
+        status: "completed",
+        args: undefined,
+        result: { ok: true },
+      },
+    ]);
+    expect(result.runId).toBe("run-1");
+    expect(result.durationMs).toBe(42);
+    expect(seen).toHaveLength(events.length);
+    expect(agent.send).toHaveBeenCalledWith("do thing");
+  });
+
+  it("prefers the SDK-provided result string over aggregated text", async () => {
+    const events: SDKMessage[] = [
+      {
+        type: "assistant",
+        agent_id: "agent-test",
+        run_id: "run-2",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "interim" }],
+        },
+      },
+    ];
+    const run = makeRun(events, {
+      id: "run-2",
+      status: "finished",
+      result: "final answer",
+    });
+    const result = await sendTask(fakeAgent(run), "go");
+    expect(result.output).toBe("final answer");
+  });
+
+  it("propagates EXPIRED stream status over RunResult.status", async () => {
+    const events: SDKMessage[] = [
+      {
+        type: "status",
+        agent_id: "agent-test",
+        run_id: "run-3",
+        status: "EXPIRED",
+      },
+    ];
+    const run = makeRun(events, { id: "run-3", status: "error" });
+    const result = await sendTask(fakeAgent(run), "go");
+    expect(result.status).toBe("expired");
+  });
+
+  it("cancels the run when the timeout fires and reports cancelled", async () => {
+    vi.useFakeTimers();
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const slowEvents: SDKMessage[] = [];
+    async function* slowStream(): AsyncGenerator<SDKMessage, void> {
+      await blocker;
+      for (const e of slowEvents) yield e;
+    }
+
+    const run: Run = {
+      id: "run-4",
+      agentId: "agent-test",
+      status: "running",
+      result: undefined,
+      model: undefined,
+      durationMs: undefined,
+      git: undefined,
+      supports: () => true,
+      unsupportedReason: () => undefined,
+      stream: slowStream,
+      conversation: async () => [],
+      wait: async () => ({ id: "run-4", status: "cancelled" }),
+      cancel: vi.fn(async () => {
+        release();
+      }),
+      onDidChangeStatus: () => () => undefined,
+    };
+
+    const agent = fakeAgent(run);
+    const promise = sendTask(agent, "go", { timeoutMs: 10 });
+    await vi.advanceTimersByTimeAsync(20);
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(run.cancel).toHaveBeenCalled();
+    expect(result.status).toBe("cancelled");
+    expect(result.timedOut).toBe(true);
+  });
+});
+
+describe("oneShot", () => {
+  it("calls Agent.prompt and normalizes the result", async () => {
+    const sdkResult: RunResult = {
+      id: "run-5",
+      status: "finished",
+      result: "done",
+      durationMs: 5,
+    };
+    sdkMocks.agentPrompt.mockResolvedValue(sdkResult);
+
+    const result = await oneShot("ping", { cwd: "/tmp/repo" });
+
+    expect(sdkMocks.agentPrompt).toHaveBeenCalledWith(
+      "ping",
+      expect.objectContaining({
+        apiKey: "test-key",
+        model: DEFAULT_MODEL,
+        local: { cwd: "/tmp/repo" },
+      }),
+    );
+    expect(result).toMatchObject({
+      status: "finished",
+      output: "done",
+      runId: "run-5",
+      durationMs: 5,
+    });
+  });
+});
+
+describe("Cursor account helpers", () => {
+  it("whoami forwards apiKey", async () => {
+    sdkMocks.cursorMe.mockResolvedValue({ apiKeyName: "test", createdAt: "0" });
+    await whoami();
+    expect(sdkMocks.cursorMe).toHaveBeenCalledWith({ apiKey: "test-key" });
+  });
+
+  it("listModels returns the SDK list", async () => {
+    const list: SDKModel[] = [{ id: "composer-2", displayName: "Composer 2" }];
+    sdkMocks.modelsList.mockResolvedValue(list);
+    await expect(listModels()).resolves.toEqual(list);
+  });
+
+  it("validateModel returns the matching entry", async () => {
+    const list: SDKModel[] = [
+      { id: "composer-2", displayName: "Composer 2" },
+      { id: "gpt-5", displayName: "GPT 5" },
+    ];
+    sdkMocks.modelsList.mockResolvedValue(list);
+    const found = await validateModel({ id: "gpt-5" });
+    expect(found.id).toBe("gpt-5");
+  });
+
+  it("validateModel throws ConfigurationError for an unknown model", async () => {
+    sdkMocks.modelsList.mockResolvedValue([{ id: "composer-2", displayName: "Composer 2" }]);
+    await expect(validateModel({ id: "imaginary" })).rejects.toThrow(/imaginary/);
+  });
+});


### PR DESCRIPTION
Implements the Phase 2.1 SDK integration layer: createAgent / resumeAgent /
sendTask / oneShot / disposeAgent plus account helpers (whoami, listModels,
validateModel). sendTask aggregates assistant text and tool_call events into
a CursorRunResult, reconciles the lowercase RunResult.status with the
uppercase SDKStatusMessage stream (including the extra EXPIRED state), and
supports a configurable timeout that cancels the run.

API key resolution falls back to CURSOR_API_KEY and fails fast with a
ConfigurationError instead of leaking a generic 401. Tests mock @cursor/sdk
and cover key resolution, status normalization, agent creation/resume, text
aggregation, EXPIRED stream override, timeout-driven cancellation, and the
account helpers.

https://claude.ai/code/session_01DamYBr4CUTFmXnPW7Qt8aM