### PR TITLE
feat(workspace): resolve workspace root via git top-level with cwd fallback

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -149,15 +149,17 @@ Key behaviors:
 
 ### 2.2 `lib/workspace.mts` — Workspace Resolution
 
-- [ ] Find git root from cwd (`git rev-parse --show-toplevel`)
-- [ ] Generate stable workspace ID (SHA-256 of absolute git root path)
-- [ ] Provide workspace metadata (branch, remote URL, dirty status)
+Slim, single-purpose module. Mirrors codex-plugin-cc's `workspace.mjs`.
+
+- [x] `resolveWorkspaceRoot(cwd)` — `git rev-parse --show-toplevel` with fallback to `cwd` when cwd is not inside a git repo (so the plugin still works in non-git scratch dirs).
+- ~~Generate stable workspace ID (SHA-256 of absolute git root path)~~ → moved to **2.3 `state.mts`**: hashing is a state-dir concern, not a workspace concern. State derives `${slug}-${sha256(canonicalRoot)[:16]}` itself from the resolved root.
+- ~~Provide workspace metadata (branch, remote URL, dirty status)~~ → moved to **2.5 `git.mts`**: branch/remote/dirty are git queries used for prompt context, not workspace identity.
 
 ### 2.3 `lib/state.mts` — Persistent State
 
 Job and session state persisted to disk.
 
-- [ ] State directory: `~/.claude/cursor-plugin/<workspace-hash>/`
+- [ ] State directory: `~/.claude/cursor-plugin/<slug>-<workspace-hash>/` where the hash is `sha256(canonicalWorkspaceRoot).slice(0, 16)` and the slug is the sanitized basename (matches codex plugin layout).
 - [ ] `state.json` — index of all jobs (last 50 retained)
 - [ ] `<jobId>.json` — per-job result payload
 - [ ] `<jobId>.log` — per-job streaming log
@@ -181,6 +183,8 @@ Job and session state persisted to disk.
 - [ ] `getStatus()` — working tree status summary
 - [ ] `getRecentCommits(n)` — last N commit messages + hashes
 - [ ] `getBranch()` — current branch name
+- [ ] `getRemoteUrl()` — origin URL (for prompt context; absent when no remote)
+- [ ] `isDirty()` — boolean working-tree-dirty check (relocated from 2.2)
 - [ ] `getChangedFiles()` — list of modified/added/deleted files
 
 ### 2.6 `lib/render.mts` — Terminal Output

--- a/plugins/cursor/scripts/lib/workspace.mts
+++ b/plugins/cursor/scripts/lib/workspace.mts
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Resolve the workspace root for a given working directory.
+ *
+ * Returns the git top-level when `cwd` is inside a git working tree, otherwise
+ * falls back to `cwd` so the plugin still works in scratch directories that
+ * aren't checked into git. The returned path is always absolute.
+ */
+export function resolveWorkspaceRoot(cwd: string): string {
+  try {
+    const out = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const root = out.trim();
+    if (root.length > 0) {
+      return path.resolve(root);
+    }
+  } catch {
+    // not a git repo, or git not available — fall through
+  }
+  return path.resolve(cwd);
+}

--- a/tests/unit/lib/workspace.test.mts
+++ b/tests/unit/lib/workspace.test.mts
@@ -1,0 +1,40 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveWorkspaceRoot } from "../../../plugins/cursor/scripts/lib/workspace.mjs";
+
+function makeTmpDir(prefix: string): string {
+  return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+describe("resolveWorkspaceRoot", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = makeTmpDir("cursor-plugin-workspace-");
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("returns the git top-level for a path inside a git repo", () => {
+    execFileSync("git", ["init", "-q", tmpRoot]);
+    const nested = path.join(tmpRoot, "a", "b");
+    execFileSync("mkdir", ["-p", nested]);
+
+    expect(resolveWorkspaceRoot(nested)).toBe(tmpRoot);
+    expect(resolveWorkspaceRoot(tmpRoot)).toBe(tmpRoot);
+  });
+
+  it("falls back to the provided cwd when not inside a git repo", () => {
+    expect(resolveWorkspaceRoot(tmpRoot)).toBe(tmpRoot);
+  });
+
+  it("returns an absolute path even for a relative cwd fallback", () => {
+    const result = resolveWorkspaceRoot(".");
+    expect(path.isAbsolute(result)).toBe(true);
+  });
+});


### PR DESCRIPTION
Slim, single-purpose module mirroring codex-plugin-cc/lib/workspace.mjs.
Hashing moves to state.mts (state-dir concern); branch/remote/dirty move
to git.mts (prompt-context concern). PLAN.md updated to reflect descope.