### PR TITLE
feat(state): persistent storage layer for jobs, logs, and session

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -159,13 +159,13 @@ Slim, single-purpose module. Mirrors codex-plugin-cc's `workspace.mjs`.
 
 Job and session state persisted to disk.
 
-- [ ] State directory: `~/.claude/cursor-plugin/<slug>-<workspace-hash>/` where the hash is `sha256(canonicalWorkspaceRoot).slice(0, 16)` and the slug is the sanitized basename (matches codex plugin layout).
-- [ ] `state.json` — index of all jobs (last 50 retained)
-- [ ] `<jobId>.json` — per-job result payload
-- [ ] `<jobId>.log` — per-job streaming log
-- [ ] `session.json` — current session metadata (session ID, agent IDs, start time)
-- [ ] Atomic writes (write to tmp, rename) to prevent corruption
-- [ ] Auto-prune: delete oldest jobs when exceeding 50
+- [x] State directory: `~/.claude/cursor-plugin/<slug>-<workspace-hash>/` where the hash is `sha256(canonicalWorkspaceRoot).slice(0, 16)` and the slug is the sanitized basename (matches codex plugin layout). `CURSOR_PLUGIN_STATE_ROOT` overrides the root for tests/dev.
+- [x] `state.json` — index of all jobs (last 50 retained)
+- [x] `<jobId>.json` — per-job result payload
+- [x] `<jobId>.log` — per-job streaming log (append-only)
+- [x] `session.json` — current session metadata (session ID, agent IDs, start time)
+- [x] Atomic writes (write to tmp, rename) to prevent corruption (`writeJsonAtomic`)
+- [x] Auto-prune: delete oldest jobs when exceeding 50 (`pruneJobIndex`, ordered by `createdAt`; also removes the per-job json/log files)
 
 ### 2.4 `lib/job-control.mts` — Job CRUD
 

--- a/plugins/cursor/scripts/lib/state.mts
+++ b/plugins/cursor/scripts/lib/state.mts
@@ -105,11 +105,32 @@ export function getStateIndexPath(stateDir: string): string {
   return path.join(stateDir, "state.json");
 }
 
+/**
+ * Reject job ids that would let `path.join(stateDir, id)` escape the state
+ * directory. The CLI surfaces ids from user input (`/cursor:result <id>`,
+ * `/cursor:cancel <id>`), so this is the boundary where untrusted strings
+ * become file paths — validating here keeps callers from having to remember.
+ */
+function assertSafeJobId(jobId: string): void {
+  if (
+    jobId.length === 0 ||
+    jobId.includes("/") ||
+    jobId.includes("\\") ||
+    jobId.includes("\0") ||
+    jobId === "." ||
+    jobId === ".."
+  ) {
+    throw new Error(`invalid jobId: ${JSON.stringify(jobId)}`);
+  }
+}
+
 export function getJobJsonPath(stateDir: string, jobId: string): string {
+  assertSafeJobId(jobId);
   return path.join(stateDir, `${jobId}.json`);
 }
 
 export function getJobLogPath(stateDir: string, jobId: string): string {
+  assertSafeJobId(jobId);
   return path.join(stateDir, `${jobId}.log`);
 }
 
@@ -204,13 +225,14 @@ export function pruneJobIndex(
   stateDir: string,
   maxEntries: number = DEFAULT_MAX_JOBS,
 ): PruneResult {
+  const limit = Math.max(0, Math.floor(maxEntries));
   const index = readStateIndex(stateDir);
-  if (index.jobs.length <= maxEntries) {
+  if (index.jobs.length <= limit) {
     return { removed: [], kept: index.jobs.length };
   }
   const sorted = [...index.jobs].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
-  const kept = sorted.slice(0, maxEntries);
-  const dropped = sorted.slice(maxEntries);
+  const kept = sorted.slice(0, limit);
+  const dropped = sorted.slice(limit);
   for (const job of dropped) {
     fs.rmSync(getJobJsonPath(stateDir, job.id), { force: true });
     fs.rmSync(getJobLogPath(stateDir, job.id), { force: true });

--- a/plugins/cursor/scripts/lib/state.mts
+++ b/plugins/cursor/scripts/lib/state.mts
@@ -1,0 +1,220 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const DEFAULT_MAX_JOBS = 50;
+export const STATE_ROOT_ENV = "CURSOR_PLUGIN_STATE_ROOT";
+
+const SLUG_HASH_LENGTH = 16;
+const SLUG_NAME_MAX = 32;
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+export type JobType = "task" | "review" | "adversarial-review";
+export type JobStatus = "pending" | "running" | "completed" | "failed" | "cancelled";
+
+export interface JobIndexEntry {
+  id: string;
+  type: JobType;
+  status: JobStatus;
+  createdAt: string;
+  updatedAt: string;
+  summary?: string;
+}
+
+export interface JobIndex {
+  version: 1;
+  jobs: JobIndexEntry[];
+}
+
+export interface JobRecord {
+  id: string;
+  type: JobType;
+  status: JobStatus;
+  prompt: string;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
+  agentId?: string;
+  runId?: string;
+  result?: string;
+  error?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SessionState {
+  version: 1;
+  sessionId: string;
+  startedAt: string;
+  agentIds: string[];
+  pluginRoot?: string;
+}
+
+export interface StateLocator {
+  /** Override the state root (defaults to $CURSOR_PLUGIN_STATE_ROOT or ~/.claude/cursor-plugin). */
+  root?: string;
+}
+
+export interface PruneResult {
+  removed: string[];
+  kept: number;
+}
+
+/**
+ * Build the workspace slug as `<sanitized-basename>-<sha256(root)[:16]>`. The
+ * canonical absolute path is hashed so two checkouts at different paths get
+ * distinct slugs even when their basenames collide.
+ */
+export function computeWorkspaceSlug(workspaceRoot: string): string {
+  const canonical = path.resolve(workspaceRoot);
+  const hash = crypto
+    .createHash("sha256")
+    .update(canonical)
+    .digest("hex")
+    .slice(0, SLUG_HASH_LENGTH);
+  const base = path.basename(canonical);
+  const sanitized =
+    base
+      .toLowerCase()
+      .replace(/[^a-z0-9._-]+/g, "-")
+      .replace(/^[-.]+|[-.]+$/g, "")
+      .slice(0, SLUG_NAME_MAX) || "workspace";
+  return `${sanitized}-${hash}`;
+}
+
+export function resolveStateRoot(opts: StateLocator = {}): string {
+  if (opts.root && opts.root.trim().length > 0) return path.resolve(opts.root);
+  const env = process.env[STATE_ROOT_ENV];
+  if (env && env.trim().length > 0) return path.resolve(env);
+  return path.join(os.homedir(), ".claude", "cursor-plugin");
+}
+
+export function resolveStateDir(workspaceRoot: string, opts: StateLocator = {}): string {
+  return path.join(resolveStateRoot(opts), computeWorkspaceSlug(workspaceRoot));
+}
+
+export function ensureStateDir(stateDir: string): string {
+  fs.mkdirSync(stateDir, { recursive: true, mode: DIR_MODE });
+  return stateDir;
+}
+
+export function getStateIndexPath(stateDir: string): string {
+  return path.join(stateDir, "state.json");
+}
+
+export function getJobJsonPath(stateDir: string, jobId: string): string {
+  return path.join(stateDir, `${jobId}.json`);
+}
+
+export function getJobLogPath(stateDir: string, jobId: string): string {
+  return path.join(stateDir, `${jobId}.log`);
+}
+
+export function getSessionPath(stateDir: string): string {
+  return path.join(stateDir, "session.json");
+}
+
+/**
+ * Atomically write JSON: write to a uniquely-named tmp file in the same
+ * directory, then rename onto the target. `rename(2)` is atomic within a
+ * filesystem, so concurrent readers either see the previous version or the
+ * new one — never a partial write.
+ */
+export function writeJsonAtomic(filePath: string, data: unknown): void {
+  ensureStateDir(path.dirname(filePath));
+  const tmp = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(data, null, 2)}\n`, { mode: FILE_MODE });
+  try {
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    fs.rmSync(tmp, { force: true });
+    throw err;
+  }
+}
+
+/** Read JSON, returning undefined if the file is missing or unparseable. */
+export function readJson<T>(filePath: string): T | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readStateIndex(stateDir: string): JobIndex {
+  const data = readJson<JobIndex>(getStateIndexPath(stateDir));
+  if (!data || !Array.isArray(data.jobs)) return { version: 1, jobs: [] };
+  return data;
+}
+
+export function writeStateIndex(stateDir: string, index: JobIndex): void {
+  writeJsonAtomic(getStateIndexPath(stateDir), index);
+}
+
+export function readJob(stateDir: string, jobId: string): JobRecord | undefined {
+  return readJson<JobRecord>(getJobJsonPath(stateDir, jobId));
+}
+
+export function writeJob(stateDir: string, record: JobRecord): void {
+  writeJsonAtomic(getJobJsonPath(stateDir, record.id), record);
+}
+
+export function appendJobLog(stateDir: string, jobId: string, text: string): void {
+  ensureStateDir(stateDir);
+  fs.appendFileSync(getJobLogPath(stateDir, jobId), text, { mode: FILE_MODE });
+}
+
+export function readJobLog(stateDir: string, jobId: string): string | undefined {
+  try {
+    return fs.readFileSync(getJobLogPath(stateDir, jobId), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return undefined;
+    throw err;
+  }
+}
+
+export function readSession(stateDir: string): SessionState | undefined {
+  return readJson<SessionState>(getSessionPath(stateDir));
+}
+
+export function writeSession(stateDir: string, session: SessionState): void {
+  writeJsonAtomic(getSessionPath(stateDir), session);
+}
+
+export function clearSession(stateDir: string): void {
+  fs.rmSync(getSessionPath(stateDir), { force: true });
+}
+
+/**
+ * Trim the index to at most `maxEntries` jobs, keeping the most-recently
+ * created and deleting the on-disk per-job json/log files for evicted jobs.
+ * Safe to call when the index already fits — it short-circuits.
+ */
+export function pruneJobIndex(
+  stateDir: string,
+  maxEntries: number = DEFAULT_MAX_JOBS,
+): PruneResult {
+  const index = readStateIndex(stateDir);
+  if (index.jobs.length <= maxEntries) {
+    return { removed: [], kept: index.jobs.length };
+  }
+  const sorted = [...index.jobs].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const kept = sorted.slice(0, maxEntries);
+  const dropped = sorted.slice(maxEntries);
+  for (const job of dropped) {
+    fs.rmSync(getJobJsonPath(stateDir, job.id), { force: true });
+    fs.rmSync(getJobLogPath(stateDir, job.id), { force: true });
+  }
+  writeStateIndex(stateDir, { version: 1, jobs: kept });
+  return { removed: dropped.map((j) => j.id), kept: kept.length };
+}

--- a/tests/unit/lib/state.test.mts
+++ b/tests/unit/lib/state.test.mts
@@ -1,0 +1,345 @@
+import {
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  appendJobLog,
+  clearSession,
+  computeWorkspaceSlug,
+  DEFAULT_MAX_JOBS,
+  ensureStateDir,
+  getJobJsonPath,
+  getJobLogPath,
+  getSessionPath,
+  getStateIndexPath,
+  type JobIndex,
+  type JobIndexEntry,
+  type JobRecord,
+  pruneJobIndex,
+  readJob,
+  readJobLog,
+  readJson,
+  readSession,
+  readStateIndex,
+  resolveStateDir,
+  resolveStateRoot,
+  STATE_ROOT_ENV,
+  writeJob,
+  writeJsonAtomic,
+  writeSession,
+  writeStateIndex,
+} from "../../../plugins/cursor/scripts/lib/state.mjs";
+
+function makeTmpDir(prefix: string): string {
+  return realpathSync(mkdtempSync(path.join(tmpdir(), prefix)));
+}
+
+function entry(
+  id: string,
+  createdAt: string,
+  status: JobIndexEntry["status"] = "completed",
+): JobIndexEntry {
+  return { id, type: "task", status, createdAt, updatedAt: createdAt };
+}
+
+describe("computeWorkspaceSlug", () => {
+  it("appends a 16-char sha256 prefix to the sanitized basename", () => {
+    const slug = computeWorkspaceSlug("/tmp/My Project!");
+    expect(slug).toMatch(/^my-project-[0-9a-f]{16}$/);
+  });
+
+  it("returns distinct slugs for paths that share a basename", () => {
+    expect(computeWorkspaceSlug("/a/repo")).not.toBe(computeWorkspaceSlug("/b/repo"));
+  });
+
+  it("returns the same slug for the same canonical path", () => {
+    expect(computeWorkspaceSlug("/tmp/foo")).toBe(computeWorkspaceSlug("/tmp/foo"));
+  });
+
+  it("falls back to 'workspace' when the basename sanitizes to empty", () => {
+    expect(computeWorkspaceSlug("/")).toMatch(/^workspace-[0-9a-f]{16}$/);
+  });
+
+  it("truncates very long basenames", () => {
+    const long = `/tmp/${"a".repeat(200)}`;
+    const slug = computeWorkspaceSlug(long);
+    const [name] = slug.split(/-(?=[0-9a-f]{16}$)/);
+    expect(name?.length).toBeLessThanOrEqual(32);
+  });
+});
+
+describe("resolveStateRoot / resolveStateDir", () => {
+  const originalEnv = process.env[STATE_ROOT_ENV];
+
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env[STATE_ROOT_ENV];
+    else process.env[STATE_ROOT_ENV] = originalEnv;
+  });
+
+  it("uses the explicit override when provided", () => {
+    expect(resolveStateRoot({ root: "/tmp/override" })).toBe("/tmp/override");
+  });
+
+  it("falls back to the env override when no explicit root", () => {
+    process.env[STATE_ROOT_ENV] = "/tmp/from-env";
+    expect(resolveStateRoot()).toBe("/tmp/from-env");
+  });
+
+  it("composes the workspace slug under the resolved root", () => {
+    const dir = resolveStateDir("/repo/foo", { root: "/tmp/root" });
+    expect(dir.startsWith("/tmp/root/")).toBe(true);
+    expect(path.basename(dir)).toMatch(/^foo-[0-9a-f]{16}$/);
+  });
+});
+
+describe("filesystem primitives", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws-slug");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("ensureStateDir creates the directory if missing and is idempotent", () => {
+    ensureStateDir(stateDir);
+    ensureStateDir(stateDir);
+    expect(statSync(stateDir).isDirectory()).toBe(true);
+  });
+
+  it("writeJsonAtomic writes JSON and creates parent dirs", () => {
+    const target = path.join(stateDir, "nested", "data.json");
+    writeJsonAtomic(target, { hello: "world" });
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual({ hello: "world" });
+  });
+
+  it("writeJsonAtomic does not leave .tmp files behind on success", () => {
+    const target = getStateIndexPath(stateDir);
+    writeJsonAtomic(target, { ok: true });
+    const dir = path.dirname(target);
+    const leftovers = readDirRecursive(dir).filter((f) => f.endsWith(".tmp"));
+    expect(leftovers).toEqual([]);
+  });
+
+  it("readJson returns undefined for missing files", () => {
+    expect(readJson(path.join(stateDir, "nope.json"))).toBeUndefined();
+  });
+
+  it("readJson returns undefined for malformed JSON", () => {
+    ensureStateDir(stateDir);
+    const target = path.join(stateDir, "bad.json");
+    writeFileSync(target, "{ not valid json");
+    expect(readJson(target)).toBeUndefined();
+  });
+});
+
+describe("state index", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("readStateIndex returns an empty index when the file is missing", () => {
+    expect(readStateIndex(stateDir)).toEqual({ version: 1, jobs: [] });
+  });
+
+  it("readStateIndex recovers from a corrupt index file", () => {
+    ensureStateDir(stateDir);
+    writeFileSync(getStateIndexPath(stateDir), "garbage");
+    expect(readStateIndex(stateDir)).toEqual({ version: 1, jobs: [] });
+  });
+
+  it("write/readStateIndex round-trips", () => {
+    const index: JobIndex = {
+      version: 1,
+      jobs: [entry("a", "2026-01-01T00:00:00Z")],
+    };
+    writeStateIndex(stateDir, index);
+    expect(readStateIndex(stateDir)).toEqual(index);
+  });
+});
+
+describe("job records and logs", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("writeJob/readJob round-trips a record", () => {
+    const record: JobRecord = {
+      id: "job-1",
+      type: "task",
+      status: "completed",
+      prompt: "do the thing",
+      createdAt: "2026-04-29T10:00:00Z",
+      updatedAt: "2026-04-29T10:01:00Z",
+      result: "done",
+    };
+    writeJob(stateDir, record);
+    expect(readJob(stateDir, "job-1")).toEqual(record);
+  });
+
+  it("appendJobLog appends in order across calls", () => {
+    appendJobLog(stateDir, "job-1", "first\n");
+    appendJobLog(stateDir, "job-1", "second\n");
+    expect(readJobLog(stateDir, "job-1")).toBe("first\nsecond\n");
+  });
+
+  it("readJobLog returns undefined when no log exists", () => {
+    expect(readJobLog(stateDir, "ghost")).toBeUndefined();
+  });
+});
+
+describe("session state", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("write/readSession round-trips", () => {
+    writeSession(stateDir, {
+      version: 1,
+      sessionId: "sess-1",
+      startedAt: "2026-04-29T00:00:00Z",
+      agentIds: ["agent-1"],
+    });
+    expect(readSession(stateDir)?.sessionId).toBe("sess-1");
+  });
+
+  it("clearSession removes the session file", () => {
+    writeSession(stateDir, {
+      version: 1,
+      sessionId: "sess-1",
+      startedAt: "2026-04-29T00:00:00Z",
+      agentIds: [],
+    });
+    clearSession(stateDir);
+    expect(readSession(stateDir)).toBeUndefined();
+  });
+
+  it("clearSession is a no-op when the file is missing", () => {
+    expect(() => clearSession(stateDir)).not.toThrow();
+  });
+});
+
+describe("pruneJobIndex", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("is a no-op when the index already fits", () => {
+    const index: JobIndex = {
+      version: 1,
+      jobs: [entry("a", "2026-01-01T00:00:00Z")],
+    };
+    writeStateIndex(stateDir, index);
+    const result = pruneJobIndex(stateDir, 5);
+    expect(result).toEqual({ removed: [], kept: 1 });
+    expect(readStateIndex(stateDir)).toEqual(index);
+  });
+
+  it("drops the oldest jobs by createdAt and removes their on-disk files", () => {
+    const jobs: JobIndexEntry[] = [
+      entry("old1", "2026-01-01T00:00:00Z"),
+      entry("old2", "2026-01-02T00:00:00Z"),
+      entry("new1", "2026-02-01T00:00:00Z"),
+      entry("new2", "2026-02-02T00:00:00Z"),
+    ];
+    writeStateIndex(stateDir, { version: 1, jobs });
+    for (const e of jobs) {
+      writeJob(stateDir, {
+        id: e.id,
+        type: "task",
+        status: "completed",
+        prompt: "p",
+        createdAt: e.createdAt,
+        updatedAt: e.updatedAt,
+      });
+      appendJobLog(stateDir, e.id, "log\n");
+    }
+
+    const result = pruneJobIndex(stateDir, 2);
+
+    expect(result.kept).toBe(2);
+    expect(new Set(result.removed)).toEqual(new Set(["old1", "old2"]));
+    const remainingIds = readStateIndex(stateDir).jobs.map((j) => j.id);
+    expect(new Set(remainingIds)).toEqual(new Set(["new1", "new2"]));
+
+    expect(readJob(stateDir, "old1")).toBeUndefined();
+    expect(readJobLog(stateDir, "old1")).toBeUndefined();
+    expect(readJob(stateDir, "new2")).toBeDefined();
+    expect(readJobLog(stateDir, "new2")).toBe("log\n");
+  });
+
+  it("defaults to DEFAULT_MAX_JOBS when no limit is supplied", () => {
+    const jobs: JobIndexEntry[] = Array.from({ length: DEFAULT_MAX_JOBS + 3 }, (_, i) =>
+      entry(`j${i}`, `2026-01-01T00:00:${String(i).padStart(2, "0")}Z`),
+    );
+    writeStateIndex(stateDir, { version: 1, jobs });
+    const result = pruneJobIndex(stateDir);
+    expect(result.kept).toBe(DEFAULT_MAX_JOBS);
+    expect(result.removed.length).toBe(3);
+  });
+});
+
+describe("path helpers", () => {
+  it("compose paths under the state directory", () => {
+    const dir = "/tmp/state";
+    expect(getStateIndexPath(dir)).toBe("/tmp/state/state.json");
+    expect(getJobJsonPath(dir, "abc")).toBe("/tmp/state/abc.json");
+    expect(getJobLogPath(dir, "abc")).toBe("/tmp/state/abc.log");
+    expect(getSessionPath(dir)).toBe("/tmp/state/session.json");
+  });
+});
+
+function readDirRecursive(dir: string): string[] {
+  const out: string[] = [];
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (current === undefined) break;
+    let names: string[];
+    try {
+      names = readdirSync(current);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      const full = path.join(current, name);
+      if (statSync(full).isDirectory()) stack.push(full);
+      else out.push(full);
+    }
+  }
+  return out;
+}

--- a/tests/unit/lib/state.test.mts
+++ b/tests/unit/lib/state.test.mts
@@ -321,6 +321,47 @@ describe("path helpers", () => {
     expect(getJobLogPath(dir, "abc")).toBe("/tmp/state/abc.log");
     expect(getSessionPath(dir)).toBe("/tmp/state/session.json");
   });
+
+  it.each([
+    ["empty", ""],
+    ["dot", "."],
+    ["dotdot", ".."],
+    ["forward slash", "../etc/passwd"],
+    ["nested forward slash", "foo/bar"],
+    ["backslash", "foo\\bar"],
+    ["nul byte", "foo\0bar"],
+  ])("rejects unsafe jobId (%s)", (_label, jobId) => {
+    expect(() => getJobJsonPath("/tmp/state", jobId)).toThrow(/invalid jobId/);
+    expect(() => getJobLogPath("/tmp/state", jobId)).toThrow(/invalid jobId/);
+  });
+
+  it("accepts safe jobIds with hyphens, underscores, and dots", () => {
+    expect(() => getJobJsonPath("/tmp/state", "job-2026-04-29_a1b2.x")).not.toThrow();
+  });
+});
+
+describe("pruneJobIndex edge cases", () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = path.join(makeTmpDir("cursor-plugin-state-"), "ws");
+  });
+
+  afterEach(() => {
+    rmSync(path.dirname(stateDir), { recursive: true, force: true });
+  });
+
+  it("treats negative or fractional limits as zero", () => {
+    const jobs: JobIndexEntry[] = [
+      entry("a", "2026-01-01T00:00:00Z"),
+      entry("b", "2026-01-02T00:00:00Z"),
+    ];
+    writeStateIndex(stateDir, { version: 1, jobs });
+    const result = pruneJobIndex(stateDir, -5);
+    expect(result.kept).toBe(0);
+    expect(new Set(result.removed)).toEqual(new Set(["a", "b"]));
+    expect(readStateIndex(stateDir).jobs).toEqual([]);
+  });
 });
 
 function readDirRecursive(dir: string): string[] {


### PR DESCRIPTION
Implements Phase 2.3 from PLAN.md. Adds lib/state.mts with:

- Workspace-scoped state dir at $CURSOR_PLUGIN_STATE_ROOT (or
  ~/.claude/cursor-plugin) under <slug>-<sha256(root)[:16]>, so two
  checkouts at different paths get distinct state even when basenames
  collide.
- Atomic JSON writes (tmp file + rename) so concurrent readers never
  observe partial state, with 0o600 file mode / 0o700 dir mode.
- Typed read/write for state.json (job index), <jobId>.json (per-job
  record), <jobId>.log (append-only stream), and session.json.
- pruneJobIndex() trims to DEFAULT_MAX_JOBS (50), keeping the newest by
  createdAt and removing the on-disk per-job files for evicted entries.
- Defensive reads: missing or corrupt JSON yields undefined / empty
  index so callers can recover with a fresh write.

Tests cover slug stability, env/explicit root resolution, atomic write
cleanup, corruption recovery, log append ordering, session lifecycle,
and prune semantics (default and custom limits).