### PR TITLE
feat: complete Phase 2-5 — CLI, plugin wiring, tests (159 passing)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3,6 +3,25 @@
 Claude Code plugin that delegates work to Cursor's AI agent via `@cursor/sdk`.
 Mirrors [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) architecture.
 
+### Reference: Cursor cookbook `coding-agent-cli`
+
+We mine [`cursor/cookbook/sdk/coding-agent-cli`](https://github.com/cursor/cookbook/tree/main/sdk/coding-agent-cli)
+for SDK-usage patterns. We do **not** vendor the project — it is Bun-only (OpenTUI via
+`bun:ffi`) and is a standalone interactive CLI, not a plugin backend. Specific files we
+lift patterns from:
+
+| Cookbook file | What we take | Where it lands |
+|--------------|--------------|----------------|
+| `src/agent.ts` `emitSdkMessage` | SDKMessage → flat `AgentEvent` mapper | §2.6 `render.mts` (also exposed by 2.1) |
+| `src/agent.ts` `buildPrompt` | System-instruction wrapper around user prompt | §2.1 `cursor-agent.mts` |
+| `src/agent.ts` `detectCloudRepository` / `normalizeGitHubRemote` | Cloud-mode repo detection | §2.1 (cloud-mode follow-on) |
+| `src/agent.ts` model dedupe / variant disambiguation | Model picker output for `setup` | §3.4 `setup` subcommand |
+| `src/agent.ts` `cancelCurrentRun` (`run.supports("cancel")`) | Capability-checked cancel | §2.1 + §2.4 job-control |
+| `src/agent.ts` `summarizeToolArgs` / `formatDuration` | Tool-call + duration formatting | §2.6 `render.mts` |
+| `src/index.ts` `runPlainPrompt` / `renderPlainEvent` | Non-interactive streaming-to-stdout | §3.2 `task` subcommand |
+
+Anything TUI/Bun/OpenTUI-related is intentionally ignored.
+
 ---
 
 ## Phase 1: Project Scaffolding
@@ -147,6 +166,25 @@ Key behaviors:
 - [x] Timeout handling: cancel run if it exceeds configurable timeout (`SendTaskOptions.timeoutMs`)
 - [x] Account helpers: `whoami` / `listModels` for `/cursor:setup`
 
+Follow-on items (from cookbook absorption — not yet implemented):
+- [ ] `buildPrompt(prompt, instructions?)` — wrap user prompt with default system
+      instructions (mirrors cookbook `AGENT_INSTRUCTIONS`). Make instructions
+      overridable per-call so `review` can supply its own.
+- [ ] Cloud execution mode: optional `mode: "local" | "cloud"` on
+      `CursorAgentOptions`; when `cloud`, pass `cloud: { repos: [...] }` to
+      `Agent.create`. Port `detectCloudRepository` + `normalizeGitHubRemote` to
+      `lib/git.mts` (§2.5) and consume from here.
+- [ ] `local.force` passthrough — surface a `force?: boolean` option that maps
+      to `local: { force: true }` so `task --force` can expire a stuck run.
+- [ ] Capability-checked cancel: replace bare `run.cancel()` in
+      `collectRunResult`'s timeout path with `run.supports("cancel")` /
+      `run.unsupportedReason("cancel")` and bubble the reason via `CursorRunResult`.
+- [ ] Token usage: include `usage?: { inputTokens?; outputTokens? }` on
+      `CursorRunResult` (read from `RunResult.usage`).
+- [ ] Export a public `AgentEvent` discriminated union + `toAgentEvent(SDKMessage)`
+      mapper (the cookbook's `emitSdkMessage` factored out) so render/CLI layers
+      consume a stable shape instead of raw `SDKMessage`.
+
 ### 2.2 `lib/workspace.mts` — Workspace Resolution
 
 Slim, single-purpose module. Mirrors codex-plugin-cc's `workspace.mjs`.
@@ -173,7 +211,8 @@ Job and session state persisted to disk.
 - [ ] `updateJobStatus(jobId, status, result?)` — pending → running → completed/failed/cancelled
 - [ ] `getJob(jobId)` → full job state
 - [ ] `listJobs(filter?)` → summary table
-- [ ] `cancelJob(jobId)` — calls `run.cancel()` on the Cursor SDK
+- [ ] `cancelJob(jobId)` — uses the capability-checked cancel path from §2.1
+      (returns `{ cancelled: false, reason }` when `run.supports("cancel")` is false)
 - [ ] Background job tracking: maintain in-memory map of active runs for cancellation
 - [ ] Job types: `task`, `review`, `adversarial-review`
 
@@ -186,13 +225,22 @@ Job and session state persisted to disk.
 - [ ] `getRemoteUrl()` — origin URL (for prompt context; absent when no remote)
 - [ ] `isDirty()` — boolean working-tree-dirty check (relocated from 2.2)
 - [ ] `getChangedFiles()` — list of modified/added/deleted files
+- [ ] `detectCloudRepository(cwd)` → `{ url, startingRef? }` — port from cookbook
+      `src/agent.ts` (handles `git@github.com:`, `ssh://`, `https://` forms,
+      strips `.git`). Used by §2.1 cloud-mode follow-on.
 
 ### 2.6 `lib/render.mts` — Terminal Output
 
 - [ ] `renderJobTable(jobs)` — formatted table of jobs with status, type, elapsed time
-- [ ] `renderStreamEvent(event)` — format a single stream event for terminal display
+- [ ] `renderStreamEvent(event)` — format a single `AgentEvent` (the flat shape
+      from §2.1) for terminal display. Mirrors cookbook `renderPlainEvent`:
+      assistant text → stdout; thinking/tool/status/task → annotated stderr lines.
 - [ ] `renderReviewResult(review)` — format structured review output with severity colors
 - [ ] `renderError(error)` — consistent error formatting
+- [ ] `formatDuration(ms)` — small helper, lifted from cookbook
+- [ ] `summarizeToolArgs(toolName, args)` — concise one-line tool-call summary
+      (port the keyed-lookup table from cookbook `getToolSummaryKeys` —
+      read/glob/grep/shell/edit each get their own preferred argument keys).
 
 **Exit criteria**: Unit tests for each module. `cursor-agent.mts` tested with mocked SDK (integration tests in Phase 5).
 
@@ -232,11 +280,14 @@ node cursor-companion.mjs task "Refactor the auth module" --write --model compos
 - [ ] Create job via job-control
 - [ ] Create Cursor agent via cursor-agent
 - [ ] Send prompt with workspace context (branch, recent commits, changed files)
-- [ ] Stream events to stdout in real-time
+- [ ] Stream events to stdout in real-time (use `renderStreamEvent` over the
+      `AgentEvent` mapper from §2.1 — same shape as cookbook `runPlainPrompt`)
 - [ ] On completion: persist result, update job status
 - [ ] `--write` flag: allow file modifications (default: read-only analysis)
 - [ ] `--resume-last` flag: resume most recent agent session
 - [ ] `--background` flag: run in background, return job ID immediately
+- [ ] `--force` flag: pass `local.force` through (recover stuck local run)
+- [ ] `--cloud` flag: run on Cursor cloud against detected repo origin
 
 ### 3.3 `review` Subcommand
 
@@ -279,7 +330,10 @@ node cursor-companion.mjs setup
 - [ ] Check Node.js version (>= 18)
 - [ ] Check `@cursor/sdk` installed
 - [ ] Validate `CURSOR_API_KEY` — call `Cursor.me()` to verify auth
-- [ ] List available models via `Cursor.models.list()`
+- [ ] List available models via `Cursor.models.list()` — apply cookbook's
+      dedupe + variant-disambiguation (`dedupeModelChoices`,
+      `disambiguateDuplicateLabels`) so multi-variant models render as one
+      readable picker entry per concrete `ModelSelection`
 - [ ] Report readiness status
 
 ### 3.5 `status`, `result`, `cancel` Subcommands

--- a/PLAN.md
+++ b/PLAN.md
@@ -218,16 +218,16 @@ Job and session state persisted to disk.
 
 ### 2.5 `lib/git.mts` — Git Helpers
 
-- [ ] `getDiff(options?)` — staged/unstaged diff for review
-- [ ] `getStatus()` — working tree status summary
-- [ ] `getRecentCommits(n)` — last N commit messages + hashes
-- [ ] `getBranch()` — current branch name
-- [ ] `getRemoteUrl()` — origin URL (for prompt context; absent when no remote)
-- [ ] `isDirty()` — boolean working-tree-dirty check (relocated from 2.2)
-- [ ] `getChangedFiles()` — list of modified/added/deleted files
-- [ ] `detectCloudRepository(cwd)` → `{ url, startingRef? }` — port from cookbook
-      `src/agent.ts` (handles `git@github.com:`, `ssh://`, `https://` forms,
-      strips `.git`). Used by §2.1 cloud-mode follow-on.
+- [x] `getDiff(options?)` — staged/unstaged diff for review
+- [x] `getStatus()` — working tree status summary
+- [x] `getRecentCommits(n)` — last N commit messages + hashes
+- [x] `getBranch()` — current branch name
+- [x] `getRemoteUrl()` — origin URL (for prompt context; absent when no remote)
+- [x] `isDirty()` — boolean working-tree-dirty check (relocated from 2.2)
+- [x] `getChangedFiles()` — list of modified/added/deleted files
+- [x] `detectCloudRepository(cwd)` + `normalizeGitHubRemote(remote)` — port
+      from cookbook `src/agent.ts` (SSH / `ssh://` / `https://` forms, strip
+      `.git`). Used by §2.1 cloud-mode follow-on.
 
 ### 2.6 `lib/render.mts` — Terminal Output
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -231,16 +231,17 @@ Job and session state persisted to disk.
 
 ### 2.6 `lib/render.mts` — Terminal Output
 
-- [ ] `renderJobTable(jobs)` — formatted table of jobs with status, type, elapsed time
-- [ ] `renderStreamEvent(event)` — format a single `AgentEvent` (the flat shape
-      from §2.1) for terminal display. Mirrors cookbook `renderPlainEvent`:
-      assistant text → stdout; thinking/tool/status/task → annotated stderr lines.
-- [ ] `renderReviewResult(review)` — format structured review output with severity colors
-- [ ] `renderError(error)` — consistent error formatting
-- [ ] `formatDuration(ms)` — small helper, lifted from cookbook
-- [ ] `summarizeToolArgs(toolName, args)` — concise one-line tool-call summary
-      (port the keyed-lookup table from cookbook `getToolSummaryKeys` —
-      read/glob/grep/shell/edit each get their own preferred argument keys).
+- [x] `renderJobTable(jobs)` — aligned text table with derived ages
+- [x] `renderStreamEvent(event)` — format a single `AgentEvent` (the flat
+      shape from §2.1) for terminal display. Mirrors cookbook
+      `renderPlainEvent`: assistant text → stdout; thinking/tool/status/task
+      → annotated stderr lines. Returns `{stdout?, stderr?}` so the caller
+      controls actual writes (testable).
+- [x] `renderReviewResult(review)` — verdict, sorted findings, next steps
+- [x] `renderError(error)` — consistent error formatting
+- [x] `formatDuration(ms)` — lifted from cookbook
+- [x] `summarizeToolArgs(toolName, args)` — keyed-lookup table for
+      read/glob/grep/shell/edit, ported from cookbook `getToolSummaryKeys`.
 
 **Exit criteria**: Unit tests for each module. `cursor-agent.mts` tested with mocked SDK (integration tests in Phase 5).
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -166,24 +166,24 @@ Key behaviors:
 - [x] Timeout handling: cancel run if it exceeds configurable timeout (`SendTaskOptions.timeoutMs`)
 - [x] Account helpers: `whoami` / `listModels` for `/cursor:setup`
 
-Follow-on items (from cookbook absorption — not yet implemented):
-- [ ] `buildPrompt(prompt, instructions?)` — wrap user prompt with default system
-      instructions (mirrors cookbook `AGENT_INSTRUCTIONS`). Make instructions
-      overridable per-call so `review` can supply its own.
-- [ ] Cloud execution mode: optional `mode: "local" | "cloud"` on
-      `CursorAgentOptions`; when `cloud`, pass `cloud: { repos: [...] }` to
-      `Agent.create`. Port `detectCloudRepository` + `normalizeGitHubRemote` to
-      `lib/git.mts` (§2.5) and consume from here.
-- [ ] `local.force` passthrough — surface a `force?: boolean` option that maps
-      to `local: { force: true }` so `task --force` can expire a stuck run.
-- [ ] Capability-checked cancel: replace bare `run.cancel()` in
-      `collectRunResult`'s timeout path with `run.supports("cancel")` /
-      `run.unsupportedReason("cancel")` and bubble the reason via `CursorRunResult`.
-- [ ] Token usage: include `usage?: { inputTokens?; outputTokens? }` on
-      `CursorRunResult` (read from `RunResult.usage`).
-- [ ] Export a public `AgentEvent` discriminated union + `toAgentEvent(SDKMessage)`
-      mapper (the cookbook's `emitSdkMessage` factored out) so render/CLI layers
-      consume a stable shape instead of raw `SDKMessage`.
+Follow-on items (from cookbook absorption):
+- [x] `buildPrompt(prompt, instructions?)` — wrap user prompt with default system
+      instructions (mirrors cookbook `AGENT_INSTRUCTIONS`). Instructions
+      overridable per-call.
+- [x] Cloud execution mode: optional `mode: "local" | "cloud"` + `cloudRepo`
+      on `CursorAgentOptions`; when `cloud`, pass `cloud: { repos: [...] }`
+      to `Agent.create`. `detectCloudRepository` lives in `lib/git.mts` (§2.5).
+- [x] `local.force` passthrough — `SendTaskOptions.force` maps to
+      `agent.send(prompt, { local: { force: true } })`.
+- [x] Capability-checked cancel: timeout path checks `run.supports("cancel")`
+      before calling cancel; `cancelRun(run)` helper exposes the
+      `{ cancelled, reason? }` result.
+- ~~Token usage on `CursorRunResult`~~ — `RunResult` does not expose `usage`
+      in the public type; the cookbook reads it via an unsafe cast. Skipped
+      to honor our "no `as any` / `@ts-ignore`" rule.
+- [x] Public `AgentEvent` discriminated union + `toAgentEvents(SDKMessage)`
+      mapper. One message can yield multiple events (assistant text +
+      tool_use blocks).
 
 ### 2.2 `lib/workspace.mts` — Workspace Resolution
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -377,18 +377,18 @@ Each file in `commands/` is a prompt document Claude reads when the user invokes
 | `result.md` | `/cursor:result <job-id>` | Retrieve job output |
 | `cancel.md` | `/cursor:cancel <job-id>` | Cancel active job |
 
-For commands that just shell out: `disable-model-invocation: true` + `allowed-tools: Bash(node:*)`.
+For commands that just shell out: `disable-model-invocation: true` + `allowed-tools: Bash(node:*)`. ✅ All seven slash command markdown files implemented.
 
 ### 4.2 Subagent: `cursor-rescue`
 
 `agents/cursor-rescue.md` — named subagent invoked via `Agent` tool with `subagent_type: "cursor:cursor-rescue"`.
 
 Behavior:
-- Receives a prompt (the hard problem)
-- Builds one shell command: `node cursor-companion.mjs task "<prompt>" --write`
-- Executes via Bash, returns stdout unchanged
-- Never orchestrates, never inspects files itself
-- Supports `$ARGUMENTS` for user input
+- [x] Receives a prompt (the hard problem)
+- [x] Builds one shell command: `node cursor-companion.mjs task "<prompt>" --write`
+- [x] Executes via Bash, returns stdout unchanged
+- [x] Never orchestrates, never inspects files itself
+- [x] Supports `$ARGUMENTS` for user input
 
 ### 4.3 Hooks
 
@@ -400,16 +400,20 @@ Behavior:
 | Session end | `SessionEnd` | `session-lifecycle-hook.mjs SessionEnd` | 5s |
 
 `session-lifecycle-hook.mts`:
-- **SessionStart**: Read session ID from stdin JSON. Write session metadata to state dir. Export env vars (`CURSOR_SESSION_ID`, `CURSOR_PLUGIN_ROOT`).
-- **SessionEnd**: Read active agent IDs from session state. Dispose each via `agent[Symbol.asyncDispose]()`. Clean up temp files. Update session state.
+- [x] **SessionStart**: read session id from stdin JSON, write session
+      metadata into state dir
+- [x] **SessionEnd**: clear the session marker. Agents are not disposed
+      because background runs may still be using them — disposal is the
+      caller's responsibility, and the SDK manages durable agent lifecycle.
+      A future enhancement could iterate `agentIds` and dispose any that
+      are still attached.
 
-### 4.4 Skills (Already Created in /init)
+### 4.4 Skills
 
-- `cursor-rescue` — delegation instructions
-- `cursor-result-handling` — output presentation rules
-
-Additional skill to create:
-- [ ] `cursor-prompting/SKILL.md` — how to compose effective prompts for Cursor agent (task structure, context inclusion, structured output contracts)
+- [x] `cursor-rescue/SKILL.md` — when to delegate, what to include
+- [x] `cursor-result-handling/SKILL.md` — output presentation rules
+- [x] `cursor-prompting/SKILL.md` — task structure, `--write` policy,
+      structured-output contracts
 
 **Exit criteria**: Install plugin locally (`/plugin install /path/to/cursor-plugin-cc`), all slash commands appear, `/cursor:setup` works.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -273,10 +273,12 @@ node cursor-companion.mjs <command> [args...] [flags]
 | `cancel <job-id>` | Cancel an active job |
 | `setup` | Check dependencies, validate API key |
 
-- [ ] Argument parsing (`lib/args.mts` — minimal, no heavy deps)
-- [ ] Subcommand routing
-- [ ] Global flags: `--model`, `--timeout`, `--json` (machine-readable output)
-- [ ] Exit codes: 0 success, 1 error, 2 invalid args
+- [x] Argument parsing (`lib/args.mts` — minimal, no heavy deps)
+- [x] Subcommand routing (handlers live in `commands/<name>.mts`)
+- [x] Subcommand-local flags: `--model`, `--timeout`, `--json`, `--help`
+- [x] Exit codes: 0 success, 1 error, 2 invalid args
+- [x] CLI takes a `CommandIO` (stdout/stderr/cwd/env) so tests can inject
+      sinks instead of writing to the real process streams.
 
 ### 3.2 `task` Subcommand
 
@@ -284,17 +286,17 @@ node cursor-companion.mjs <command> [args...] [flags]
 node cursor-companion.mjs task "Refactor the auth module" --write --model composer-2
 ```
 
-- [ ] Create job via job-control
-- [ ] Create Cursor agent via cursor-agent
-- [ ] Send prompt with workspace context (branch, recent commits, changed files)
-- [ ] Stream events to stdout in real-time (use `renderStreamEvent` over the
+- [x] Create job via job-control
+- [x] Create Cursor agent via cursor-agent
+- [x] Send prompt with workspace context (branch, recent commits, changed files)
+- [x] Stream events to stdout in real-time (`renderStreamEvent` over the
       `AgentEvent` mapper from §2.1 — same shape as cookbook `runPlainPrompt`)
-- [ ] On completion: persist result, update job status
-- [ ] `--write` flag: allow file modifications (default: read-only analysis)
-- [ ] `--resume-last` flag: resume most recent agent session
-- [ ] `--background` flag: run in background, return job ID immediately
-- [ ] `--force` flag: pass `local.force` through (recover stuck local run)
-- [ ] `--cloud` flag: run on Cursor cloud against detected repo origin
+- [x] On completion: persist result, update job status
+- [x] `--write` flag: allow file modifications (default: read-only analysis)
+- [x] `--resume-last` flag: resume most recent agent session
+- [x] `--background` flag: run in background, return job ID immediately
+- [x] `--force` flag: pass `local.force` through (recover stuck local run)
+- [x] `--cloud` flag: run on Cursor cloud against detected repo origin
 
 ### 3.3 `review` Subcommand
 
@@ -302,12 +304,13 @@ node cursor-companion.mjs task "Refactor the auth module" --write --model compos
 node cursor-companion.mjs review [--staged] [--adversarial]
 ```
 
-- [ ] Collect git diff (staged or all changes)
-- [ ] Build review prompt with diff, file list, and project context
-- [ ] Request structured output matching review schema
-- [ ] Parse and validate Cursor's response against schema
-- [ ] Output structured review (verdict, findings, next steps)
-- [ ] `--adversarial` flag: switches prompt to challenge design decisions
+- [x] Collect git diff (staged or all changes)
+- [x] Build review prompt with diff, file list, and project context
+- [x] Request structured output matching review schema
+- [x] Parse and validate Cursor's response against schema (tolerant fence
+      stripping; verdict/summary/findings/next_steps shape checks)
+- [x] Output structured review (verdict, findings, next steps)
+- [x] `adversarial-review` subcommand uses challenge-the-design instructions
 
 Review output schema (matches codex plugin):
 ```typescript
@@ -334,20 +337,23 @@ interface ReviewOutput {
 node cursor-companion.mjs setup
 ```
 
-- [ ] Check Node.js version (>= 18)
-- [ ] Check `@cursor/sdk` installed
-- [ ] Validate `CURSOR_API_KEY` — call `Cursor.me()` to verify auth
-- [ ] List available models via `Cursor.models.list()` — apply cookbook's
-      dedupe + variant-disambiguation (`dedupeModelChoices`,
-      `disambiguateDuplicateLabels`) so multi-variant models render as one
-      readable picker entry per concrete `ModelSelection`
-- [ ] Report readiness status
+- [x] Check Node.js version (>= 18)
+- ~~Check `@cursor/sdk` installed~~ (implicit at import-time; if it's missing
+      the CLI fails to load before this check runs)
+- [x] Validate `CURSOR_API_KEY` — call `Cursor.me()` to verify auth
+- [x] List available models via `Cursor.models.list()` — apply cookbook
+      `modelToChoices`-style flattening so multi-variant models render as one
+      row per concrete `ModelSelection`
+- [x] Report readiness status (text + `--json` machine-readable)
 
 ### 3.5 `status`, `result`, `cancel` Subcommands
 
-- [ ] `status` — read job index, render table. With `--job-id`, show single job detail
-- [ ] `result <job-id>` — read persisted result, output verbatim
-- [ ] `cancel <job-id>` — find active run, call cancel, update job status
+- [x] `status` — read job index, render table. Positional `<job-id>` shows
+      detail. Filters: `--type`, `--status`, `--limit`, `--json`.
+- [x] `result <job-id>` — read persisted result; `--log` reads streaming log;
+      `--json` emits the full JobRecord
+- [x] `cancel <job-id>` — capability-checked cancel via `cancelJob`
+      (returns 1 + reason when not cancellable)
 
 **Exit criteria**: Each subcommand works end-to-end from CLI. Manual test: `node cursor-companion.mjs setup` succeeds with valid API key.
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -423,14 +423,18 @@ Behavior:
 
 ### 5.1 Unit Tests (`tests/unit/`)
 
-| Module | Test Coverage |
-|--------|--------------|
-| `lib/workspace.mts` | Git root resolution, workspace ID generation, edge cases (no git, nested repos) |
-| `lib/state.mts` | Read/write/prune jobs, atomic writes, corruption recovery |
-| `lib/job-control.mts` | Job lifecycle (create → running → completed/failed/cancelled), listing, filtering |
-| `lib/git.mts` | Diff parsing, status parsing, empty repo handling |
-| `lib/render.mts` | Table formatting, event rendering, review formatting |
-| `lib/args.mts` | Argument parsing, flag extraction, validation |
+| Module | Test Coverage | Status |
+|--------|---------------|--------|
+| `lib/workspace.mts` | Git root resolution, workspace ID generation, edge cases (no git, nested repos) | ✅ |
+| `lib/state.mts` | Read/write/prune jobs, atomic writes, corruption recovery | ✅ |
+| `lib/job-control.mts` | Job lifecycle (create → running → completed/failed/cancelled), listing, filtering | ✅ |
+| `lib/git.mts` | Diff parsing, status parsing, empty repo handling, GitHub remote normalization | ✅ |
+| `lib/render.mts` | Table formatting, event rendering, review formatting, tool-arg summarizer | ✅ |
+| `lib/args.mts` | Argument parsing, flag extraction, validation | ✅ |
+| `lib/cursor-agent.mts` | Mocked SDK: createAgent / sendTask / oneShot / cancel / cloud-mode / force / AgentEvent mapper | ✅ |
+| `commands/review.mts` | JSON extraction (fence-stripping), shape validation | ✅ |
+| `cursor-companion.mts` | Router smoke (help, unknown, status empty, --help, missing-id, setup-no-key) | ✅ |
+| `session-lifecycle-hook.mts` | SessionStart writes session.json, SessionEnd clears it | ✅ |
 
 ### 5.2 Integration Tests (`tests/integration/`)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -207,14 +207,20 @@ Job and session state persisted to disk.
 
 ### 2.4 `lib/job-control.mts` — Job CRUD
 
-- [ ] `createJob(type, prompt)` → jobId
-- [ ] `updateJobStatus(jobId, status, result?)` — pending → running → completed/failed/cancelled
-- [ ] `getJob(jobId)` → full job state
-- [ ] `listJobs(filter?)` → summary table
-- [ ] `cancelJob(jobId)` — uses the capability-checked cancel path from §2.1
-      (returns `{ cancelled: false, reason }` when `run.supports("cancel")` is false)
-- [ ] Background job tracking: maintain in-memory map of active runs for cancellation
-- [ ] Job types: `task`, `review`, `adversarial-review`
+- [x] `createJob(input)` → JobRecord (returns full record, not just id)
+- [x] State transitions: `markRunning` / `markFinished` / `markFailed` /
+      `markCancelled`. `markFinished` maps CursorAgentStatus → JobStatus
+      (`finished`→`completed`, `error`→`failed`, `expired`→`cancelled`+meta).
+- [x] `getJob(jobId)` → full job state
+- [x] `listJobs(filter?)` with type/status/limit filters
+- [x] `cancelJob(jobId)` — capability-checked via `cancelRun` from §2.1
+      (returns `{ cancelled, reason?, job? }` so callers can render a clean
+      diagnostic). Marks pending+no-active-run as cancelled with
+      reason="run-not-active".
+- [x] Background job tracking: in-process `activeRuns` map keyed by jobId
+      (`registerActiveRun` / `unregisterActiveRun` / `getActiveRun`).
+- [x] Job types: `task`, `review`, `adversarial-review` (id prefix `adv-`).
+- [x] `logJobLine` helper appends to per-job log file.
 
 ### 2.5 `lib/git.mts` — Git Helpers
 

--- a/plugins/cursor/agents/cursor-rescue.md
+++ b/plugins/cursor/agents/cursor-rescue.md
@@ -1,0 +1,27 @@
+---
+name: cursor-rescue
+description: Delegate a hard problem to a Cursor agent. Use when stuck, when an independent implementation pass would help, or when a deeper root-cause analysis is needed. Returns Cursor's output unchanged.
+tools: Bash
+model: inherit
+---
+
+You are a thin forwarder. Your job is to:
+
+1. Take the prompt the parent passed in (`$ARGUMENTS`).
+2. Build exactly one shell command:
+   ```bash
+   node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs task "<prompt>" --write
+   ```
+   Quote-escape the prompt; preserve any extra flags the caller passed
+   (`--cloud`, `--force`, `--model`, `--background`, `--timeout`).
+3. Run it via the Bash tool and return the **complete stdout unchanged**.
+
+Do **not**:
+- Inspect files yourself.
+- Edit, plan, or summarize the result.
+- Add prose around the output.
+- Re-run the command on a non-zero exit; surface the exit context to the
+  caller and stop.
+
+If the command fails before producing any output (e.g. `CURSOR_API_KEY`
+unset), say so in one line and stop.

--- a/plugins/cursor/commands/adversarial-review.md
+++ b/plugins/cursor/commands/adversarial-review.md
@@ -1,0 +1,19 @@
+---
+description: Adversarial review — challenge design choices in the current diff.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:adversarial-review
+
+Run a deliberately challenging review. Where `/cursor:review` hunts for
+defects, this prompt pushes back on premature abstractions, hidden coupling,
+unnecessary state, and brittle assumptions.
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs adversarial-review $ARGUMENTS
+```
+
+Same output shape as `/cursor:review`. If the change is genuinely simple and
+correct, the review will say so — adversarial framing is not "always find
+fault." Surface the output verbatim to the user.

--- a/plugins/cursor/commands/cancel.md
+++ b/plugins/cursor/commands/cancel.md
@@ -1,0 +1,20 @@
+---
+description: Cancel an active cursor-plugin-cc job.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:cancel
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs cancel $ARGUMENTS
+```
+
+Required: a job id.
+
+If the run is in-process, calls `run.cancel()` (capability-checked). If the
+run was started in `--background` mode by a different CLI invocation, the
+in-memory Run object is gone — the job record is marked cancelled with
+`reason: "run-not-active"`, but the underlying SDK run may still be live.
+
+Exit code 0 on cancel, 1 on any failure with a reason printed to stderr.

--- a/plugins/cursor/commands/result.md
+++ b/plugins/cursor/commands/result.md
@@ -1,0 +1,19 @@
+---
+description: Print a completed job's result text.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:result
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs result $ARGUMENTS
+```
+
+Required: a job id (from `/cursor:status`).
+
+Flags:
+- `--log` — print the streaming event log captured while the run was alive
+- `--json` — emit the full JobRecord
+
+If the job hasn't finished, exits 1. Surface the output verbatim.

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -1,0 +1,25 @@
+---
+description: Independent code review of the working-tree diff via Cursor.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:review
+
+Run a Cursor-driven structured review of the current diff.
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs review $ARGUMENTS
+```
+
+Useful flags:
+- `--staged` — review staged changes only (default: working tree)
+- `--base <ref>` — diff against a specific ref instead of HEAD
+- `--json` — emit the structured ReviewOutput JSON unchanged
+
+The CLI prints a verdict (`approve` / `needs-attention`), a summary, and
+per-finding entries with severity, file:line, and a recommendation. Exit code
+is 0 on `approve`, 1 on `needs-attention` or any failure.
+
+Pass the output through to the user. Do not summarize away severity or file
+locations — they are the high-signal bits.

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,0 +1,17 @@
+---
+description: Validate the cursor-plugin-cc runtime — Node, API key, account, models.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:setup
+
+Run the plugin's self-check.
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs setup
+```
+
+If anything fails (API key missing, network error, model catalog empty), the
+exit code is non-zero and the failure rows print on stdout. No further action
+needed — surface the output verbatim to the user.

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -9,9 +9,10 @@ disable-model-invocation: true
 Run the plugin's self-check.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs setup
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs setup $ARGUMENTS
 ```
 
-If anything fails (API key missing, network error, model catalog empty), the
-exit code is non-zero and the failure rows print on stdout. No further action
-needed — surface the output verbatim to the user.
+Pass `--json` for machine-readable output. If anything fails (API key missing,
+network error, model catalog empty), the exit code is non-zero and the failure
+rows print on stdout. No further action needed — surface the output verbatim
+to the user.

--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -1,0 +1,20 @@
+---
+description: Show cursor-plugin-cc job table for the current workspace.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:status
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs status $ARGUMENTS
+```
+
+With no arguments: prints a table of recent jobs (id, type, status, age,
+summary). With a job id positional: prints the full job detail.
+
+Filters available: `--type <task|review|adversarial-review>`,
+`--status <pending|running|completed|failed|cancelled>`, `--limit <n>`.
+`--json` emits machine-readable output.
+
+Surface the output verbatim.

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -1,0 +1,25 @@
+---
+description: Delegate a coding task to a Cursor agent.
+argument-hint: <prompt>
+---
+
+# /cursor:task
+
+Hand off a coding task to a Cursor agent. Use this when the work is
+well-scoped and you want a second pair of hands rather than driving the
+implementation yourself.
+
+Invoke the `cursor-rescue` subagent with the task description. The subagent
+forwards the prompt to `cursor-companion.mjs task` and returns whatever
+Cursor produces, unchanged.
+
+Default invocation:
+
+> Use the cursor-rescue subagent with: `$ARGUMENTS`
+
+If the user passed `--write`, `--cloud`, `--background`, `--force`, or
+`--model`, include them verbatim in the prompt to the subagent.
+
+When the result comes back, follow `cursor-result-handling/SKILL.md` —
+present the deliverables and any caveats clearly, do not silently accept
+the output.

--- a/plugins/cursor/scripts/commands/cancel.mts
+++ b/plugins/cursor/scripts/commands/cancel.mts
@@ -1,5 +1,5 @@
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, parseArgs } from "../lib/args.mjs";
+import { bool, parseArgs, UsageError } from "../lib/args.mjs";
 import { cancelJob } from "../lib/job-control.mjs";
 import { resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
@@ -21,7 +21,7 @@ export async function runCancel(args: readonly string[], io: CommandIO): Promise
     return 0;
   }
   const jobId = parsed.positionals[0];
-  if (!jobId) throw new Error("cancel requires a job id");
+  if (!jobId) throw new UsageError("cancel requires a job id");
 
   const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);

--- a/plugins/cursor/scripts/commands/cancel.mts
+++ b/plugins/cursor/scripts/commands/cancel.mts
@@ -1,0 +1,41 @@
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, parseArgs } from "../lib/args.mjs";
+import { cancelJob } from "../lib/job-control.mjs";
+import { resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
+
+const HELP = `cursor-companion cancel <job-id> [--json] [--help]
+
+Cancel an active job. If the run is in-process, calls run.cancel() (when
+supported). Otherwise marks the persisted job as cancelled with reason
+"run-not-active" — the underlying SDK run may still complete.
+`;
+
+export async function runCancel(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const parsed = parseArgs(args, {
+    long: { json: "boolean", help: "boolean" },
+    short: { h: "help" },
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP);
+    return 0;
+  }
+  const jobId = parsed.positionals[0];
+  if (!jobId) throw new Error("cancel requires a job id");
+
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+
+  const result = await cancelJob(stateDir, jobId);
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.cancelled ? 0 : 1;
+  }
+  if (result.cancelled) {
+    io.stdout.write(`cancelled: ${jobId}${result.reason ? ` (${result.reason})` : ""}\n`);
+    return 0;
+  }
+  io.stderr.write(`could not cancel ${jobId}: ${result.reason ?? "unknown"}\n`);
+  return 1;
+}

--- a/plugins/cursor/scripts/commands/result.mts
+++ b/plugins/cursor/scripts/commands/result.mts
@@ -1,5 +1,5 @@
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, parseArgs } from "../lib/args.mjs";
+import { bool, parseArgs, UsageError } from "../lib/args.mjs";
 import { getJob } from "../lib/job-control.mjs";
 import { readJobLog, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
@@ -21,7 +21,7 @@ export async function runResult(args: readonly string[], io: CommandIO): Promise
   }
 
   const jobId = parsed.positionals[0];
-  if (!jobId) throw new Error("result requires a job id");
+  if (!jobId) throw new UsageError("result requires a job id");
 
   const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);

--- a/plugins/cursor/scripts/commands/result.mts
+++ b/plugins/cursor/scripts/commands/result.mts
@@ -1,0 +1,60 @@
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, parseArgs } from "../lib/args.mjs";
+import { getJob } from "../lib/job-control.mjs";
+import { readJobLog, resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
+
+const HELP = `cursor-companion result <job-id> [--log] [--json] [--help]
+
+Print a completed job's result text. With --log, print the streaming log
+captured while the run was alive. With --json, emit the full JobRecord.
+`;
+
+export async function runResult(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const parsed = parseArgs(args, {
+    long: { log: "boolean", json: "boolean", help: "boolean" },
+    short: { h: "help" },
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP);
+    return 0;
+  }
+
+  const jobId = parsed.positionals[0];
+  if (!jobId) throw new Error("result requires a job id");
+
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+
+  const job = getJob(stateDir, jobId);
+  if (!job) {
+    io.stderr.write(`job not found: ${jobId}\n`);
+    return 1;
+  }
+
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
+    return 0;
+  }
+
+  if (bool(parsed, "log")) {
+    const log = readJobLog(stateDir, jobId);
+    if (!log) {
+      io.stderr.write(`no log for job ${jobId}\n`);
+      return 1;
+    }
+    io.stdout.write(log);
+    if (!log.endsWith("\n")) io.stdout.write("\n");
+    return 0;
+  }
+
+  if (!job.result) {
+    if (job.error) io.stderr.write(`job failed: ${job.error}\n`);
+    else io.stderr.write(`no result for job ${jobId} (status: ${job.status})\n`);
+    return 1;
+  }
+  io.stdout.write(job.result);
+  if (!job.result.endsWith("\n")) io.stdout.write("\n");
+  return 0;
+}

--- a/plugins/cursor/scripts/commands/review.mts
+++ b/plugins/cursor/scripts/commands/review.mts
@@ -4,7 +4,7 @@ import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs } from "../lib/args.mjs";
 import { oneShot } from "../lib/cursor-agent.mjs";
 import { getDiff, getStatus } from "../lib/git.mjs";
-import { createJob, markFailed, markFinished } from "../lib/job-control.mjs";
+import { createJob, markFailed, markFinished, markRunning } from "../lib/job-control.mjs";
 import { type ReviewOutput, renderReviewResult } from "../lib/render.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
@@ -186,7 +186,12 @@ export async function runReview(
     prompt: `${options.adversarial ? "adversarial-" : ""}review of ${flags.staged ? "staged" : "working-tree"} diff`,
   });
 
-  const oneShotOpts: Parameters<typeof oneShot>[1] = { cwd: workspaceRoot };
+  const oneShotOpts: Parameters<typeof oneShot>[1] = {
+    cwd: workspaceRoot,
+    onRunStart: (run) => {
+      markRunning(stateDir, job.id, { agentId: run.agentId, runId: run.id });
+    },
+  };
   if (flags.model) oneShotOpts.model = flags.model;
   if (flags.timeoutMs) oneShotOpts.timeoutMs = flags.timeoutMs;
 

--- a/plugins/cursor/scripts/commands/review.mts
+++ b/plugins/cursor/scripts/commands/review.mts
@@ -1,0 +1,227 @@
+import type { ModelSelection } from "@cursor/sdk";
+
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import { oneShot } from "../lib/cursor-agent.mjs";
+import { getDiff, getStatus } from "../lib/git.mjs";
+import { createJob, markFailed, markFinished } from "../lib/job-control.mjs";
+import { type ReviewOutput, renderReviewResult } from "../lib/render.mjs";
+import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
+
+const HELP = `cursor-companion review [flags]
+cursor-companion adversarial-review [flags]
+
+Review the working-tree diff (or staged diff with --staged). Returns a
+structured ReviewOutput JSON: verdict, summary, findings[], next_steps[].
+
+flags:
+  --staged             Review staged changes only (git diff --cached)
+  --base <ref>         Diff against this ref instead of working tree
+  --model <id>         Override the default model
+  --timeout <ms>       Cancel the review if it exceeds this duration
+  --json               Print the raw structured review JSON
+  --help, -h
+`;
+
+const REVIEW_INSTRUCTIONS = [
+  "You are a senior code reviewer doing a focused review of a small change.",
+  "Be precise and concrete. Cite the exact file:line that triggers each finding.",
+  "Distinguish severity: critical (likely to break prod), high (clear bug or security issue),",
+  "  medium (correctness/design concern), low (style/nit).",
+  "Confidence is 0.0–1.0; be honest, do not bluff at 1.0.",
+  "Output ONLY a single JSON object matching the schema below — no prose, no markdown fences.",
+].join("\n");
+
+const ADVERSARIAL_INSTRUCTIONS = [
+  "You are an adversarial reviewer. Your job is to challenge design choices,",
+  "  not just hunt for defects. Push back on premature abstractions, hidden coupling,",
+  "  unnecessary state, brittle assumptions, and missing edge cases.",
+  "Be precise: cite file:line for each finding. Don't manufacture issues — if the",
+  "  change is genuinely simple and correct, say so and approve.",
+  "Output ONLY a single JSON object matching the schema below — no prose, no markdown fences.",
+].join("\n");
+
+const SCHEMA = `{
+  "verdict": "approve" | "needs-attention",
+  "summary": string,
+  "findings": [{
+    "severity": "critical" | "high" | "medium" | "low",
+    "title": string,
+    "body": string,
+    "file": string,
+    "line_start": number,
+    "line_end": number,
+    "confidence": number,
+    "recommendation": string
+  }],
+  "next_steps": string[]
+}`;
+
+interface ReviewFlags {
+  staged: boolean;
+  baseRef?: string;
+  model?: ModelSelection;
+  timeoutMs?: number;
+  json: boolean;
+}
+
+class HelpRequested extends Error {}
+
+function parseFlags(args: readonly string[]): ReviewFlags {
+  const parsed = parseArgs(args, {
+    long: {
+      staged: "boolean",
+      base: "string",
+      model: "string",
+      timeout: "string",
+      json: "boolean",
+      help: "boolean",
+    },
+    short: { h: "help", m: "model" },
+  });
+  if (bool(parsed, "help")) throw new HelpRequested();
+  const flags: ReviewFlags = {
+    staged: bool(parsed, "staged"),
+    json: bool(parsed, "json"),
+  };
+  const base = optionalString(parsed, "base");
+  if (base) flags.baseRef = base;
+  const modelId = optionalString(parsed, "model");
+  if (modelId) flags.model = { id: modelId };
+  const timeout = optionalString(parsed, "timeout");
+  if (timeout) {
+    const ms = Number(timeout);
+    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid --timeout: ${timeout}`);
+    flags.timeoutMs = ms;
+  }
+  return flags;
+}
+
+function buildReviewPrompt(diff: string, status: string, instructions: string): string {
+  return [
+    instructions,
+    "",
+    "Output schema:",
+    SCHEMA,
+    "",
+    "Working-tree status:",
+    status || "(clean)",
+    "",
+    "Diff to review:",
+    diff,
+  ].join("\n");
+}
+
+/**
+ * Tolerant JSON extraction: agents sometimes wrap output in ```json fences
+ * despite instructions. Strip surrounding fences before parsing.
+ */
+function extractJson(raw: string): string {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fenced) return fenced[1] ?? trimmed;
+  return trimmed;
+}
+
+function parseReview(raw: string): ReviewOutput {
+  const text = extractJson(raw);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `review output was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!parsed || typeof parsed !== "object") throw new Error("review output is not an object");
+  const obj = parsed as Record<string, unknown>;
+  if (obj.verdict !== "approve" && obj.verdict !== "needs-attention") {
+    throw new Error(`review verdict is invalid: ${JSON.stringify(obj.verdict)}`);
+  }
+  if (typeof obj.summary !== "string") throw new Error("review summary missing");
+  if (!Array.isArray(obj.findings)) throw new Error("review findings must be an array");
+  if (!Array.isArray(obj.next_steps)) throw new Error("review next_steps must be an array");
+  return parsed as ReviewOutput;
+}
+
+export interface RunReviewOptions {
+  adversarial: boolean;
+}
+
+export async function runReview(
+  args: readonly string[],
+  io: CommandIO,
+  options: RunReviewOptions,
+): Promise<ExitCode> {
+  let flags: ReviewFlags;
+  try {
+    flags = parseFlags(args);
+  } catch (err) {
+    if (err instanceof HelpRequested) {
+      io.stdout.write(HELP);
+      return 0;
+    }
+    throw err;
+  }
+
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+
+  const diffOpts: { staged?: boolean; baseRef?: string } = {};
+  if (flags.staged) diffOpts.staged = true;
+  if (flags.baseRef) diffOpts.baseRef = flags.baseRef;
+  const diff = getDiff(workspaceRoot, diffOpts);
+  if (!diff) {
+    io.stderr.write("nothing to review (empty diff)\n");
+    return 0;
+  }
+
+  const instructions = options.adversarial ? ADVERSARIAL_INSTRUCTIONS : REVIEW_INSTRUCTIONS;
+  const prompt = buildReviewPrompt(diff, getStatus(workspaceRoot), instructions);
+
+  const job = createJob(stateDir, {
+    type: options.adversarial ? "adversarial-review" : "review",
+    prompt: `${options.adversarial ? "adversarial-" : ""}review of ${flags.staged ? "staged" : "working-tree"} diff`,
+  });
+
+  const oneShotOpts: Parameters<typeof oneShot>[1] = { cwd: workspaceRoot };
+  if (flags.model) oneShotOpts.model = flags.model;
+  if (flags.timeoutMs) oneShotOpts.timeoutMs = flags.timeoutMs;
+
+  let result: Awaited<ReturnType<typeof oneShot>>;
+  try {
+    result = await oneShot(prompt, oneShotOpts);
+  } catch (err) {
+    markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
+    throw err;
+  }
+
+  markFinished(stateDir, job.id, result);
+
+  if (result.status !== "finished") {
+    io.stderr.write(`review run did not finish: ${result.status}\n`);
+    return 1;
+  }
+
+  let review: ReviewOutput;
+  try {
+    review = parseReview(result.output);
+  } catch (err) {
+    io.stderr.write(
+      `failed to parse review output: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    io.stderr.write("raw output:\n");
+    io.stderr.write(result.output);
+    if (!result.output.endsWith("\n")) io.stderr.write("\n");
+    return 1;
+  }
+
+  if (flags.json) {
+    io.stdout.write(`${JSON.stringify(review, null, 2)}\n`);
+  } else {
+    io.stdout.write(renderReviewResult(review));
+  }
+  return review.verdict === "approve" ? 0 : 1;
+}

--- a/plugins/cursor/scripts/commands/review.mts
+++ b/plugins/cursor/scripts/commands/review.mts
@@ -1,7 +1,7 @@
 import type { ModelSelection } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import { oneShot } from "../lib/cursor-agent.mjs";
 import { getDiff, getStatus } from "../lib/git.mjs";
 import { createJob, markFailed, markFinished, markRunning } from "../lib/job-control.mjs";
@@ -92,7 +92,7 @@ function parseFlags(args: readonly string[]): ReviewFlags {
   const timeout = optionalString(parsed, "timeout");
   if (timeout) {
     const ms = Number(timeout);
-    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid --timeout: ${timeout}`);
+    if (!Number.isFinite(ms) || ms <= 0) throw new UsageError(`invalid --timeout: ${timeout}`);
     flags.timeoutMs = ms;
   }
   return flags;

--- a/plugins/cursor/scripts/commands/review.mts
+++ b/plugins/cursor/scripts/commands/review.mts
@@ -117,14 +117,14 @@ function buildReviewPrompt(diff: string, status: string, instructions: string): 
  * Tolerant JSON extraction: agents sometimes wrap output in ```json fences
  * despite instructions. Strip surrounding fences before parsing.
  */
-function extractJson(raw: string): string {
+export function extractJson(raw: string): string {
   const trimmed = raw.trim();
   const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
   if (fenced) return fenced[1] ?? trimmed;
   return trimmed;
 }
 
-function parseReview(raw: string): ReviewOutput {
+export function parseReview(raw: string): ReviewOutput {
   const text = extractJson(raw);
   let parsed: unknown;
   try {

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -1,0 +1,158 @@
+import type { ModelSelection } from "@cursor/sdk";
+
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, parseArgs } from "../lib/args.mjs";
+import { listModels, resolveApiKey, whoami } from "../lib/cursor-agent.mjs";
+
+const NODE_MIN_MAJOR = 18;
+
+interface ModelChoice {
+  label: string;
+  selection: ModelSelection;
+  description?: string;
+}
+
+const HELP = `cursor-companion setup [--json] [--help]
+
+Validates the plugin runtime:
+  - Node.js >= ${NODE_MIN_MAJOR}
+  - CURSOR_API_KEY is set
+  - Cursor.me() succeeds (key is valid)
+  - Cursor.models.list() returns at least one model
+`;
+
+function nodeMajor(): number {
+  const m = process.versions.node.match(/^(\d+)\./);
+  return m ? Number(m[1]) : 0;
+}
+
+/**
+ * Flatten the SDK model catalog into selectable variants. Mirrors the cookbook
+ * `modelToChoices` shape (one row per concrete `ModelSelection`).
+ */
+export function modelChoices(models: Awaited<ReturnType<typeof listModels>>): ModelChoice[] {
+  const choices: ModelChoice[] = [];
+  const seen = new Set<string>();
+  for (const model of models) {
+    const baseLabel = model.displayName || model.id;
+    const variants = model.variants ?? [];
+    if (variants.length === 0) {
+      const key = model.id;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const choice: ModelChoice = { label: baseLabel, selection: { id: model.id } };
+      if (model.description) choice.description = model.description;
+      choices.push(choice);
+      continue;
+    }
+    for (const variant of variants) {
+      const selection: ModelSelection = { id: model.id, params: variant.params };
+      const key = JSON.stringify({
+        id: selection.id,
+        params: [...(selection.params ?? [])]
+          .sort((a, b) => a.id.localeCompare(b.id))
+          .map((p) => `${p.id}=${p.value}`),
+      });
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const variantLabel = variant.displayName.trim();
+      const label =
+        !variantLabel || variantLabel.toLowerCase() === baseLabel.toLowerCase()
+          ? baseLabel
+          : `${baseLabel} - ${variantLabel}`;
+      const choice: ModelChoice = { label, selection };
+      const description = variant.description ?? model.description;
+      if (description) choice.description = description;
+      choices.push(choice);
+    }
+  }
+  return choices;
+}
+
+interface SetupReport {
+  node: { ok: boolean; version: string };
+  apiKey: { ok: boolean; error?: string };
+  account: { ok: boolean; apiKeyName?: string; error?: string };
+  models: { ok: boolean; choices: ModelChoice[]; error?: string };
+}
+
+async function buildReport(): Promise<SetupReport> {
+  const report: SetupReport = {
+    node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
+    apiKey: { ok: false },
+    account: { ok: false },
+    models: { ok: false, choices: [] },
+  };
+
+  try {
+    resolveApiKey();
+    report.apiKey.ok = true;
+  } catch (err) {
+    report.apiKey.error = err instanceof Error ? err.message : String(err);
+    return report;
+  }
+
+  try {
+    const me = await whoami();
+    report.account.ok = true;
+    report.account.apiKeyName = me.apiKeyName;
+  } catch (err) {
+    report.account.error = err instanceof Error ? err.message : String(err);
+  }
+
+  try {
+    const models = await listModels();
+    report.models.choices = modelChoices(models);
+    report.models.ok = report.models.choices.length > 0;
+  } catch (err) {
+    report.models.error = err instanceof Error ? err.message : String(err);
+  }
+
+  return report;
+}
+
+function renderReport(report: SetupReport): string {
+  const lines: string[] = [];
+  const yes = (ok: boolean): string => (ok ? "ok" : "fail");
+  lines.push(`Node.js     ${yes(report.node.ok)}  (${report.node.version})`);
+  lines.push(
+    `API key     ${yes(report.apiKey.ok)}` +
+      (report.apiKey.error ? `  ${report.apiKey.error}` : ""),
+  );
+  if (report.account.ok) {
+    lines.push(`Account     ok    (key: ${report.account.apiKeyName ?? "?"})`);
+  } else if (report.account.error) {
+    lines.push(`Account     fail  ${report.account.error}`);
+  }
+  if (report.models.ok) {
+    lines.push(`Models      ok    (${report.models.choices.length} available)`);
+    for (const choice of report.models.choices) {
+      lines.push(`  - ${choice.label}  [${choice.selection.id}]`);
+    }
+  } else if (report.models.error) {
+    lines.push(`Models      fail  ${report.models.error}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export async function runSetup(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const parsed = parseArgs(args, {
+    long: { json: "boolean", help: "boolean" },
+    short: { h: "help" },
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP);
+    return 0;
+  }
+
+  const report = await buildReport();
+
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  } else {
+    io.stdout.write(renderReport(report));
+  }
+
+  const allOk = report.node.ok && report.apiKey.ok && report.account.ok && report.models.ok;
+  return allOk ? 0 : 1;
+}

--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -1,5 +1,5 @@
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import { getJob, type ListJobsFilter, listJobs } from "../lib/job-control.mjs";
 import { renderJobTable } from "../lib/render.mjs";
 import { type JobStatus, type JobType, resolveStateDir } from "../lib/state.mjs";
@@ -60,14 +60,16 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
   const type = optionalString(parsed, "type");
   if (type) {
     if (!VALID_TYPES.has(type)) {
-      throw new Error(`invalid --type: ${type} (expected one of ${[...VALID_TYPES].join(", ")})`);
+      throw new UsageError(
+        `invalid --type: ${type} (expected one of ${[...VALID_TYPES].join(", ")})`,
+      );
     }
     filter.type = type as JobType;
   }
   const status = optionalString(parsed, "status");
   if (status) {
     if (!VALID_STATUSES.has(status)) {
-      throw new Error(
+      throw new UsageError(
         `invalid --status: ${status} (expected one of ${[...VALID_STATUSES].join(", ")})`,
       );
     }
@@ -76,7 +78,7 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
   const limit = optionalString(parsed, "limit");
   if (limit) {
     const n = Number(limit);
-    if (!Number.isFinite(n) || n < 0) throw new Error(`invalid --limit: ${limit}`);
+    if (!Number.isFinite(n) || n < 0) throw new UsageError(`invalid --limit: ${limit}`);
     filter.limit = Math.floor(n);
   }
   const jobs = listJobs(stateDir, filter);

--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -1,0 +1,100 @@
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import { getJob, type ListJobsFilter, listJobs } from "../lib/job-control.mjs";
+import { renderJobTable } from "../lib/render.mjs";
+import { type JobStatus, type JobType, resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
+
+const HELP = `cursor-companion status [<job-id>] [flags]
+
+Show the job table for the current workspace, or detail for one job.
+
+flags:
+  --type <task|review|adversarial-review>  Filter by type
+  --status <pending|running|completed|failed|cancelled>
+  --limit <n>                              Cap number of rows
+  --json                                   Print as JSON
+  --help, -h
+`;
+
+export async function runStatus(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const parsed = parseArgs(args, {
+    long: {
+      type: "string",
+      status: "string",
+      limit: "string",
+      json: "boolean",
+      help: "boolean",
+    },
+    short: { h: "help" },
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP);
+    return 0;
+  }
+
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const json = bool(parsed, "json");
+
+  const jobId = parsed.positionals[0];
+  if (jobId) {
+    const job = getJob(stateDir, jobId);
+    if (!job) {
+      io.stderr.write(`job not found: ${jobId}\n`);
+      return 1;
+    }
+    if (json) {
+      io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
+    } else {
+      io.stdout.write(renderJobDetail(job));
+    }
+    return 0;
+  }
+
+  const filter: ListJobsFilter = {};
+  const type = optionalString(parsed, "type");
+  if (type) filter.type = type as JobType;
+  const status = optionalString(parsed, "status");
+  if (status) filter.status = status as JobStatus;
+  const limit = optionalString(parsed, "limit");
+  if (limit) {
+    const n = Number(limit);
+    if (!Number.isFinite(n) || n < 0) throw new Error(`invalid --limit: ${limit}`);
+    filter.limit = Math.floor(n);
+  }
+  const jobs = listJobs(stateDir, filter);
+
+  if (json) {
+    io.stdout.write(`${JSON.stringify(jobs, null, 2)}\n`);
+  } else {
+    io.stdout.write(renderJobTable(jobs));
+  }
+  return 0;
+}
+
+function renderJobDetail(job: ReturnType<typeof getJob>): string {
+  if (!job) return "";
+  const lines: string[] = [];
+  lines.push(`id:         ${job.id}`);
+  lines.push(`type:       ${job.type}`);
+  lines.push(`status:     ${job.status}`);
+  lines.push(`createdAt:  ${job.createdAt}`);
+  lines.push(`updatedAt:  ${job.updatedAt}`);
+  if (job.startedAt) lines.push(`startedAt:  ${job.startedAt}`);
+  if (job.finishedAt) lines.push(`finishedAt: ${job.finishedAt}`);
+  if (typeof job.durationMs === "number") lines.push(`durationMs: ${job.durationMs}`);
+  if (job.agentId) lines.push(`agentId:    ${job.agentId}`);
+  if (job.runId) lines.push(`runId:      ${job.runId}`);
+  if (job.metadata && Object.keys(job.metadata).length > 0) {
+    lines.push(`metadata:   ${JSON.stringify(job.metadata)}`);
+  }
+  if (job.error) {
+    lines.push("", "error:", job.error);
+  }
+  if (job.prompt) {
+    lines.push("", "prompt:", job.prompt);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -5,6 +5,9 @@ import { renderJobTable } from "../lib/render.mjs";
 import { type JobStatus, type JobType, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
+const VALID_TYPES = new Set<string>(["task", "review", "adversarial-review"]);
+const VALID_STATUSES = new Set<string>(["pending", "running", "completed", "failed", "cancelled"]);
+
 const HELP = `cursor-companion status [<job-id>] [flags]
 
 Show the job table for the current workspace, or detail for one job.
@@ -55,9 +58,21 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
 
   const filter: ListJobsFilter = {};
   const type = optionalString(parsed, "type");
-  if (type) filter.type = type as JobType;
+  if (type) {
+    if (!VALID_TYPES.has(type)) {
+      throw new Error(`invalid --type: ${type} (expected one of ${[...VALID_TYPES].join(", ")})`);
+    }
+    filter.type = type as JobType;
+  }
   const status = optionalString(parsed, "status");
-  if (status) filter.status = status as JobStatus;
+  if (status) {
+    if (!VALID_STATUSES.has(status)) {
+      throw new Error(
+        `invalid --status: ${status} (expected one of ${[...VALID_STATUSES].join(", ")})`,
+      );
+    }
+    filter.status = status as JobStatus;
+  }
   const limit = optionalString(parsed, "limit");
   if (limit) {
     const n = Number(limit);

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -19,6 +19,8 @@ import {
   markFailed,
   markFinished,
   markRunning,
+  registerActiveRun,
+  unregisterActiveRun,
 } from "../lib/job-control.mjs";
 import { renderStreamEvent } from "../lib/render.mjs";
 import { ensureStateDir, readJob, resolveStateDir } from "../lib/state.mjs";
@@ -187,6 +189,10 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
     const result = await sendTask(agent, fullPrompt, {
       ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
       ...(flags.force ? { force: true } : {}),
+      onRunStart: (run) => {
+        markRunning(stateDir, job.id, { agentId: run.agentId, runId: run.id });
+        registerActiveRun(job.id, run);
+      },
       onEvent: (event: SDKMessage) => {
         for (const ae of toAgentEvents(event)) {
           const rendered = renderStreamEvent(ae, { quietStatus: true });
@@ -199,7 +205,6 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
       },
     });
 
-    markRunning(stateDir, job.id, { agentId: result.agentId, runId: result.runId });
     markFinished(stateDir, job.id, result);
 
     if (flags.json) {
@@ -213,15 +218,19 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
     markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
     throw err;
   } finally {
+    unregisterActiveRun(job.id);
     await disposeAgent(agent).catch(() => undefined);
   }
 }
 
 /**
  * Background mode: kick off the run, persist its events to the per-job log,
- * and return immediately. The CLI process exits right after; the run keeps
- * going under the SDK's local runtime. Cancellation of a background run
- * falls back to `run-not-active` + persisted-mark in the calling process.
+ * and return immediately. The CLI process keeps running until the IIFE
+ * resolves (Node won't exit while a Promise is pending), so the run
+ * actually completes — but stdout was already returned to the user. Cancel
+ * of a background run from a different CLI invocation falls back to
+ * `run-not-active` + persisted-mark since the Run object is in this process
+ * only.
  */
 function detachBackgroundRun(
   agent: Awaited<ReturnType<typeof createAgent>>,
@@ -235,6 +244,10 @@ function detachBackgroundRun(
       const result = await sendTask(agent, prompt, {
         ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
         ...(flags.force ? { force: true } : {}),
+        onRunStart: (run) => {
+          markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
+          registerActiveRun(jobId, run);
+        },
         onEvent: (event: SDKMessage) => {
           for (const ae of toAgentEvents(event)) {
             const rendered = renderStreamEvent(ae);
@@ -243,11 +256,11 @@ function detachBackgroundRun(
           }
         },
       });
-      markRunning(stateDir, jobId, { agentId: result.agentId, runId: result.runId });
       markFinished(stateDir, jobId, result);
     } catch (err) {
       markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
     } finally {
+      unregisterActiveRun(jobId);
       await disposeAgent(agent).catch(() => undefined);
     }
   })();

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -1,0 +1,254 @@
+import type { ModelSelection, SDKMessage } from "@cursor/sdk";
+
+import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
+import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import {
+  buildPrompt,
+  type CursorAgentOptions,
+  createAgent,
+  disposeAgent,
+  resumeAgent,
+  sendTask,
+  toAgentEvents,
+} from "../lib/cursor-agent.mjs";
+import { detectCloudRepository, getBranch, getRecentCommits } from "../lib/git.mjs";
+import {
+  createJob,
+  listJobs,
+  logJobLine,
+  markFailed,
+  markFinished,
+  markRunning,
+} from "../lib/job-control.mjs";
+import { renderStreamEvent } from "../lib/render.mjs";
+import { ensureStateDir, readJob, resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
+
+const HELP = `cursor-companion task <prompt> [flags]
+
+Delegate an implementation task to a Cursor agent. Streams events to stdout
+(assistant text) and stderr (annotations).
+
+flags:
+  --write              Allow file modifications (default: read-only)
+  --resume-last        Resume the most-recent task agent for this workspace
+  --background         Start the run and exit, returning the job id
+  --force              Expire any wedged active local run before sending
+  --cloud              Use Cursor cloud against the detected GitHub origin
+  --model <id>         Override the default model
+  -m <id>
+  --timeout <ms>       Cancel the run if it exceeds this duration
+  --json               Print the final result as JSON (single line)
+  --help, -h
+`;
+
+interface TaskFlags {
+  prompt: string;
+  write: boolean;
+  resumeLast: boolean;
+  background: boolean;
+  force: boolean;
+  cloud: boolean;
+  model?: ModelSelection;
+  timeoutMs?: number;
+  json: boolean;
+}
+
+class HelpRequested extends Error {}
+
+function parseFlags(args: readonly string[]): TaskFlags {
+  const parsed = parseArgs(args, {
+    long: {
+      write: "boolean",
+      "resume-last": "boolean",
+      background: "boolean",
+      force: "boolean",
+      cloud: "boolean",
+      model: "string",
+      timeout: "string",
+      json: "boolean",
+      help: "boolean",
+    },
+    short: { h: "help", m: "model" },
+  });
+  if (bool(parsed, "help")) throw new HelpRequested();
+
+  const prompt = parsed.positionals.join(" ").trim();
+  if (!prompt) throw new Error("task requires a prompt argument");
+
+  const flags: TaskFlags = {
+    prompt,
+    write: bool(parsed, "write"),
+    resumeLast: bool(parsed, "resume-last"),
+    background: bool(parsed, "background"),
+    force: bool(parsed, "force"),
+    cloud: bool(parsed, "cloud"),
+    json: bool(parsed, "json"),
+  };
+  const modelId = optionalString(parsed, "model");
+  if (modelId) flags.model = { id: modelId };
+  const timeout = optionalString(parsed, "timeout");
+  if (timeout) {
+    const ms = Number(timeout);
+    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid --timeout: ${timeout}`);
+    flags.timeoutMs = ms;
+  }
+  return flags;
+}
+
+function buildContextHeader(workspaceRoot: string): string {
+  const lines: string[] = [];
+  const branch = getBranch(workspaceRoot);
+  if (branch) lines.push(`Current branch: ${branch}`);
+  const commits = getRecentCommits(workspaceRoot, 5);
+  if (commits.length > 0) {
+    lines.push("Recent commits:");
+    for (const c of commits) {
+      lines.push(`  ${c.hash.slice(0, 8)} ${c.subject}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function buildAgentOptionsForFlags(flags: TaskFlags, workspaceRoot: string): CursorAgentOptions {
+  const opts: CursorAgentOptions = { cwd: workspaceRoot };
+  if (flags.model) opts.model = flags.model;
+  if (flags.cloud) {
+    opts.mode = "cloud";
+    opts.cloudRepo = detectCloudRepository(workspaceRoot);
+  }
+  return opts;
+}
+
+function findResumeAgentId(stateDir: string): string | undefined {
+  const recent = listJobs(stateDir, { type: "task", limit: 10 });
+  for (const entry of recent) {
+    const job = readJob(stateDir, entry.id);
+    if (job?.agentId) return job.agentId;
+  }
+  return undefined;
+}
+
+export async function runTask(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  let flags: TaskFlags;
+  try {
+    flags = parseFlags(args);
+  } catch (err) {
+    if (err instanceof HelpRequested) {
+      io.stdout.write(HELP);
+      return 0;
+    }
+    throw err;
+  }
+
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+
+  const writePolicy = flags.write
+    ? "You may modify files in the workspace."
+    : "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
+  const fullPrompt = buildPrompt(
+    [buildContextHeader(workspaceRoot), "", writePolicy, "", flags.prompt]
+      .filter((line) => line.length > 0 || line === "")
+      .join("\n"),
+  );
+
+  const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
+
+  const agentOpts = buildAgentOptionsForFlags(flags, workspaceRoot);
+  let agent: Awaited<ReturnType<typeof createAgent>>;
+  if (flags.resumeLast) {
+    const agentId = findResumeAgentId(stateDir);
+    if (!agentId) {
+      io.stderr.write("no previous task agent to resume — starting fresh\n");
+      agent = await createAgent(agentOpts);
+    } else {
+      try {
+        agent = await resumeAgent(agentId, agentOpts);
+      } catch (err) {
+        io.stderr.write(
+          `resume failed (${err instanceof Error ? err.message : String(err)}); starting fresh\n`,
+        );
+        agent = await createAgent(agentOpts);
+      }
+    }
+  } else {
+    agent = await createAgent(agentOpts);
+  }
+
+  if (flags.background) {
+    detachBackgroundRun(agent, fullPrompt, flags, stateDir, job.id);
+    io.stdout.write(`${job.id}\n`);
+    return 0;
+  }
+
+  try {
+    const result = await sendTask(agent, fullPrompt, {
+      ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
+      ...(flags.force ? { force: true } : {}),
+      onEvent: (event: SDKMessage) => {
+        for (const ae of toAgentEvents(event)) {
+          const rendered = renderStreamEvent(ae, { quietStatus: true });
+          if (rendered.stdout) io.stdout.write(rendered.stdout);
+          if (rendered.stderr) {
+            io.stderr.write(rendered.stderr);
+            logJobLine(stateDir, job.id, rendered.stderr.replace(/\n$/, ""));
+          }
+        }
+      },
+    });
+
+    markRunning(stateDir, job.id, { agentId: result.agentId, runId: result.runId });
+    markFinished(stateDir, job.id, result);
+
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify({ jobId: job.id, ...result })}\n`);
+    } else if (!result.output.endsWith("\n")) {
+      io.stdout.write("\n");
+    }
+
+    return result.status === "finished" ? 0 : 1;
+  } catch (err) {
+    markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
+    throw err;
+  } finally {
+    await disposeAgent(agent).catch(() => undefined);
+  }
+}
+
+/**
+ * Background mode: kick off the run, persist its events to the per-job log,
+ * and return immediately. The CLI process exits right after; the run keeps
+ * going under the SDK's local runtime. Cancellation of a background run
+ * falls back to `run-not-active` + persisted-mark in the calling process.
+ */
+function detachBackgroundRun(
+  agent: Awaited<ReturnType<typeof createAgent>>,
+  prompt: string,
+  flags: TaskFlags,
+  stateDir: string,
+  jobId: string,
+): void {
+  void (async () => {
+    try {
+      const result = await sendTask(agent, prompt, {
+        ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
+        ...(flags.force ? { force: true } : {}),
+        onEvent: (event: SDKMessage) => {
+          for (const ae of toAgentEvents(event)) {
+            const rendered = renderStreamEvent(ae);
+            if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
+            if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
+          }
+        },
+      });
+      markRunning(stateDir, jobId, { agentId: result.agentId, runId: result.runId });
+      markFinished(stateDir, jobId, result);
+    } catch (err) {
+      markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
+    } finally {
+      await disposeAgent(agent).catch(() => undefined);
+    }
+  })();
+}

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -150,11 +150,11 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
   const writePolicy = flags.write
     ? "You may modify files in the workspace."
     : "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
-  const fullPrompt = buildPrompt(
-    [buildContextHeader(workspaceRoot), "", writePolicy, "", flags.prompt]
-      .filter((line) => line.length > 0 || line === "")
-      .join("\n"),
-  );
+  // Skip local-workspace context in cloud mode: the cloud agent runs against
+  // `startingRef` of the remote, so local uncommitted state would mislead it.
+  const contextHeader = flags.cloud ? "" : buildContextHeader(workspaceRoot);
+  const sections = [contextHeader, writePolicy, flags.prompt].filter((s) => s.length > 0);
+  const fullPrompt = buildPrompt(sections.join("\n\n"));
 
   const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
 

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -1,7 +1,7 @@
 import type { ModelSelection, SDKMessage } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, optionalString, parseArgs } from "../lib/args.mjs";
+import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
   buildPrompt,
   type CursorAgentOptions,
@@ -76,7 +76,7 @@ function parseFlags(args: readonly string[]): TaskFlags {
   if (bool(parsed, "help")) throw new HelpRequested();
 
   const prompt = parsed.positionals.join(" ").trim();
-  if (!prompt) throw new Error("task requires a prompt argument");
+  if (!prompt) throw new UsageError("task requires a prompt argument");
 
   const flags: TaskFlags = {
     prompt,
@@ -92,7 +92,7 @@ function parseFlags(args: readonly string[]): TaskFlags {
   const timeout = optionalString(parsed, "timeout");
   if (timeout) {
     const ms = Number(timeout);
-    if (!Number.isFinite(ms) || ms <= 0) throw new Error(`invalid --timeout: ${timeout}`);
+    if (!Number.isFinite(ms) || ms <= 0) throw new UsageError(`invalid --timeout: ${timeout}`);
     flags.timeoutMs = ms;
   }
   return flags;

--- a/plugins/cursor/scripts/cursor-companion.mts
+++ b/plugins/cursor/scripts/cursor-companion.mts
@@ -5,6 +5,7 @@ import { runReview } from "./commands/review.mjs";
 import { runSetup } from "./commands/setup.mjs";
 import { runStatus } from "./commands/status.mjs";
 import { runTask } from "./commands/task.mjs";
+import { UsageError } from "./lib/args.mjs";
 import { renderError } from "./lib/render.mjs";
 
 export type ExitCode = 0 | 1 | 2;
@@ -65,7 +66,7 @@ export async function main(argv: readonly string[], io: CommandIO): Promise<Exit
     }
   } catch (err) {
     io.stderr.write(renderError(err));
-    return 1;
+    return err instanceof UsageError ? 2 : 1;
   }
 }
 

--- a/plugins/cursor/scripts/cursor-companion.mts
+++ b/plugins/cursor/scripts/cursor-companion.mts
@@ -1,20 +1,82 @@
 #!/usr/bin/env node
-const SUBCOMMANDS = ["task", "review", "adversarial-review", "status", "result", "cancel", "setup"];
+import { runCancel } from "./commands/cancel.mjs";
+import { runResult } from "./commands/result.mjs";
+import { runReview } from "./commands/review.mjs";
+import { runSetup } from "./commands/setup.mjs";
+import { runStatus } from "./commands/status.mjs";
+import { runTask } from "./commands/task.mjs";
+import { renderError } from "./lib/render.mjs";
 
-export function main(argv: readonly string[]): number {
-  const command = argv[2];
-  if (command === undefined) {
-    console.log(`cursor-companion <command>\n\ncommands:\n  ${SUBCOMMANDS.join("\n  ")}`);
+export type ExitCode = 0 | 1 | 2;
+
+interface CommandIO {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  cwd: () => string;
+  env: NodeJS.ProcessEnv;
+}
+
+const HELP = `cursor-companion <command> [args]
+
+commands:
+  task <prompt>          Delegate an implementation task to Cursor
+  review                 Review the current diff
+  adversarial-review     Challenge design choices, not just defects
+  status [<job-id>]      Show job table or single job detail
+  result <job-id>        Retrieve a completed job's output
+  cancel <job-id>        Cancel an active job
+  setup                  Validate API key, list available models
+
+global flags:
+  --json                 Machine-readable output where supported
+  --help, -h             Show this help
+
+run '<command> --help' for command-specific options.
+`;
+
+export async function main(argv: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const [, , command, ...rest] = argv;
+
+  if (command === undefined || command === "--help" || command === "-h") {
+    io.stdout.write(HELP);
     return 0;
   }
-  if (!SUBCOMMANDS.includes(command)) {
-    console.error(`cursor-companion: unknown command '${command}'`);
-    return 2;
+
+  try {
+    switch (command) {
+      case "task":
+        return await runTask(rest, io);
+      case "review":
+        return await runReview(rest, io, { adversarial: false });
+      case "adversarial-review":
+        return await runReview(rest, io, { adversarial: true });
+      case "status":
+        return await runStatus(rest, io);
+      case "result":
+        return await runResult(rest, io);
+      case "cancel":
+        return await runCancel(rest, io);
+      case "setup":
+        return await runSetup(rest, io);
+      default:
+        io.stderr.write(`cursor-companion: unknown command '${command}'\n`);
+        io.stderr.write(HELP);
+        return 2;
+    }
+  } catch (err) {
+    io.stderr.write(renderError(err));
+    return 1;
   }
-  console.error(`cursor-companion: '${command}' is not implemented yet.`);
-  return 1;
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
-  process.exit(main(process.argv));
+  const code = await main(process.argv, {
+    stdout: process.stdout,
+    stderr: process.stderr,
+    cwd: () => process.cwd(),
+    env: process.env,
+  });
+  process.exit(code);
 }
+
+export type { CommandIO };

--- a/plugins/cursor/scripts/lib/args.mts
+++ b/plugins/cursor/scripts/lib/args.mts
@@ -10,6 +10,19 @@
  * flags throw because they would otherwise silently swallow the next token.
  */
 
+/**
+ * Thrown for any user-supplied argv defect: missing required value, unknown
+ * short flag, missing positional, invalid filter value, etc. The CLI router
+ * maps this to exit code 2 (per the documented convention) instead of the
+ * generic exit 1 used for runtime failures.
+ */
+export class UsageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UsageError";
+  }
+}
+
 export interface ParsedArgs {
   /** Positional arguments, in order. */
   positionals: string[];
@@ -60,7 +73,7 @@ export function parseArgs(argv: readonly string[], spec: ArgSpec = {}): ParsedAr
         } else {
           const next = argv[i + 1];
           if (next === undefined || next.startsWith("-")) {
-            throw new Error(`expected value after --${name}`);
+            throw new UsageError(`expected value after --${name}`);
           }
           flags[name] = next;
           i += 1;
@@ -77,13 +90,13 @@ export function parseArgs(argv: readonly string[], spec: ArgSpec = {}): ParsedAr
       const shortName = arg.slice(1);
       const longName = short[shortName];
       if (!longName) {
-        throw new Error(`unknown short flag: ${arg}`);
+        throw new UsageError(`unknown short flag: ${arg}`);
       }
       const kind = long[longName];
       if (kind === "string") {
         const next = argv[i + 1];
         if (next === undefined || next.startsWith("-")) {
-          throw new Error(`expected value after ${arg}`);
+          throw new UsageError(`expected value after ${arg}`);
         }
         flags[longName] = next;
         i += 1;
@@ -102,7 +115,7 @@ export function parseArgs(argv: readonly string[], spec: ArgSpec = {}): ParsedAr
 /** Convenience: extract a string flag, throwing if missing. */
 export function requireString(parsed: ParsedArgs, name: string): string {
   const v = parsed.flags[name];
-  if (typeof v !== "string") throw new Error(`missing required --${name}`);
+  if (typeof v !== "string") throw new UsageError(`missing required --${name}`);
   return v;
 }
 

--- a/plugins/cursor/scripts/lib/args.mts
+++ b/plugins/cursor/scripts/lib/args.mts
@@ -1,0 +1,118 @@
+/**
+ * Minimal argv parser. Distinguishes:
+ *  - boolean flags: `--write`, `-w`
+ *  - value flags: `--model x`, `--model=x`, `-m x`
+ *  - positionals (everything else)
+ *  - `--`: stop flag-parsing; remainder is treated as positionals
+ *
+ * Unknown long flags are still parsed (recorded in `flags`) — the caller
+ * decides whether they are valid for the active subcommand. Unknown short
+ * flags throw because they would otherwise silently swallow the next token.
+ */
+
+export interface ParsedArgs {
+  /** Positional arguments, in order. */
+  positionals: string[];
+  /** Boolean flags that were present (true), and value flags as strings. */
+  flags: Record<string, string | true>;
+}
+
+export interface ArgSpec {
+  /** Long names → kind. Always include without leading `--`. */
+  long?: Record<string, "boolean" | "string">;
+  /** Short alias → long name (without leading `-` / `--`). */
+  short?: Record<string, string>;
+}
+
+export function parseArgs(argv: readonly string[], spec: ArgSpec = {}): ParsedArgs {
+  const long = spec.long ?? {};
+  const short = spec.short ?? {};
+  const flags: Record<string, string | true> = {};
+  const positionals: string[] = [];
+  let stopParsing = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+    if (stopParsing) {
+      positionals.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      stopParsing = true;
+      continue;
+    }
+
+    if (arg.startsWith("--")) {
+      const eqIdx = arg.indexOf("=");
+      const name = eqIdx === -1 ? arg.slice(2) : arg.slice(2, eqIdx);
+      const inlineValue = eqIdx === -1 ? undefined : arg.slice(eqIdx + 1);
+      const kind = long[name];
+      if (kind === "boolean") {
+        if (inlineValue === "false") {
+          delete flags[name];
+        } else {
+          flags[name] = true;
+        }
+      } else if (kind === "string") {
+        if (inlineValue !== undefined) {
+          flags[name] = inlineValue;
+        } else {
+          const next = argv[i + 1];
+          if (next === undefined || next.startsWith("-")) {
+            throw new Error(`expected value after --${name}`);
+          }
+          flags[name] = next;
+          i += 1;
+        }
+      } else {
+        // Unknown long flag — record as boolean if no value, else as string.
+        if (inlineValue !== undefined) flags[name] = inlineValue;
+        else flags[name] = true;
+      }
+      continue;
+    }
+
+    if (arg.startsWith("-") && arg.length > 1) {
+      const shortName = arg.slice(1);
+      const longName = short[shortName];
+      if (!longName) {
+        throw new Error(`unknown short flag: ${arg}`);
+      }
+      const kind = long[longName];
+      if (kind === "string") {
+        const next = argv[i + 1];
+        if (next === undefined || next.startsWith("-")) {
+          throw new Error(`expected value after ${arg}`);
+        }
+        flags[longName] = next;
+        i += 1;
+      } else {
+        flags[longName] = true;
+      }
+      continue;
+    }
+
+    positionals.push(arg);
+  }
+
+  return { positionals, flags };
+}
+
+/** Convenience: extract a string flag, throwing if missing. */
+export function requireString(parsed: ParsedArgs, name: string): string {
+  const v = parsed.flags[name];
+  if (typeof v !== "string") throw new Error(`missing required --${name}`);
+  return v;
+}
+
+/** Convenience: extract an optional string flag. */
+export function optionalString(parsed: ParsedArgs, name: string): string | undefined {
+  const v = parsed.flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+/** Convenience: presence-check a boolean flag (or absent → false). */
+export function bool(parsed: ParsedArgs, name: string): boolean {
+  return parsed.flags[name] === true;
+}

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -12,12 +12,20 @@ import {
   type SDKModel,
   type SDKStatusMessage,
   type SDKUser,
+  type SendOptions,
   type SettingSource,
 } from "@cursor/sdk";
 
 export const DEFAULT_MODEL: ModelSelection = { id: "composer-2" };
 
 export type CursorAgentStatus = "finished" | "error" | "cancelled" | "expired";
+
+export type AgentMode = "local" | "cloud";
+
+export interface CloudRepo {
+  url: string;
+  startingRef?: string;
+}
 
 export interface ToolCallEvent {
   callId: string;
@@ -45,6 +53,10 @@ export interface CursorAgentOptions {
   mcpServers?: Record<string, McpServerConfig>;
   settingSources?: SettingSource[];
   name?: string;
+  /** Execution mode. Defaults to "local". */
+  mode?: AgentMode;
+  /** Required when mode === "cloud". */
+  cloudRepo?: CloudRepo;
 }
 
 export interface SendTaskOptions {
@@ -52,9 +64,20 @@ export interface SendTaskOptions {
   timeoutMs?: number;
   /** Invoked once for every SDKMessage emitted while the run streams. */
   onEvent?: (event: SDKMessage) => void;
+  /**
+   * Local-only: expire the agent's currently-active persisted run before
+   * starting this one. Recovery path when a previous CLI process crashed
+   * mid-run and left the agent wedged.
+   */
+  force?: boolean;
 }
 
 export type OneShotOptions = CursorAgentOptions & SendTaskOptions;
+
+export interface CancelResult {
+  cancelled: boolean;
+  reason?: string;
+}
 
 interface RequestOptions {
   apiKey?: string;
@@ -75,16 +98,59 @@ export function resolveApiKey(apiKey?: string): string {
   return resolved;
 }
 
+/**
+ * Default system instructions wrapped around user prompts via `buildPrompt`.
+ * Mirrors the pattern from cursor/cookbook coding-agent-cli — small framing
+ * that nudges the agent toward focused changes and concise progress.
+ */
+export const DEFAULT_AGENT_INSTRUCTIONS = [
+  "You are a coding agent invoked by Claude Code via the cursor-plugin-cc plugin.",
+  "Operate in the configured workspace.",
+  "Make focused, well-scoped changes; preserve unrelated user work.",
+  "Before changing files, understand the surrounding code.",
+  "Keep progress updates concise and summarize the result clearly at the end.",
+].join("\n");
+
+/**
+ * Wrap a user prompt with system instructions. Callers that need raw prompts
+ * (e.g. structured-output review) can skip this and pass the prompt directly
+ * to `sendTask`.
+ */
+export function buildPrompt(prompt: string, instructions?: string): string {
+  const sys = instructions ?? DEFAULT_AGENT_INSTRUCTIONS;
+  return `${sys}\n\nUser task:\n${prompt}`;
+}
+
 function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
+  const apiKey = resolveApiKey(opts.apiKey);
+  const model = opts.model ?? DEFAULT_MODEL;
+  const mode: AgentMode = opts.mode ?? "local";
+
+  const base: AgentOptions = {
+    apiKey,
+    model,
+    ...(opts.name ? { name: opts.name } : {}),
+    ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
+  };
+
+  if (mode === "cloud") {
+    if (!opts.cloudRepo) {
+      throw new ConfigurationError(
+        "Cloud mode requires a cloudRepo (url, optional startingRef). " +
+          "Use detectCloudRepository() from lib/git.mts.",
+      );
+    }
+    const repo: { url: string; startingRef?: string } = { url: opts.cloudRepo.url };
+    if (opts.cloudRepo.startingRef) repo.startingRef = opts.cloudRepo.startingRef;
+    return { ...base, cloud: { repos: [repo] } };
+  }
+
   return {
-    apiKey: resolveApiKey(opts.apiKey),
-    model: opts.model ?? DEFAULT_MODEL,
+    ...base,
     local: {
       cwd: opts.cwd,
       ...(opts.settingSources ? { settingSources: opts.settingSources } : {}),
     },
-    ...(opts.name ? { name: opts.name } : {}),
-    ...(opts.mcpServers ? { mcpServers: opts.mcpServers } : {}),
   };
 }
 
@@ -106,7 +172,9 @@ export async function sendTask(
   prompt: string,
   options: SendTaskOptions = {},
 ): Promise<CursorRunResult> {
-  const run = await agent.send(prompt);
+  const run = options.force
+    ? await agent.send(prompt, { local: { force: true } } satisfies SendOptions)
+    : await agent.send(prompt);
   return collectRunResult(run, options);
 }
 
@@ -117,18 +185,33 @@ export async function sendTask(
  * signal to callers.
  */
 export async function oneShot(prompt: string, opts: OneShotOptions): Promise<CursorRunResult> {
-  const { timeoutMs, onEvent, ...agentOpts } = opts;
+  const { timeoutMs, onEvent, force, ...agentOpts } = opts;
   const agent = await createAgent(agentOpts);
   try {
     const sendOpts: SendTaskOptions = {};
     if (timeoutMs !== undefined) sendOpts.timeoutMs = timeoutMs;
     if (onEvent !== undefined) sendOpts.onEvent = onEvent;
+    if (force !== undefined) sendOpts.force = force;
     return await sendTask(agent, prompt, sendOpts);
   } finally {
     await disposeAgent(agent).catch(() => {
       /* dispose is best-effort; primary result is what callers care about */
     });
   }
+}
+
+/**
+ * Cancel a running operation, checking `run.supports("cancel")` first so the
+ * caller gets a clean reason instead of a thrown UnsupportedRunOperationError
+ * on agents that can't be cancelled.
+ */
+export async function cancelRun(run: Run): Promise<CancelResult> {
+  if (!run.supports("cancel")) {
+    const reason = run.unsupportedReason("cancel") ?? "This run cannot be cancelled.";
+    return { cancelled: false, reason };
+  }
+  await run.cancel();
+  return { cancelled: true };
 }
 
 export async function listArtifacts(agent: SDKAgent): Promise<SDKArtifact[]> {
@@ -171,6 +254,93 @@ export function normalizeStreamStatus(
   return status.toLowerCase() as CursorAgentStatus | "creating" | "running";
 }
 
+/**
+ * Flat representation of a stream event for terminal/UI consumers. One
+ * `SDKMessage` may produce 0+ `AgentEvent`s — assistant messages with
+ * multiple content blocks emit one per text/tool_use block.
+ */
+export type AgentEvent =
+  | { type: "assistant_text"; text: string }
+  | { type: "thinking"; text: string }
+  | {
+      type: "tool";
+      callId: string;
+      name: string;
+      status: "requested" | "running" | "completed" | "error";
+      args?: unknown;
+    }
+  | {
+      type: "status";
+      status: CursorAgentStatus | "creating" | "running";
+      message?: string;
+    }
+  | { type: "task"; status?: string; text?: string }
+  | { type: "system"; model?: ModelSelection; tools?: string[] };
+
+/**
+ * Map a single `SDKMessage` to flat `AgentEvent`s. Inspired by the cookbook's
+ * `emitSdkMessage`. Unknown event types are dropped (forward-compatible).
+ */
+export function toAgentEvents(message: SDKMessage): AgentEvent[] {
+  switch (message.type) {
+    case "assistant": {
+      const events: AgentEvent[] = [];
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          events.push({ type: "assistant_text", text: block.text });
+        } else {
+          events.push({
+            type: "tool",
+            callId: block.id,
+            name: block.name,
+            status: "requested",
+            args: block.input,
+          });
+        }
+      }
+      return events;
+    }
+    case "thinking":
+      return [{ type: "thinking", text: message.text }];
+    case "tool_call":
+      return [
+        {
+          type: "tool",
+          callId: message.call_id,
+          name: message.name,
+          status: message.status,
+          args: message.args,
+        },
+      ];
+    case "status":
+      return [
+        {
+          type: "status",
+          status: normalizeStreamStatus(message.status),
+          ...(message.message ? { message: message.message } : {}),
+        },
+      ];
+    case "task":
+      return [
+        {
+          type: "task",
+          ...(message.status ? { status: message.status } : {}),
+          ...(message.text ? { text: message.text } : {}),
+        },
+      ];
+    case "system":
+      return [
+        {
+          type: "system",
+          ...(message.model ? { model: message.model } : {}),
+          ...(message.tools ? { tools: message.tools } : {}),
+        },
+      ];
+    default:
+      return [];
+  }
+}
+
 async function collectRunResult(run: Run, options: SendTaskOptions): Promise<CursorRunResult> {
   const toolCalls = new Map<string, ToolCallEvent>();
   const textParts: string[] = [];
@@ -181,9 +351,11 @@ async function collectRunResult(run: Run, options: SendTaskOptions): Promise<Cur
     options.timeoutMs !== undefined && options.timeoutMs > 0
       ? setTimeout(() => {
           timedOut = true;
-          run.cancel().catch(() => {
-            /* run may already be terminal; swallow */
-          });
+          if (run.supports("cancel")) {
+            run.cancel().catch(() => {
+              /* run may already be terminal; swallow */
+            });
+          }
         }, options.timeoutMs)
       : undefined;
 

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -65,6 +65,12 @@ export interface SendTaskOptions {
   /** Invoked once for every SDKMessage emitted while the run streams. */
   onEvent?: (event: SDKMessage) => void;
   /**
+   * Fires once `agent.send` resolves and we have a `Run` — before any events
+   * are streamed. Lets callers stamp job state to "running" and register the
+   * Run for capability-checked cancellation while the work is in flight.
+   */
+  onRunStart?: (run: Run) => void;
+  /**
    * Local-only: expire the agent's currently-active persisted run before
    * starting this one. Recovery path when a previous CLI process crashed
    * mid-run and left the agent wedged.
@@ -175,6 +181,7 @@ export async function sendTask(
   const run = options.force
     ? await agent.send(prompt, { local: { force: true } } satisfies SendOptions)
     : await agent.send(prompt);
+  options.onRunStart?.(run);
   return collectRunResult(run, options);
 }
 
@@ -185,12 +192,13 @@ export async function sendTask(
  * signal to callers.
  */
 export async function oneShot(prompt: string, opts: OneShotOptions): Promise<CursorRunResult> {
-  const { timeoutMs, onEvent, force, ...agentOpts } = opts;
+  const { timeoutMs, onEvent, onRunStart, force, ...agentOpts } = opts;
   const agent = await createAgent(agentOpts);
   try {
     const sendOpts: SendTaskOptions = {};
     if (timeoutMs !== undefined) sendOpts.timeoutMs = timeoutMs;
     if (onEvent !== undefined) sendOpts.onEvent = onEvent;
+    if (onRunStart !== undefined) sendOpts.onRunStart = onRunStart;
     if (force !== undefined) sendOpts.force = force;
     return await sendTask(agent, prompt, sendOpts);
   } finally {

--- a/plugins/cursor/scripts/lib/git.mts
+++ b/plugins/cursor/scripts/lib/git.mts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+
+/**
+ * Run a `git` command in the given working directory and return trimmed stdout.
+ * Returns `undefined` when the process exits non-zero or git is not installed
+ * — callers can treat absent/error as "not in a repo" or "no info".
+ */
+function runGit(cwd: string, args: string[]): string | undefined {
+  try {
+    const out = execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // Only strip trailing newlines — porcelain status lines have a leading
+    // space that encodes index-vs-worktree state, so a generic .trim() loses
+    // information.
+    return out.replace(/\n+$/, "");
+  } catch {
+    return undefined;
+  }
+}
+
+export interface DiffOptions {
+  /** When true, only return staged changes (`git diff --cached`). */
+  staged?: boolean;
+  /**
+   * When set, diff against this ref (e.g. `main`). Falls back to working-tree
+   * diff when omitted. Mutually compatible with `staged`.
+   */
+  baseRef?: string;
+}
+
+/**
+ * Return the git diff for the working tree. The shape mirrors what `git diff`
+ * prints — multi-file unified diff, suitable for sending to a review agent.
+ */
+export function getDiff(cwd: string, options: DiffOptions = {}): string {
+  const args = ["diff", "--no-color"];
+  if (options.staged) args.push("--cached");
+  if (options.baseRef) args.push(options.baseRef);
+  return runGit(cwd, args) ?? "";
+}
+
+/** `git status --short` — one line per changed file. Empty string when clean. */
+export function getStatus(cwd: string): string {
+  return runGit(cwd, ["status", "--short"]) ?? "";
+}
+
+/** True when the working tree has uncommitted changes (staged or unstaged). */
+export function isDirty(cwd: string): boolean {
+  return getStatus(cwd).length > 0;
+}
+
+export interface CommitInfo {
+  hash: string;
+  subject: string;
+}
+
+/**
+ * Last `n` commits on HEAD, oldest first reversed (so most recent is first).
+ * Returns an empty array on a fresh repo with no commits.
+ */
+export function getRecentCommits(cwd: string, n: number): CommitInfo[] {
+  if (n <= 0) return [];
+  const out = runGit(cwd, ["log", `-${Math.floor(n)}`, "--pretty=format:%H%x09%s"]);
+  if (!out) return [];
+  return out
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [hash, ...rest] = line.split("\t");
+      return { hash: hash ?? "", subject: rest.join("\t") };
+    });
+}
+
+/** Current branch name, or `undefined` when HEAD is detached or not a repo. */
+export function getBranch(cwd: string): string | undefined {
+  const out = runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!out || out === "HEAD") return undefined;
+  return out;
+}
+
+/** `remote.origin.url` if set; otherwise `undefined`. */
+export function getRemoteUrl(cwd: string): string | undefined {
+  return runGit(cwd, ["config", "--get", "remote.origin.url"]) || undefined;
+}
+
+/**
+ * Files changed against HEAD (or against `baseRef` when provided). Returns
+ * one entry per file with the porcelain status code (`M`, `A`, `D`, `R`...).
+ */
+export interface ChangedFile {
+  status: string;
+  path: string;
+}
+
+export function getChangedFiles(cwd: string, options: { baseRef?: string } = {}): ChangedFile[] {
+  const args = options.baseRef
+    ? ["diff", "--name-status", options.baseRef]
+    : ["status", "--porcelain"];
+  const out = runGit(cwd, args);
+  if (!out) return [];
+  return out
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      // status --porcelain uses 2-char status; diff --name-status uses TAB
+      if (options.baseRef) {
+        const [status, ...rest] = line.split("\t");
+        return { status: status ?? "?", path: rest.join("\t") };
+      }
+      const status = line.slice(0, 2).trim() || "?";
+      const path = line.slice(3);
+      return { status, path };
+    });
+}
+
+export interface CloudRepoRef {
+  url: string;
+  startingRef?: string;
+}
+
+/**
+ * Normalize a git remote URL to the canonical `https://github.com/<owner>/<repo>`
+ * form. Returns `undefined` when the remote isn't a recognizable GitHub URL.
+ * Ported from cursor/cookbook coding-agent-cli — keeps cloud-mode startup
+ * simple by accepting the three forms developers typically have configured.
+ */
+export function normalizeGitHubRemote(remote: string): string | undefined {
+  const trimmed = remote.trim().replace(/\.git$/, "");
+  const sshMatch = trimmed.match(/^git@github\.com:(.+\/.+)$/);
+  const sshUrlMatch = trimmed.match(/^ssh:\/\/git@github\.com\/(.+\/.+)$/);
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/(.+\/.+)$/);
+  const repoPath = sshMatch?.[1] ?? sshUrlMatch?.[1] ?? httpsMatch?.[1];
+  return repoPath ? `https://github.com/${repoPath}` : undefined;
+}
+
+/**
+ * Resolve the cloud-repository descriptor used by `Agent.create({ cloud })`.
+ * Throws when `cwd` is not in a git repo with a recognizable GitHub origin —
+ * cloud mode currently only works against GitHub-hosted repos.
+ */
+export function detectCloudRepository(cwd: string): CloudRepoRef {
+  const remote = getRemoteUrl(cwd);
+  if (!remote) {
+    throw new Error(
+      "Cloud mode requires a git repository with remote.origin.url set. " +
+        "Configure a remote or run in --local mode.",
+    );
+  }
+  const url = normalizeGitHubRemote(remote);
+  if (!url) {
+    throw new Error(
+      `Cloud mode currently expects remote.origin.url to point at GitHub. Got: ${remote}`,
+    );
+  }
+  const branch = getBranch(cwd);
+  return branch ? { url, startingRef: branch } : { url };
+}

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -71,10 +71,17 @@ function upsertIndex(stateDir: string, record: JobRecord): void {
 /**
  * Create a new job in `pending` state. Returns the full record so callers
  * can pass it straight into `markRunning` once the agent run starts.
+ *
+ * `input.metadata` is shallow-copied — we never hold a reference to the
+ * caller's object so subsequent updates can't leak back into their state.
  */
 export function createJob(stateDir: string, input: CreateJobInput): JobRecord {
   const id = newJobId(input.type);
   const created = nowIso();
+  const metadata: Record<string, unknown> | undefined =
+    input.metadata || input.summary
+      ? { ...(input.metadata ?? {}), ...(input.summary ? { summary: input.summary } : {}) }
+      : undefined;
   const record: JobRecord = {
     id,
     type: input.type,
@@ -82,10 +89,8 @@ export function createJob(stateDir: string, input: CreateJobInput): JobRecord {
     prompt: input.prompt,
     createdAt: created,
     updatedAt: created,
-    ...(input.metadata ? { metadata: input.metadata } : {}),
+    ...(metadata ? { metadata } : {}),
   };
-  if (input.summary && record.metadata) record.metadata.summary = input.summary;
-  else if (input.summary) record.metadata = { summary: input.summary };
   writeJob(stateDir, record);
   upsertIndex(stateDir, record);
   return record;

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -1,0 +1,288 @@
+import crypto from "node:crypto";
+import type { Run } from "@cursor/sdk";
+
+import { type CursorRunResult, cancelRun } from "./cursor-agent.mjs";
+import {
+  appendJobLog,
+  type JobIndex,
+  type JobIndexEntry,
+  type JobRecord,
+  type JobStatus,
+  type JobType,
+  pruneJobIndex,
+  readJob,
+  readStateIndex,
+  writeJob,
+  writeStateIndex,
+} from "./state.mjs";
+
+const JOB_ID_BYTES = 6; // 12 hex chars — short, collision-resistant enough for ~50 retained jobs
+
+interface CreateJobInput {
+  type: JobType;
+  prompt: string;
+  summary?: string;
+  metadata?: Record<string, unknown>;
+}
+
+/** Generate a fresh, unique-enough job id (`<type-prefix><hex>`). */
+function newJobId(type: JobType): string {
+  const prefix = type === "adversarial-review" ? "adv" : type;
+  return `${prefix}-${crypto.randomBytes(JOB_ID_BYTES).toString("hex")}`;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function summarize(prompt: string, max = 80): string {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  return compact.length <= max ? compact : `${compact.slice(0, max - 3)}...`;
+}
+
+function indexEntry(record: JobRecord): JobIndexEntry {
+  const entry: JobIndexEntry = {
+    id: record.id,
+    type: record.type,
+    status: record.status,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  };
+  const summary =
+    record.metadata && typeof record.metadata.summary === "string"
+      ? record.metadata.summary
+      : summarize(record.prompt);
+  if (summary) entry.summary = summary;
+  return entry;
+}
+
+function upsertIndex(stateDir: string, record: JobRecord): void {
+  const idx: JobIndex = readStateIndex(stateDir);
+  const entry = indexEntry(record);
+  const i = idx.jobs.findIndex((j) => j.id === record.id);
+  if (i === -1) {
+    idx.jobs.unshift(entry);
+  } else {
+    idx.jobs[i] = entry;
+  }
+  writeStateIndex(stateDir, idx);
+}
+
+/**
+ * Create a new job in `pending` state. Returns the full record so callers
+ * can pass it straight into `markRunning` once the agent run starts.
+ */
+export function createJob(stateDir: string, input: CreateJobInput): JobRecord {
+  const id = newJobId(input.type);
+  const created = nowIso();
+  const record: JobRecord = {
+    id,
+    type: input.type,
+    status: "pending",
+    prompt: input.prompt,
+    createdAt: created,
+    updatedAt: created,
+    ...(input.metadata ? { metadata: input.metadata } : {}),
+  };
+  if (input.summary && record.metadata) record.metadata.summary = input.summary;
+  else if (input.summary) record.metadata = { summary: input.summary };
+  writeJob(stateDir, record);
+  upsertIndex(stateDir, record);
+  return record;
+}
+
+/** Read a job by id. Returns undefined when the file does not exist. */
+export function getJob(stateDir: string, jobId: string): JobRecord | undefined {
+  return readJob(stateDir, jobId);
+}
+
+export interface ListJobsFilter {
+  type?: JobType;
+  status?: JobStatus;
+  /** Cap returned entries (most recent first). */
+  limit?: number;
+}
+
+/** Read the index, optionally filtered. Sorted most-recent-first by `createdAt`. */
+export function listJobs(stateDir: string, filter: ListJobsFilter = {}): JobIndexEntry[] {
+  const idx = readStateIndex(stateDir);
+  let entries = [...idx.jobs].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  if (filter.type) entries = entries.filter((j) => j.type === filter.type);
+  if (filter.status) entries = entries.filter((j) => j.status === filter.status);
+  if (typeof filter.limit === "number" && filter.limit >= 0) {
+    entries = entries.slice(0, Math.floor(filter.limit));
+  }
+  return entries;
+}
+
+interface UpdateInput {
+  status?: JobStatus;
+  startedAt?: string;
+  finishedAt?: string;
+  durationMs?: number;
+  agentId?: string;
+  runId?: string;
+  result?: string;
+  error?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function update(stateDir: string, jobId: string, input: UpdateInput): JobRecord {
+  const existing = readJob(stateDir, jobId);
+  if (!existing) {
+    throw new Error(`job not found: ${jobId}`);
+  }
+  const next: JobRecord = {
+    ...existing,
+    ...input,
+    metadata: input.metadata
+      ? { ...(existing.metadata ?? {}), ...input.metadata }
+      : existing.metadata,
+    updatedAt: nowIso(),
+  };
+  writeJob(stateDir, next);
+  upsertIndex(stateDir, next);
+  return next;
+}
+
+/** Transition a job to `running` and stamp its agent/run identifiers. */
+export function markRunning(
+  stateDir: string,
+  jobId: string,
+  refs: { agentId: string; runId: string },
+): JobRecord {
+  return update(stateDir, jobId, {
+    status: "running",
+    startedAt: nowIso(),
+    agentId: refs.agentId,
+    runId: refs.runId,
+  });
+}
+
+/**
+ * Persist a successful run result. Maps `CursorAgentStatus` to our `JobStatus`
+ * (`finished` → `completed`, `error` → `failed`, others pass through).
+ */
+export function markFinished(stateDir: string, jobId: string, result: CursorRunResult): JobRecord {
+  let status: JobStatus;
+  let extraMetadata: Record<string, unknown> | undefined;
+  switch (result.status) {
+    case "finished":
+      status = "completed";
+      break;
+    case "error":
+      status = "failed";
+      break;
+    case "cancelled":
+      status = "cancelled";
+      break;
+    case "expired":
+      // SDK reports a wedged local run as "expired". From the plugin's view
+      // it's a non-success terminal — treat it as cancelled and tag the
+      // metadata so /cursor:status can show why.
+      status = "cancelled";
+      extraMetadata = { expired: true };
+      break;
+  }
+  const updates: UpdateInput = {
+    status,
+    finishedAt: nowIso(),
+    agentId: result.agentId,
+    runId: result.runId,
+    result: result.output,
+  };
+  if (typeof result.durationMs === "number") updates.durationMs = result.durationMs;
+  if (result.timedOut || extraMetadata) {
+    updates.metadata = { ...(result.timedOut ? { timedOut: true } : {}), ...extraMetadata };
+  }
+  return update(stateDir, jobId, updates);
+}
+
+/** Mark a job as failed, recording the error message. */
+export function markFailed(stateDir: string, jobId: string, error: string): JobRecord {
+  return update(stateDir, jobId, {
+    status: "failed",
+    finishedAt: nowIso(),
+    error,
+  });
+}
+
+/** Mark a job as cancelled (without an associated Run). */
+export function markCancelled(stateDir: string, jobId: string, reason?: string): JobRecord {
+  const updates: UpdateInput = {
+    status: "cancelled",
+    finishedAt: nowIso(),
+  };
+  if (reason) updates.metadata = { cancelReason: reason };
+  return update(stateDir, jobId, updates);
+}
+
+/* -------------------------------------------------------------------------
+ * In-memory active-run registry — scoped to a single CLI process. The Run
+ * object can't be persisted across processes, so background-job cancellation
+ * works only within the process that started the run. Cross-process cancel
+ * relies on SDK-side state (and would call `Agent.resume` to reach the run).
+ * ----------------------------------------------------------------------- */
+
+const activeRuns = new Map<string, Run>();
+
+export function registerActiveRun(jobId: string, run: Run): void {
+  activeRuns.set(jobId, run);
+}
+
+export function unregisterActiveRun(jobId: string): void {
+  activeRuns.delete(jobId);
+}
+
+export function getActiveRun(jobId: string): Run | undefined {
+  return activeRuns.get(jobId);
+}
+
+export interface CancelJobResult {
+  cancelled: boolean;
+  reason?: string;
+  job?: JobRecord;
+}
+
+/**
+ * Cancel a job by id. When an in-memory `Run` is registered, calls
+ * `cancelRun(run)` (capability-checked); otherwise marks the persisted record
+ * as cancelled with reason="run-not-active".
+ */
+export async function cancelJob(stateDir: string, jobId: string): Promise<CancelJobResult> {
+  const job = readJob(stateDir, jobId);
+  if (!job) {
+    return { cancelled: false, reason: `job not found: ${jobId}` };
+  }
+  if (job.status !== "pending" && job.status !== "running") {
+    return { cancelled: false, reason: `job is ${job.status}`, job };
+  }
+
+  const run = activeRuns.get(jobId);
+  if (!run) {
+    const updated = markCancelled(stateDir, jobId, "run-not-active");
+    return { cancelled: true, reason: "run-not-active", job: updated };
+  }
+
+  const result = await cancelRun(run);
+  if (!result.cancelled) {
+    return { cancelled: false, reason: result.reason, job };
+  }
+  const updated = markCancelled(stateDir, jobId, result.reason);
+  activeRuns.delete(jobId);
+  return { cancelled: true, ...(result.reason ? { reason: result.reason } : {}), job: updated };
+}
+
+/** Append a line to the per-job streaming log. */
+export function logJobLine(stateDir: string, jobId: string, line: string): void {
+  const text = line.endsWith("\n") ? line : `${line}\n`;
+  appendJobLog(stateDir, jobId, text);
+}
+
+/**
+ * Trim the index to keep the most recent `maxEntries`. Thin wrapper over
+ * `pruneJobIndex` for symmetry — callers don't have to import from state.mts.
+ */
+export function pruneJobs(stateDir: string, maxEntries?: number): void {
+  pruneJobIndex(stateDir, maxEntries);
+}

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -1,0 +1,293 @@
+import type { AgentEvent } from "./cursor-agent.mjs";
+import type { JobIndexEntry } from "./state.mjs";
+
+/**
+ * Format a duration in milliseconds for terminal display. Sub-second values
+ * stay in ms; everything above renders as seconds with one decimal.
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Compact whitespace for inline display: collapse runs of whitespace to a
+ * single space, trim ends. Used to keep multi-line tool args / status
+ * messages on a single annotated line.
+ */
+export function compactText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+const TOOL_SUMMARY_KEYS: Record<string, string[][]> = {
+  read: [["path", "filePath", "target_file", "absolutePath"], ["offset"], ["limit"]],
+  glob: [
+    ["pattern", "glob", "glob_pattern"],
+    ["path", "cwd", "target_directory"],
+  ],
+  grep: [["pattern", "query"], ["path"], ["glob"], ["type"]],
+  search: [["pattern", "query"], ["path"], ["glob"], ["type"]],
+  shell: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"],
+  ],
+  terminal: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"],
+  ],
+  command: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"],
+  ],
+  edit: [["path", "target_file", "file"], ["instruction"]],
+  write: [["path", "target_file", "file"], ["instruction"]],
+  patch: [["path", "target_file", "file"], ["instruction"]],
+};
+
+const TOOL_SUMMARY_FALLBACK: string[][] = [
+  ["path", "file", "target_file"],
+  ["pattern", "query", "command"],
+];
+
+function getToolSummaryKeys(toolName: string): string[][] {
+  const lower = toolName.toLowerCase();
+  for (const [needle, keys] of Object.entries(TOOL_SUMMARY_KEYS)) {
+    if (lower.includes(needle)) return keys;
+  }
+  return TOOL_SUMMARY_FALLBACK;
+}
+
+function shortenValue(value: string, maxLength = 80): string {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function formatArgValue(value: unknown): string | undefined {
+  if (typeof value === "string") return shortenValue(value.replace(/\s+/g, " ").trim());
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const items = value.slice(0, 3).map(formatArgValue).filter(Boolean) as string[];
+    return items.length > 0 ? `[${items.join(",")}]` : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * One-line summary of a tool call's args, indexed by likely-relevant keys for
+ * common tool names (read/glob/grep/shell/edit). Returns `undefined` when no
+ * summary value can be extracted — caller should fall back to just the name.
+ */
+export function summarizeToolArgs(toolName: string, args: unknown): string | undefined {
+  if (!args || typeof args !== "object") return undefined;
+  const record = args as Record<string, unknown>;
+  const groups = getToolSummaryKeys(toolName);
+  const parts: string[] = [];
+  for (const keys of groups) {
+    for (const key of keys) {
+      const value = record[key];
+      const formatted = formatArgValue(value);
+      if (formatted) {
+        parts.push(`${key}=${formatted}`);
+        break;
+      }
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : undefined;
+}
+
+export interface RenderEventOptions {
+  /** Suppress non-error status events to keep stderr quiet. Default false. */
+  quietStatus?: boolean;
+}
+
+export interface RenderedEvent {
+  /** Lines to write to stdout — typically assistant text only. */
+  stdout?: string;
+  /** Lines to write to stderr — annotations like [tool], [status]. */
+  stderr?: string;
+}
+
+/**
+ * Format an `AgentEvent` for plain-text terminal output. Mirrors the
+ * cookbook's `renderPlainEvent` but operates on our flat AgentEvent shape:
+ *
+ * - `assistant_text`  → stdout (no annotation)
+ * - `thinking`        → `[thinking] ...` on stderr (compacted)
+ * - `tool`            → `[tool] <status> <name> <args-summary>` on stderr
+ * - `status`          → `[status] <STATE> <message>` on stderr (skipped on
+ *                       FINISHED unless verbose)
+ * - `task`            → `[task] <status> <text>` on stderr
+ * - `system`          → no output (init noise)
+ */
+export function renderStreamEvent(
+  event: AgentEvent,
+  options: RenderEventOptions = {},
+): RenderedEvent {
+  switch (event.type) {
+    case "assistant_text":
+      return { stdout: event.text };
+    case "thinking": {
+      const t = compactText(event.text);
+      return t ? { stderr: `[thinking] ${t}\n` } : {};
+    }
+    case "tool": {
+      const summary = summarizeToolArgs(event.name, event.args);
+      const tail = summary ? ` ${summary}` : "";
+      return { stderr: `[tool] ${event.status} ${event.name}${tail}\n` };
+    }
+    case "status": {
+      if (options.quietStatus && event.status === "finished") return {};
+      const msg = event.message ? ` ${compactText(event.message)}` : "";
+      return { stderr: `[status] ${event.status}${msg}\n` };
+    }
+    case "task": {
+      const head = [event.status, event.text].filter((s): s is string => Boolean(s));
+      if (head.length === 0) return {};
+      return { stderr: `[task] ${compactText(head.join(" "))}\n` };
+    }
+    case "system":
+      return {};
+  }
+}
+
+export interface JobTableRow {
+  id: string;
+  type: string;
+  status: string;
+  age: string;
+  summary: string;
+}
+
+const TABLE_HEADERS: Array<keyof JobTableRow> = ["id", "type", "status", "age", "summary"];
+
+function rowsFromJobs(jobs: JobIndexEntry[], now: number): JobTableRow[] {
+  return jobs.map((job) => {
+    const created = Date.parse(job.createdAt);
+    const ageMs = Number.isFinite(created) ? now - created : 0;
+    return {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      age: formatAge(ageMs),
+      summary: job.summary ? compactText(job.summary).slice(0, 60) : "",
+    };
+  });
+}
+
+function formatAge(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "?";
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  return `${Math.floor(hr / 24)}d`;
+}
+
+/**
+ * Render a job-index list as an aligned text table. No color, no Unicode box
+ * drawing — keeps output stable in CI logs and terminals without ANSI support.
+ */
+export function renderJobTable(jobs: JobIndexEntry[], now: number = Date.now()): string {
+  if (jobs.length === 0) return "(no jobs)\n";
+  const rows = rowsFromJobs(jobs, now);
+  const widths: Record<keyof JobTableRow, number> = {
+    id: "id".length,
+    type: "type".length,
+    status: "status".length,
+    age: "age".length,
+    summary: "summary".length,
+  };
+  for (const r of rows) {
+    for (const key of TABLE_HEADERS) {
+      widths[key] = Math.max(widths[key], r[key].length);
+    }
+  }
+  const header = TABLE_HEADERS.map((k) => k.toUpperCase().padEnd(widths[k])).join("  ");
+  const separator = TABLE_HEADERS.map((k) => "-".repeat(widths[k])).join("  ");
+  const body = rows
+    .map((r) => TABLE_HEADERS.map((k) => r[k].padEnd(widths[k])).join("  "))
+    .join("\n");
+  return `${header}\n${separator}\n${body}\n`;
+}
+
+/* -------------------------------------------------------------------------
+ * Structured review rendering — used by §3.3 review subcommand.
+ * ----------------------------------------------------------------------- */
+
+export type ReviewSeverity = "critical" | "high" | "medium" | "low";
+export type ReviewVerdict = "approve" | "needs-attention";
+
+export interface ReviewFinding {
+  severity: ReviewSeverity;
+  title: string;
+  body: string;
+  file: string;
+  line_start: number;
+  line_end: number;
+  confidence: number;
+  recommendation: string;
+}
+
+export interface ReviewOutput {
+  verdict: ReviewVerdict;
+  summary: string;
+  findings: ReviewFinding[];
+  next_steps: string[];
+}
+
+const SEVERITY_ORDER: Record<ReviewSeverity, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+/**
+ * Format a structured review for terminal display. Findings sorted by
+ * severity then file. No ANSI color — callers can wrap output if they need it.
+ */
+export function renderReviewResult(review: ReviewOutput): string {
+  const lines: string[] = [];
+  lines.push(`verdict: ${review.verdict}`);
+  if (review.summary) lines.push("", review.summary);
+
+  const findings = [...review.findings].sort((a, b) => {
+    const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (sev !== 0) return sev;
+    return a.file.localeCompare(b.file);
+  });
+
+  if (findings.length === 0) {
+    lines.push("", "findings: (none)");
+  } else {
+    lines.push("", `findings: ${findings.length}`);
+    for (const f of findings) {
+      const loc =
+        f.line_start === f.line_end
+          ? `${f.file}:${f.line_start}`
+          : `${f.file}:${f.line_start}-${f.line_end}`;
+      const conf = Number.isFinite(f.confidence) ? `(confidence ${f.confidence.toFixed(2)})` : "";
+      lines.push("", `[${f.severity.toUpperCase()}] ${f.title} — ${loc} ${conf}`.trim(), f.body);
+      if (f.recommendation) {
+        lines.push(`  → ${f.recommendation}`);
+      }
+    }
+  }
+
+  if (review.next_steps.length > 0) {
+    lines.push("", "next steps:");
+    for (const step of review.next_steps) {
+      lines.push(`  - ${step}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+/** Consistent error formatting for CLI failures. */
+export function renderError(error: unknown): string {
+  if (error instanceof Error) return `error: ${error.message}\n`;
+  return `error: ${String(error)}\n`;
+}

--- a/plugins/cursor/scripts/session-lifecycle-hook.mts
+++ b/plugins/cursor/scripts/session-lifecycle-hook.mts
@@ -1,13 +1,89 @@
 #!/usr/bin/env node
-const EVENTS = ["SessionStart", "SessionEnd"];
+import { readFileSync } from "node:fs";
+import {
+  clearSession,
+  ensureStateDir,
+  readSession,
+  resolveStateDir,
+  type SessionState,
+  writeSession,
+} from "./lib/state.mjs";
+import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+
+const EVENTS = ["SessionStart", "SessionEnd"] as const;
+type LifecycleEvent = (typeof EVENTS)[number];
+
+interface SessionStartPayload {
+  session_id?: string;
+  hook_event_name?: string;
+  source?: string;
+}
+
+function readStdinSync(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function parseStdin(raw: string): SessionStartPayload {
+  if (!raw.trim()) return {};
+  try {
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object") return data as SessionStartPayload;
+  } catch {
+    // ignore malformed payloads
+  }
+  return {};
+}
+
+function handleSessionStart(): number {
+  const payload = parseStdin(readStdinSync());
+  const cwd = process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+
+  const sessionId = payload.session_id ?? `local-${Date.now()}`;
+  const session: SessionState = {
+    version: 1,
+    sessionId,
+    startedAt: new Date().toISOString(),
+    agentIds: [],
+    pluginRoot: process.env.CLAUDE_PLUGIN_ROOT,
+  };
+  writeSession(stateDir, session);
+  return 0;
+}
+
+function handleSessionEnd(): number {
+  // Reading stdin is harmless if Claude Code didn't send anything.
+  parseStdin(readStdinSync());
+  const cwd = process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const session = readSession(stateDir);
+  if (!session) return 0;
+  // Best-effort: clear the session marker. We don't dispose agents here —
+  // background tasks may still be running, and the SDK manages durable agent
+  // lifecycle on its own. A future enhancement could iterate `agentIds` and
+  // dispose any that are still attached.
+  clearSession(stateDir);
+  return 0;
+}
 
 export function main(argv: readonly string[]): number {
-  const event = argv[2];
+  const event = argv[2] as LifecycleEvent | undefined;
   if (event === undefined || !EVENTS.includes(event)) {
     console.error(`session-lifecycle-hook: expected one of ${EVENTS.join(", ")}`);
     return 2;
   }
-  return 0;
+  try {
+    return event === "SessionStart" ? handleSessionStart() : handleSessionEnd();
+  } catch {
+    // Hooks must not crash Claude Code — best-effort persistence only.
+    return 0;
+  }
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/plugins/cursor/scripts/session-lifecycle-hook.mts
+++ b/plugins/cursor/scripts/session-lifecycle-hook.mts
@@ -20,6 +20,10 @@ interface SessionStartPayload {
 }
 
 function readStdinSync(): string {
+  // readFileSync(0) blocks on a TTY waiting for input. Claude Code always
+  // pipes JSON via stdin for hooks, but a developer running the hook by hand
+  // would otherwise hang forever — guard the interactive case.
+  if (process.stdin.isTTY) return "";
   try {
     return readFileSync(0, "utf8");
   } catch {

--- a/plugins/cursor/skills/cursor-prompting/SKILL.md
+++ b/plugins/cursor/skills/cursor-prompting/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cursor-prompting
+description: How to compose effective prompts for the Cursor agent (task structure, context inclusion, structured-output contracts).
+---
+
+# Task structure
+
+A good `cursor-companion.mjs task` prompt has three parts:
+
+1. **Goal**: one sentence stating what success looks like ("the auth tests
+   pass", "the function is renamed throughout the codebase").
+2. **Constraints**: anything Cursor needs to preserve. Files to leave alone,
+   APIs that other code depends on, performance budgets, no-deps rules.
+3. **Acceptance signal**: how you (or the user) will know it worked. A
+   command to run, a test that should pass, a property that should hold.
+
+The task subcommand prepends a short system instruction and (when in a git
+repo) the current branch + last 5 commits, so you don't need to restate
+"you are a coding agent" or paste git context.
+
+# When to use `--write` vs read-only
+
+Default is **read-only**: Cursor reads, analyzes, and proposes changes in
+its response. Use this when you want to preview the work or get a design
+opinion.
+
+`--write` lets Cursor modify files. Use this when:
+- The change is mechanical (rename, codemod, format).
+- You're prepared to review the resulting `git diff` before keeping it.
+- The task is well-scoped enough that the agent won't drift.
+
+# Structured-output contracts
+
+The `review` subcommand demands strict JSON. If you need similar discipline
+in a custom prompt:
+
+- State the schema inline (TypeScript syntax is fine).
+- End with `Output ONLY a single JSON object — no prose, no markdown
+  fences.` Cursor still sometimes wraps in fences; the parser strips them.
+- Validate the parsed object before trusting any field.
+
+# What to avoid
+
+- **Vague verbs** ("improve", "clean up", "refactor as needed"). Replace
+  with a concrete goal.
+- **Pasting whole files**. Cursor has the workspace; reference paths
+  instead.
+- **Stacking unrelated tasks**. One prompt = one task. Use multiple jobs
+  if you need to.
+- **Telling Cursor what tools to use**. Let it choose its tools.

--- a/plugins/cursor/skills/cursor-rescue/SKILL.md
+++ b/plugins/cursor/skills/cursor-rescue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: cursor-rescue
+description: Delegate a hard problem or second-opinion investigation to a Cursor agent. Use when Claude Code is stuck, wants an independent implementation pass, or needs a deeper root-cause analysis.
+---
+
+# When to use
+
+- Claude Code has tried two or more reasonable approaches to a bug and is
+  guessing.
+- The user explicitly wants a second pair of hands or a different agent's
+  take ("get a second opinion", "have Cursor try this").
+- The work is well-scoped (one feature, one bug, one refactor target). For
+  unscoped exploration, drive the work yourself.
+
+# How to use
+
+Invoke the `cursor-rescue` subagent (`subagent_type: "cursor:cursor-rescue"`)
+with a single prompt. The subagent runs `cursor-companion.mjs task` and
+returns Cursor's stdout unchanged.
+
+# What to include in the prompt
+
+- The concrete deliverable ("make the integration test pass", "rename
+  `getCwd` to `getCurrentWorkingDirectory` everywhere")
+- Any constraints or files to focus on
+- Whether file modifications are wanted (`--write` is on by default in the
+  subagent's invocation)
+
+# What to avoid
+
+- Don't paste the entire codebase — Cursor has its own workspace context.
+- Don't ask for vague "improvements" — give Cursor a concrete success
+  criterion.
+- Don't stack tasks. One task per invocation.

--- a/plugins/cursor/skills/cursor-result-handling/SKILL.md
+++ b/plugins/cursor/skills/cursor-result-handling/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cursor-result-handling
+description: How to present Cursor agent output back to the user. Loaded automatically when processing results from cursor-companion.
+---
+
+# Default behavior
+
+When a Cursor task finishes (via `cursor-rescue` or `/cursor:task`):
+
+1. **Show the deliverables verbatim**. Don't paraphrase the agent's
+   summary; the user wants to see what Cursor actually said.
+2. **Surface the exit code**. If non-zero, lead with that and the reason
+   (timeout, cancelled, expired, parse error).
+3. **List file changes**. If `--write` was on, the diff lives in the
+   workspace. Run `git status` and show what was modified — don't claim
+   "Cursor edited X" without verifying.
+
+# Reviews
+
+For `/cursor:review` and `/cursor:adversarial-review`:
+
+1. Lead with the **verdict** (`approve` / `needs-attention`).
+2. Quote findings ordered by severity (critical → high → medium → low).
+3. Include `file:line` for each finding — it's the high-signal bit.
+4. Don't filter out low-severity items unless the user asked to.
+
+# Caveats to flag
+
+- **Background runs**: the CLI returns the job id immediately. Tell the user
+  to check `/cursor:status` and `/cursor:result <id>` later — don't pretend
+  the run is done.
+- **Cancelled / expired**: the job did not complete. Show whatever partial
+  log was captured.
+- **Parse failures**: when review JSON parsing fails, the CLI prints the
+  raw output. Pass it through unmodified — don't try to extract structure
+  yourself.

--- a/tests/unit/cli/companion.test.mts
+++ b/tests/unit/cli/companion.test.mts
@@ -60,16 +60,28 @@ describe("cursor-companion router", () => {
     expect(io.captured.stdout.join("")).toContain("(no jobs)");
   });
 
-  it("result with missing job id exits non-zero", async () => {
+  it("result with missing job id exits 2 (UsageError)", async () => {
     const io = captureIO(workDir);
-    expect(await companionMain(argv("result"), io)).toBe(1);
+    expect(await companionMain(argv("result"), io)).toBe(2);
     expect(io.captured.stderr.join("")).toContain("error: result requires a job id");
   });
 
-  it("cancel of a missing job exits 1", async () => {
+  it("cancel without a job id exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("cancel"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("cancel requires a job id");
+  });
+
+  it("cancel of a missing job exits 1 (runtime error, not usage)", async () => {
     const io = captureIO(workDir);
     expect(await companionMain(argv("cancel", "missing-id"), io)).toBe(1);
     expect(io.captured.stderr.join("")).toContain("could not cancel");
+  });
+
+  it("task without a prompt exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("task"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("task requires a prompt argument");
   });
 
   it("--help on a subcommand prints subcommand help and exits 0", async () => {
@@ -78,17 +90,17 @@ describe("cursor-companion router", () => {
     expect(io.captured.stdout.join("")).toContain("Delegate an implementation task");
   });
 
-  it("status rejects invalid --type with a helpful error", async () => {
+  it("status rejects invalid --type with exit 2", async () => {
     const io = captureIO(workDir);
-    expect(await companionMain(argv("status", "--type", "bogus"), io)).toBe(1);
+    expect(await companionMain(argv("status", "--type", "bogus"), io)).toBe(2);
     const err = io.captured.stderr.join("");
     expect(err).toContain("invalid --type");
     expect(err).toContain("task");
   });
 
-  it("status rejects invalid --status with a helpful error", async () => {
+  it("status rejects invalid --status with exit 2", async () => {
     const io = captureIO(workDir);
-    expect(await companionMain(argv("status", "--status", "weird"), io)).toBe(1);
+    expect(await companionMain(argv("status", "--status", "weird"), io)).toBe(2);
     expect(io.captured.stderr.join("")).toContain("invalid --status");
   });
 

--- a/tests/unit/cli/companion.test.mts
+++ b/tests/unit/cli/companion.test.mts
@@ -1,0 +1,94 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Writable } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { main as companionMain } from "../../../plugins/cursor/scripts/cursor-companion.mjs";
+
+function captureIO(cwd: string) {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const sink = (sink: string[]): NodeJS.WritableStream =>
+    new Writable({
+      write(chunk, _enc, cb) {
+        sink.push(chunk.toString());
+        cb();
+      },
+    });
+  return {
+    stdout: sink(stdout),
+    stderr: sink(stderr),
+    cwd: () => cwd,
+    env: process.env,
+    captured: { stdout, stderr },
+  };
+}
+
+let workDir: string;
+let stateDir: string;
+const argv = (...rest: string[]): string[] => ["node", "cursor-companion", ...rest];
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-cli-cwd-"));
+  stateDir = mkdtempSync(path.join(tmpdir(), "cursor-cli-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateDir;
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateDir, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+});
+
+describe("cursor-companion router", () => {
+  it("prints help and exits 0 with no args", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv(), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("cursor-companion <command>");
+  });
+
+  it("returns 2 for unknown commands", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("bogus"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("unknown command");
+  });
+
+  it("status with no jobs prints '(no jobs)'", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("(no jobs)");
+  });
+
+  it("result with missing job id exits non-zero", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("error: result requires a job id");
+  });
+
+  it("cancel of a missing job exits 1", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("cancel", "missing-id"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("could not cancel");
+  });
+
+  it("--help on a subcommand prints subcommand help and exits 0", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("task", "--help"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("Delegate an implementation task");
+  });
+
+  it("setup without API key exits 1 with diagnostic", async () => {
+    const io = captureIO(workDir);
+    const original = process.env.CURSOR_API_KEY;
+    delete process.env.CURSOR_API_KEY;
+    try {
+      const code = await companionMain(argv("setup"), io);
+      expect(code).toBe(1);
+      expect(io.captured.stdout.join("")).toContain("API key");
+      expect(io.captured.stdout.join("")).toContain("fail");
+    } finally {
+      if (original !== undefined) process.env.CURSOR_API_KEY = original;
+    }
+  });
+});

--- a/tests/unit/cli/companion.test.mts
+++ b/tests/unit/cli/companion.test.mts
@@ -78,6 +78,25 @@ describe("cursor-companion router", () => {
     expect(io.captured.stdout.join("")).toContain("Delegate an implementation task");
   });
 
+  it("status rejects invalid --type with a helpful error", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status", "--type", "bogus"), io)).toBe(1);
+    const err = io.captured.stderr.join("");
+    expect(err).toContain("invalid --type");
+    expect(err).toContain("task");
+  });
+
+  it("status rejects invalid --status with a helpful error", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status", "--status", "weird"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("invalid --status");
+  });
+
+  it("status accepts a valid --type filter", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status", "--type", "task"), io)).toBe(0);
+  });
+
   it("setup without API key exits 1 with diagnostic", async () => {
     const io = captureIO(workDir);
     const original = process.env.CURSOR_API_KEY;

--- a/tests/unit/commands/review.test.mts
+++ b/tests/unit/commands/review.test.mts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { extractJson, parseReview } from "../../../plugins/cursor/scripts/commands/review.mjs";
+
+describe("extractJson", () => {
+  it("returns the input unchanged when no fences are present", () => {
+    expect(extractJson('{"verdict":"approve"}')).toBe('{"verdict":"approve"}');
+  });
+
+  it("strips ```json fences", () => {
+    const wrapped = '```json\n{"verdict":"approve"}\n```';
+    expect(extractJson(wrapped)).toBe('{"verdict":"approve"}');
+  });
+
+  it("strips bare ``` fences", () => {
+    const wrapped = '```\n{"verdict":"approve"}\n```';
+    expect(extractJson(wrapped)).toBe('{"verdict":"approve"}');
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(extractJson('   {"x":1}   ')).toBe('{"x":1}');
+  });
+});
+
+const VALID_REVIEW = JSON.stringify({
+  verdict: "needs-attention",
+  summary: "two findings",
+  findings: [
+    {
+      severity: "high",
+      title: "uh-oh",
+      body: "...",
+      file: "src/x.ts",
+      line_start: 10,
+      line_end: 12,
+      confidence: 0.8,
+      recommendation: "fix it",
+    },
+  ],
+  next_steps: ["fix the bug"],
+});
+
+describe("parseReview", () => {
+  it("parses a valid structured review", () => {
+    const parsed = parseReview(VALID_REVIEW);
+    expect(parsed.verdict).toBe("needs-attention");
+    expect(parsed.findings).toHaveLength(1);
+    expect(parsed.next_steps).toEqual(["fix the bug"]);
+  });
+
+  it("accepts a fence-wrapped review", () => {
+    const wrapped = `\`\`\`json\n${VALID_REVIEW}\n\`\`\``;
+    expect(parseReview(wrapped).verdict).toBe("needs-attention");
+  });
+
+  it("throws on malformed JSON", () => {
+    expect(() => parseReview("not json at all")).toThrow(/not valid JSON/);
+  });
+
+  it("throws when verdict is missing or invalid", () => {
+    expect(() => parseReview('{"summary":"","findings":[],"next_steps":[]}')).toThrow(/verdict/);
+    expect(() =>
+      parseReview('{"verdict":"maybe","summary":"","findings":[],"next_steps":[]}'),
+    ).toThrow(/verdict/);
+  });
+
+  it("throws when findings is not an array", () => {
+    expect(() =>
+      parseReview('{"verdict":"approve","summary":"ok","findings":{},"next_steps":[]}'),
+    ).toThrow(/findings/);
+  });
+
+  it("throws when next_steps is not an array", () => {
+    expect(() =>
+      parseReview('{"verdict":"approve","summary":"ok","findings":[],"next_steps":"go"}'),
+    ).toThrow(/next_steps/);
+  });
+});

--- a/tests/unit/lib/args.test.mts
+++ b/tests/unit/lib/args.test.mts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bool,
+  optionalString,
+  parseArgs,
+  requireString,
+} from "../../../plugins/cursor/scripts/lib/args.mjs";
+
+describe("parseArgs", () => {
+  it("collects positionals and known boolean flags", () => {
+    const r = parseArgs(["a", "--write", "b"], { long: { write: "boolean" } });
+    expect(r.positionals).toEqual(["a", "b"]);
+    expect(r.flags.write).toBe(true);
+  });
+
+  it("supports --flag=value form", () => {
+    const r = parseArgs(["--model=gpt-5"], { long: { model: "string" } });
+    expect(r.flags.model).toBe("gpt-5");
+  });
+
+  it("supports --flag value form", () => {
+    const r = parseArgs(["--model", "gpt-5"], { long: { model: "string" } });
+    expect(r.flags.model).toBe("gpt-5");
+  });
+
+  it("supports short alias", () => {
+    const r = parseArgs(["-m", "gpt-5"], {
+      long: { model: "string" },
+      short: { m: "model" },
+    });
+    expect(r.flags.model).toBe("gpt-5");
+  });
+
+  it("treats -- as end-of-flags", () => {
+    const r = parseArgs(["--write", "--", "--not-a-flag", "x"], {
+      long: { write: "boolean" },
+    });
+    expect(r.flags.write).toBe(true);
+    expect(r.positionals).toEqual(["--not-a-flag", "x"]);
+  });
+
+  it("throws when a string flag is missing its value", () => {
+    expect(() => parseArgs(["--model"], { long: { model: "string" } })).toThrow(/--model/);
+    expect(() => parseArgs(["--model", "--other"], { long: { model: "string" } })).toThrow(
+      /--model/,
+    );
+  });
+
+  it("throws on unknown short flags (would silently swallow next token otherwise)", () => {
+    expect(() => parseArgs(["-x"], {})).toThrow(/unknown short flag/);
+  });
+
+  it("records unknown long flags as boolean by default", () => {
+    const r = parseArgs(["--frob"], {});
+    expect(r.flags.frob).toBe(true);
+  });
+
+  it("--flag=false unsets a boolean flag", () => {
+    const r = parseArgs(["--write=false"], { long: { write: "boolean" } });
+    expect(r.flags.write).toBeUndefined();
+  });
+});
+
+describe("flag accessors", () => {
+  it("requireString throws when missing", () => {
+    expect(() => requireString({ positionals: [], flags: {} }, "model")).toThrow(/--model/);
+  });
+
+  it("optionalString returns undefined when missing", () => {
+    expect(optionalString({ positionals: [], flags: { model: true } }, "model")).toBeUndefined();
+    expect(optionalString({ positionals: [], flags: { model: "x" } }, "model")).toBe("x");
+  });
+
+  it("bool returns true only when explicitly set", () => {
+    expect(bool({ positionals: [], flags: {} }, "write")).toBe(false);
+    expect(bool({ positionals: [], flags: { write: true } }, "write")).toBe(true);
+    expect(bool({ positionals: [], flags: { write: "x" } }, "write")).toBe(false);
+  });
+});

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -32,7 +32,10 @@ vi.mock("@cursor/sdk", async () => {
 });
 
 import {
+  buildPrompt,
+  cancelRun,
   createAgent,
+  DEFAULT_AGENT_INSTRUCTIONS,
   DEFAULT_MODEL,
   disposeAgent,
   listModels,
@@ -41,6 +44,7 @@ import {
   resolveApiKey,
   resumeAgent,
   sendTask,
+  toAgentEvents,
   validateModel,
   whoami,
 } from "../../../plugins/cursor/scripts/lib/cursor-agent.mjs";
@@ -472,5 +476,127 @@ describe("Cursor account helpers", () => {
   it("validateModel throws ConfigurationError for an unknown model", async () => {
     sdkMocks.modelsList.mockResolvedValue([{ id: "composer-2", displayName: "Composer 2" }]);
     await expect(validateModel({ id: "imaginary" })).rejects.toThrow(/imaginary/);
+  });
+});
+
+describe("buildPrompt", () => {
+  it("wraps a user prompt with the default instructions", () => {
+    const out = buildPrompt("ship it");
+    expect(out.startsWith(DEFAULT_AGENT_INSTRUCTIONS)).toBe(true);
+    expect(out.endsWith("User task:\nship it")).toBe(true);
+  });
+
+  it("honors a custom instructions override", () => {
+    expect(buildPrompt("hi", "custom rules")).toBe("custom rules\n\nUser task:\nhi");
+  });
+});
+
+describe("toAgentEvents", () => {
+  it("emits one event per text/tool_use block from an assistant message", () => {
+    const events = toAgentEvents({
+      type: "assistant",
+      agent_id: "a",
+      run_id: "r",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "tool_use", id: "u1", name: "edit", input: { path: "x" } },
+        ],
+      },
+    });
+    expect(events).toEqual([
+      { type: "assistant_text", text: "hello" },
+      { type: "tool", callId: "u1", name: "edit", status: "requested", args: { path: "x" } },
+    ]);
+  });
+
+  it("normalizes status messages into lowercase enum", () => {
+    const [event] = toAgentEvents({
+      type: "status",
+      agent_id: "a",
+      run_id: "r",
+      status: "FINISHED",
+      message: "done",
+    });
+    expect(event).toEqual({ type: "status", status: "finished", message: "done" });
+  });
+
+  it("drops unknown event types", () => {
+    expect(
+      toAgentEvents({
+        type: "user",
+        agent_id: "a",
+        run_id: "r",
+        message: { role: "user", content: [] },
+      }),
+    ).toEqual([]);
+    expect(
+      toAgentEvents({ type: "request", agent_id: "a", run_id: "r", request_id: "rq" }),
+    ).toEqual([]);
+  });
+});
+
+describe("cancelRun", () => {
+  it("returns cancelled=false with the SDK reason when the run does not support cancel", async () => {
+    const run = {
+      supports: (op: string) => op !== "cancel",
+      unsupportedReason: () => "completed runs cannot be cancelled",
+      cancel: vi.fn(),
+    } as unknown as Parameters<typeof cancelRun>[0];
+
+    const result = await cancelRun(run);
+    expect(result).toEqual({ cancelled: false, reason: "completed runs cannot be cancelled" });
+  });
+
+  it("calls run.cancel() when supported", async () => {
+    const cancel = vi.fn(async () => undefined);
+    const run = {
+      supports: () => true,
+      unsupportedReason: () => undefined,
+      cancel,
+    } as unknown as Parameters<typeof cancelRun>[0];
+
+    expect(await cancelRun(run)).toEqual({ cancelled: true });
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("cloud mode", () => {
+  it("createAgent forwards cloud.repos when mode='cloud' is set", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+
+    await createAgent({
+      cwd: "/tmp/repo",
+      mode: "cloud",
+      cloudRepo: { url: "https://github.com/example/repo", startingRef: "main" },
+    });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.cloud).toEqual({
+      repos: [{ url: "https://github.com/example/repo", startingRef: "main" }],
+    });
+    expect(call?.local).toBeUndefined();
+  });
+
+  it("createAgent throws when mode='cloud' is set without a cloudRepo", async () => {
+    await expect(createAgent({ cwd: "/tmp/repo", mode: "cloud" })).rejects.toThrow(/cloudRepo/);
+  });
+});
+
+describe("sendTask force flag", () => {
+  it("passes local.force=true to agent.send when options.force is set", async () => {
+    const run = makeRun([], { id: "r-force", status: "finished" });
+    const agent = fakeAgent(run);
+    await sendTask(agent, "go", { force: true });
+    expect(agent.send).toHaveBeenCalledWith("go", { local: { force: true } });
+  });
+
+  it("omits options when force is not set", async () => {
+    const run = makeRun([], { id: "r-noforce", status: "finished" });
+    const agent = fakeAgent(run);
+    await sendTask(agent, "go");
+    expect(agent.send).toHaveBeenCalledWith("go");
   });
 });

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -585,6 +585,35 @@ describe("cloud mode", () => {
   });
 });
 
+describe("sendTask onRunStart", () => {
+  it("fires once with the live Run before streaming begins", async () => {
+    const events: SDKMessage[] = [
+      {
+        type: "assistant",
+        agent_id: "agent-test",
+        run_id: "run-onstart",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      },
+    ];
+    const run = makeRun(events, { id: "run-onstart", status: "finished" });
+    const agent = fakeAgent(run);
+    const observed: string[] = [];
+    let observedRunId: string | undefined;
+
+    await sendTask(agent, "go", {
+      onRunStart: (r) => {
+        observedRunId = r.id;
+        observed.push("start");
+      },
+      onEvent: () => observed.push("event"),
+    });
+
+    expect(observedRunId).toBe("run-onstart");
+    expect(observed[0]).toBe("start");
+    expect(observed.includes("event")).toBe(true);
+  });
+});
+
 describe("sendTask force flag", () => {
   it("passes local.force=true to agent.send when options.force is set", async () => {
     const run = makeRun([], { id: "r-force", status: "finished" });

--- a/tests/unit/lib/git.test.mts
+++ b/tests/unit/lib/git.test.mts
@@ -1,0 +1,184 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  detectCloudRepository,
+  getBranch,
+  getChangedFiles,
+  getDiff,
+  getRecentCommits,
+  getRemoteUrl,
+  getStatus,
+  isDirty,
+  normalizeGitHubRemote,
+} from "../../../plugins/cursor/scripts/lib/git.mjs";
+
+function git(cwd: string, args: string[]): void {
+  execFileSync("git", ["-C", cwd, ...args], { stdio: "ignore" });
+}
+
+function makeRepo(): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "cursor-git-test-"));
+  git(dir, ["init", "-q", "-b", "main"]);
+  git(dir, ["config", "user.email", "test@example.com"]);
+  git(dir, ["config", "user.name", "Test"]);
+  git(dir, ["config", "commit.gpgsign", "false"]);
+  return dir;
+}
+
+describe("normalizeGitHubRemote", () => {
+  it("accepts SSH form", () => {
+    expect(normalizeGitHubRemote("git@github.com:foo/bar.git")).toBe("https://github.com/foo/bar");
+  });
+
+  it("accepts ssh:// form", () => {
+    expect(normalizeGitHubRemote("ssh://git@github.com/foo/bar.git")).toBe(
+      "https://github.com/foo/bar",
+    );
+  });
+
+  it("accepts https form and strips .git", () => {
+    expect(normalizeGitHubRemote("https://github.com/foo/bar.git")).toBe(
+      "https://github.com/foo/bar",
+    );
+  });
+
+  it("returns undefined for non-GitHub remotes", () => {
+    expect(normalizeGitHubRemote("https://gitlab.com/foo/bar")).toBeUndefined();
+    expect(normalizeGitHubRemote("git@bitbucket.org:foo/bar.git")).toBeUndefined();
+  });
+});
+
+describe("git helpers (in a real temp repo)", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("getBranch returns the current branch on a fresh repo with one commit", () => {
+    writeFileSync(path.join(repo, "a.txt"), "hello\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    expect(getBranch(repo)).toBe("main");
+  });
+
+  it("getRemoteUrl returns origin when set, undefined when absent", () => {
+    expect(getRemoteUrl(repo)).toBeUndefined();
+    git(repo, ["remote", "add", "origin", "git@github.com:foo/bar.git"]);
+    expect(getRemoteUrl(repo)).toBe("git@github.com:foo/bar.git");
+  });
+
+  it("getStatus and isDirty reflect uncommitted changes", () => {
+    writeFileSync(path.join(repo, "a.txt"), "x\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    expect(isDirty(repo)).toBe(false);
+    writeFileSync(path.join(repo, "a.txt"), "modified\n");
+    expect(isDirty(repo)).toBe(true);
+    expect(getStatus(repo)).toContain("a.txt");
+  });
+
+  it("getDiff returns the working-tree diff", () => {
+    writeFileSync(path.join(repo, "a.txt"), "one\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    writeFileSync(path.join(repo, "a.txt"), "two\n");
+    const diff = getDiff(repo);
+    expect(diff).toContain("a.txt");
+    expect(diff).toContain("-one");
+    expect(diff).toContain("+two");
+  });
+
+  it("getDiff with staged=true only includes staged changes", () => {
+    writeFileSync(path.join(repo, "a.txt"), "one\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    writeFileSync(path.join(repo, "a.txt"), "two\n");
+    git(repo, ["add", "a.txt"]);
+    writeFileSync(path.join(repo, "a.txt"), "three\n");
+    const staged = getDiff(repo, { staged: true });
+    expect(staged).toContain("+two");
+    expect(staged).not.toContain("+three");
+  });
+
+  it("getRecentCommits returns hash + subject pairs", () => {
+    writeFileSync(path.join(repo, "a.txt"), "x\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "first commit"]);
+    writeFileSync(path.join(repo, "b.txt"), "y\n");
+    git(repo, ["add", "b.txt"]);
+    git(repo, ["commit", "-q", "-m", "second commit"]);
+
+    const commits = getRecentCommits(repo, 5);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]?.subject).toBe("second commit");
+    expect(commits[1]?.subject).toBe("first commit");
+    expect(commits[0]?.hash).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("getChangedFiles returns porcelain status when no baseRef given", () => {
+    writeFileSync(path.join(repo, "a.txt"), "x\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    writeFileSync(path.join(repo, "a.txt"), "modified\n");
+    writeFileSync(path.join(repo, "b.txt"), "new\n");
+    const files = getChangedFiles(repo);
+    const paths = files.map((f) => f.path);
+    expect(paths).toContain("a.txt");
+    expect(paths).toContain("b.txt");
+    const aFile = files.find((f) => f.path === "a.txt");
+    const bFile = files.find((f) => f.path === "b.txt");
+    expect(aFile?.status).toBe("M");
+    expect(bFile?.status).toBe("??");
+  });
+
+  it("detectCloudRepository succeeds when origin points at GitHub", () => {
+    writeFileSync(path.join(repo, "a.txt"), "x\n");
+    git(repo, ["add", "a.txt"]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    git(repo, ["remote", "add", "origin", "git@github.com:foo/bar.git"]);
+    expect(detectCloudRepository(repo)).toEqual({
+      url: "https://github.com/foo/bar",
+      startingRef: "main",
+    });
+  });
+
+  it("detectCloudRepository throws when there is no origin", () => {
+    expect(() => detectCloudRepository(repo)).toThrow(/remote\.origin\.url/);
+  });
+
+  it("detectCloudRepository throws on non-GitHub origins", () => {
+    git(repo, ["remote", "add", "origin", "https://gitlab.com/foo/bar"]);
+    expect(() => detectCloudRepository(repo)).toThrow(/GitHub/);
+  });
+});
+
+describe("git helpers in a non-git directory", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "cursor-non-git-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("getDiff/getStatus/getBranch/getRemoteUrl all return empty/undefined", () => {
+    expect(getDiff(dir)).toBe("");
+    expect(getStatus(dir)).toBe("");
+    expect(getBranch(dir)).toBeUndefined();
+    expect(getRemoteUrl(dir)).toBeUndefined();
+    expect(isDirty(dir)).toBe(false);
+    expect(getRecentCommits(dir, 5)).toEqual([]);
+    expect(getChangedFiles(dir)).toEqual([]);
+  });
+});

--- a/tests/unit/lib/job-control.test.mts
+++ b/tests/unit/lib/job-control.test.mts
@@ -47,6 +47,18 @@ describe("createJob / getJob / listJobs", () => {
     expect(job.id.startsWith("adv-")).toBe(true);
   });
 
+  it("does not mutate the caller's metadata object when summary is also passed", () => {
+    const callerMetadata = { tag: "regression" };
+    const job = createJob(stateDir, {
+      type: "task",
+      prompt: "x",
+      summary: "explicit summary",
+      metadata: callerMetadata,
+    });
+    expect(callerMetadata).toEqual({ tag: "regression" });
+    expect(job.metadata).toEqual({ tag: "regression", summary: "explicit summary" });
+  });
+
   it("filters by type and status, and respects limit", () => {
     createJob(stateDir, { type: "task", prompt: "a" });
     const r = createJob(stateDir, { type: "review", prompt: "b" });

--- a/tests/unit/lib/job-control.test.mts
+++ b/tests/unit/lib/job-control.test.mts
@@ -1,0 +1,190 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CursorRunResult } from "../../../plugins/cursor/scripts/lib/cursor-agent.mjs";
+import {
+  cancelJob,
+  createJob,
+  getActiveRun,
+  getJob,
+  listJobs,
+  logJobLine,
+  markFailed,
+  markFinished,
+  markRunning,
+  registerActiveRun,
+  unregisterActiveRun,
+} from "../../../plugins/cursor/scripts/lib/job-control.mjs";
+import { readJobLog } from "../../../plugins/cursor/scripts/lib/state.mjs";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(path.join(tmpdir(), "cursor-jobctl-"));
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("createJob / getJob / listJobs", () => {
+  it("creates a pending job, persists it, and exposes it via list", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "do thing" });
+    expect(job.status).toBe("pending");
+    expect(job.id.startsWith("task-")).toBe(true);
+    const fetched = getJob(stateDir, job.id);
+    expect(fetched?.id).toBe(job.id);
+    const listed = listJobs(stateDir);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.id).toBe(job.id);
+    expect(listed[0]?.summary).toBe("do thing");
+  });
+
+  it("uses an 'adv-' prefix for adversarial-review jobs", () => {
+    const job = createJob(stateDir, { type: "adversarial-review", prompt: "challenge" });
+    expect(job.id.startsWith("adv-")).toBe(true);
+  });
+
+  it("filters by type and status, and respects limit", () => {
+    createJob(stateDir, { type: "task", prompt: "a" });
+    const r = createJob(stateDir, { type: "review", prompt: "b" });
+    createJob(stateDir, { type: "task", prompt: "c" });
+
+    expect(listJobs(stateDir, { type: "review" })).toHaveLength(1);
+    expect(listJobs(stateDir, { status: "pending" })).toHaveLength(3);
+    expect(listJobs(stateDir, { limit: 1 })).toHaveLength(1);
+
+    markFinished(stateDir, r.id, fakeResult({ status: "finished" }));
+    expect(listJobs(stateDir, { status: "completed" })).toHaveLength(1);
+  });
+});
+
+describe("state transitions", () => {
+  it("markRunning stamps agent/run ids and startedAt", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    const after = markRunning(stateDir, job.id, { agentId: "a-1", runId: "r-1" });
+    expect(after.status).toBe("running");
+    expect(after.agentId).toBe("a-1");
+    expect(after.runId).toBe("r-1");
+    expect(after.startedAt).toBeDefined();
+  });
+
+  it("markFinished maps CursorAgentStatus to JobStatus", () => {
+    const j1 = createJob(stateDir, { type: "task", prompt: "1" });
+    expect(markFinished(stateDir, j1.id, fakeResult({ status: "finished" })).status).toBe(
+      "completed",
+    );
+
+    const j2 = createJob(stateDir, { type: "task", prompt: "2" });
+    expect(markFinished(stateDir, j2.id, fakeResult({ status: "error" })).status).toBe("failed");
+
+    const j3 = createJob(stateDir, { type: "task", prompt: "3" });
+    expect(markFinished(stateDir, j3.id, fakeResult({ status: "cancelled" })).status).toBe(
+      "cancelled",
+    );
+
+    const j4 = createJob(stateDir, { type: "task", prompt: "4" });
+    const expired = markFinished(stateDir, j4.id, fakeResult({ status: "expired" }));
+    expect(expired.status).toBe("cancelled");
+    expect(expired.metadata?.expired).toBe(true);
+  });
+
+  it("markFinished records timedOut metadata", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "to" });
+    const after = markFinished(
+      stateDir,
+      job.id,
+      fakeResult({ status: "cancelled", timedOut: true }),
+    );
+    expect(after.metadata?.timedOut).toBe(true);
+  });
+
+  it("markFailed records the error message", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "broken" });
+    const after = markFailed(stateDir, job.id, "boom");
+    expect(after.status).toBe("failed");
+    expect(after.error).toBe("boom");
+  });
+
+  it("update of a missing id throws", () => {
+    expect(() => markFailed(stateDir, "missing-job", "x")).toThrow(/job not found/);
+  });
+});
+
+describe("cancelJob", () => {
+  it("returns cancelled=false with a reason when the job does not exist", async () => {
+    const r = await cancelJob(stateDir, "missing-job");
+    expect(r.cancelled).toBe(false);
+    expect(r.reason).toMatch(/not found/);
+  });
+
+  it("returns cancelled=false when the job is already terminal", async () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    markFinished(stateDir, job.id, fakeResult({ status: "finished" }));
+    const r = await cancelJob(stateDir, job.id);
+    expect(r.cancelled).toBe(false);
+    expect(r.reason).toMatch(/completed/);
+  });
+
+  it("marks pending+no-active-run as cancelled with run-not-active", async () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    const r = await cancelJob(stateDir, job.id);
+    expect(r.cancelled).toBe(true);
+    expect(r.reason).toBe("run-not-active");
+    expect(r.job?.status).toBe("cancelled");
+  });
+
+  it("calls run.cancel() when an active run is registered", async () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    markRunning(stateDir, job.id, { agentId: "a", runId: "r" });
+    const cancel = vi.fn(async () => undefined);
+    registerActiveRun(job.id, {
+      supports: () => true,
+      unsupportedReason: () => undefined,
+      cancel,
+    } as unknown as Parameters<typeof registerActiveRun>[1]);
+
+    const r = await cancelJob(stateDir, job.id);
+    expect(cancel).toHaveBeenCalled();
+    expect(r.cancelled).toBe(true);
+    expect(r.job?.status).toBe("cancelled");
+    expect(getActiveRun(job.id)).toBeUndefined();
+  });
+
+  it("propagates the SDK reason when the run cannot be cancelled", async () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    markRunning(stateDir, job.id, { agentId: "a", runId: "r" });
+    registerActiveRun(job.id, {
+      supports: () => false,
+      unsupportedReason: () => "already finished",
+      cancel: vi.fn(),
+    } as unknown as Parameters<typeof registerActiveRun>[1]);
+
+    const r = await cancelJob(stateDir, job.id);
+    expect(r.cancelled).toBe(false);
+    expect(r.reason).toBe("already finished");
+    unregisterActiveRun(job.id);
+  });
+});
+
+describe("logJobLine", () => {
+  it("appends to the job log file with a trailing newline", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    logJobLine(stateDir, job.id, "hello");
+    logJobLine(stateDir, job.id, "world\n");
+    expect(readJobLog(stateDir, job.id)).toBe("hello\nworld\n");
+  });
+});
+
+function fakeResult(overrides: Partial<CursorRunResult>): CursorRunResult {
+  return {
+    status: "finished",
+    output: "ok",
+    toolCalls: [],
+    agentId: "a",
+    runId: "r",
+    ...overrides,
+  };
+}

--- a/tests/unit/lib/render.test.mts
+++ b/tests/unit/lib/render.test.mts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentEvent } from "../../../plugins/cursor/scripts/lib/cursor-agent.mjs";
+import {
+  compactText,
+  formatDuration,
+  type ReviewOutput,
+  renderError,
+  renderJobTable,
+  renderReviewResult,
+  renderStreamEvent,
+  summarizeToolArgs,
+} from "../../../plugins/cursor/scripts/lib/render.mjs";
+import type { JobIndexEntry } from "../../../plugins/cursor/scripts/lib/state.mjs";
+
+describe("formatDuration", () => {
+  it("renders sub-second values in ms", () => {
+    expect(formatDuration(0)).toBe("0ms");
+    expect(formatDuration(42)).toBe("42ms");
+    expect(formatDuration(999)).toBe("999ms");
+  });
+
+  it("renders >=1s in tenths-of-a-second", () => {
+    expect(formatDuration(1000)).toBe("1.0s");
+    expect(formatDuration(1500)).toBe("1.5s");
+    expect(formatDuration(60000)).toBe("60.0s");
+  });
+
+  it("guards bad input", () => {
+    expect(formatDuration(Number.NaN)).toBe("0ms");
+    expect(formatDuration(-5)).toBe("0ms");
+  });
+});
+
+describe("compactText", () => {
+  it("collapses whitespace and trims", () => {
+    expect(compactText("  hello\n   world  ")).toBe("hello world");
+    expect(compactText("a\t\tb")).toBe("a b");
+  });
+});
+
+describe("summarizeToolArgs", () => {
+  it("picks path/offset/limit for read tools", () => {
+    expect(summarizeToolArgs("read_file", { path: "/x/y", offset: 10, limit: 20 })).toBe(
+      "path=/x/y offset=10 limit=20",
+    );
+  });
+
+  it("picks pattern + path for grep tools", () => {
+    expect(summarizeToolArgs("grep_text", { pattern: "foo", path: "src/" })).toBe(
+      "pattern=foo path=src/",
+    );
+  });
+
+  it("picks command for shell tools", () => {
+    expect(summarizeToolArgs("run_shell", { command: "ls -la" })).toBe("command=ls -la");
+  });
+
+  it("falls back to common keys for unknown tool names", () => {
+    expect(summarizeToolArgs("xyz_unknown", { path: "p" })).toBe("path=p");
+  });
+
+  it("returns undefined when no relevant keys present", () => {
+    expect(summarizeToolArgs("read_file", {})).toBeUndefined();
+    expect(summarizeToolArgs("read_file", null)).toBeUndefined();
+    expect(summarizeToolArgs("read_file", "string")).toBeUndefined();
+  });
+
+  it("shortens overlong string values", () => {
+    const long = "x".repeat(200);
+    const out = summarizeToolArgs("shell", { command: long }) ?? "";
+    expect(out.length).toBeLessThanOrEqual("command=".length + 80);
+    expect(out.endsWith("...")).toBe(true);
+  });
+});
+
+describe("renderStreamEvent", () => {
+  it("forwards assistant_text to stdout", () => {
+    const e: AgentEvent = { type: "assistant_text", text: "hi" };
+    expect(renderStreamEvent(e)).toEqual({ stdout: "hi" });
+  });
+
+  it("annotates tool events with status, name, and arg summary", () => {
+    const e: AgentEvent = {
+      type: "tool",
+      callId: "c",
+      name: "read_file",
+      status: "completed",
+      args: { path: "/a" },
+    };
+    expect(renderStreamEvent(e)).toEqual({
+      stderr: "[tool] completed read_file path=/a\n",
+    });
+  });
+
+  it("renders status events; can suppress 'finished' via quietStatus", () => {
+    const e: AgentEvent = { type: "status", status: "finished" };
+    expect(renderStreamEvent(e)).toEqual({ stderr: "[status] finished\n" });
+    expect(renderStreamEvent(e, { quietStatus: true })).toEqual({});
+  });
+
+  it("compacts thinking text and skips empty messages", () => {
+    expect(renderStreamEvent({ type: "thinking", text: "  multi\nline " })).toEqual({
+      stderr: "[thinking] multi line\n",
+    });
+    expect(renderStreamEvent({ type: "thinking", text: "  \n  " })).toEqual({});
+  });
+
+  it("renders task events with status and text", () => {
+    expect(renderStreamEvent({ type: "task", status: "started", text: "doing x" })).toEqual({
+      stderr: "[task] started doing x\n",
+    });
+  });
+
+  it("system events produce no output", () => {
+    expect(renderStreamEvent({ type: "system" })).toEqual({});
+  });
+});
+
+describe("renderJobTable", () => {
+  it("returns a hint when there are no jobs", () => {
+    expect(renderJobTable([])).toBe("(no jobs)\n");
+  });
+
+  it("renders aligned columns with derived ages", () => {
+    const now = new Date("2026-04-29T12:00:00Z").getTime();
+    const jobs: JobIndexEntry[] = [
+      {
+        id: "abc123",
+        type: "task",
+        status: "completed",
+        createdAt: new Date(now - 30_000).toISOString(),
+        updatedAt: new Date(now - 30_000).toISOString(),
+        summary: "hello",
+      },
+      {
+        id: "def456",
+        type: "review",
+        status: "running",
+        createdAt: new Date(now - 3_600_000).toISOString(),
+        updatedAt: new Date(now - 3_600_000).toISOString(),
+      },
+    ];
+    const out = renderJobTable(jobs, now);
+    expect(out).toContain("ID");
+    expect(out).toContain("STATUS");
+    expect(out).toContain("abc123");
+    expect(out).toContain("30s");
+    expect(out).toContain("1h");
+  });
+});
+
+describe("renderReviewResult", () => {
+  it("renders verdict, summary, sorted findings, and next steps", () => {
+    const review: ReviewOutput = {
+      verdict: "needs-attention",
+      summary: "Two issues found.",
+      findings: [
+        {
+          severity: "low",
+          title: "naming nit",
+          body: "rename foo to bar",
+          file: "src/foo.ts",
+          line_start: 10,
+          line_end: 10,
+          confidence: 0.4,
+          recommendation: "rename",
+        },
+        {
+          severity: "critical",
+          title: "auth bypass",
+          body: "missing check",
+          file: "src/auth.ts",
+          line_start: 1,
+          line_end: 4,
+          confidence: 0.95,
+          recommendation: "add guard",
+        },
+      ],
+      next_steps: ["fix auth", "rename foo"],
+    };
+    const out = renderReviewResult(review);
+    expect(out).toContain("verdict: needs-attention");
+    expect(out).toContain("findings: 2");
+    expect(out.indexOf("[CRITICAL]")).toBeLessThan(out.indexOf("[LOW]"));
+    expect(out).toContain("src/auth.ts:1-4");
+    expect(out).toContain("src/foo.ts:10");
+    expect(out).toContain("→ add guard");
+    expect(out).toContain("- fix auth");
+  });
+
+  it("handles empty findings cleanly", () => {
+    const out = renderReviewResult({
+      verdict: "approve",
+      summary: "looks good",
+      findings: [],
+      next_steps: [],
+    });
+    expect(out).toContain("findings: (none)");
+  });
+});
+
+describe("renderError", () => {
+  it("uses the message of an Error", () => {
+    expect(renderError(new Error("boom"))).toBe("error: boom\n");
+  });
+
+  it("falls back to String() for non-Errors", () => {
+    expect(renderError("plain")).toBe("error: plain\n");
+    expect(renderError(42)).toBe("error: 42\n");
+  });
+});

--- a/tests/unit/lifecycle-hook.test.mts
+++ b/tests/unit/lifecycle-hook.test.mts
@@ -1,0 +1,63 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveStateDir } from "../../plugins/cursor/scripts/lib/state.mjs";
+import { resolveWorkspaceRoot } from "../../plugins/cursor/scripts/lib/workspace.mjs";
+
+let stateRoot: string;
+let prevCwd: string;
+let workDir: string;
+
+beforeEach(() => {
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-hook-state-"));
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-hook-cwd-"));
+  prevCwd = process.cwd();
+  process.chdir(workDir);
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+});
+
+afterEach(() => {
+  process.chdir(prevCwd);
+  rmSync(stateRoot, { recursive: true, force: true });
+  rmSync(workDir, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+});
+
+describe("session-lifecycle-hook (vitest re-import)", () => {
+  it("returns 2 for an unknown event", async () => {
+    // Re-import per-test so each gets a fresh module (the env var is read at call time anyway).
+    const { main } = await import("../../plugins/cursor/scripts/session-lifecycle-hook.mjs");
+    expect(main(["node", "hook"])).toBe(2);
+    expect(main(["node", "hook", "Unknown"])).toBe(2);
+  });
+
+  it("SessionStart writes a session.json with the parsed session id", async () => {
+    const { main } = await import("../../plugins/cursor/scripts/session-lifecycle-hook.mjs");
+    expect(main(["node", "hook", "SessionEnd"])).toBe(0);
+
+    // We can't pipe stdin into main() easily, so for SessionStart we just
+    // verify it returns 0 and writes the session file. Without a stdin
+    // payload, sessionId falls back to "local-<ts>".
+    expect(main(["node", "hook", "SessionStart"])).toBe(0);
+
+    const stateDir = resolveStateDir(resolveWorkspaceRoot(workDir));
+    const sessionPath = path.join(stateDir, "session.json");
+    const data = JSON.parse(readFileSync(sessionPath, "utf8"));
+    expect(data.version).toBe(1);
+    expect(typeof data.sessionId).toBe("string");
+    expect(data.startedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(Array.isArray(data.agentIds)).toBe(true);
+  });
+
+  it("SessionEnd clears the session file", async () => {
+    const { main } = await import("../../plugins/cursor/scripts/session-lifecycle-hook.mjs");
+    expect(main(["node", "hook", "SessionStart"])).toBe(0);
+    expect(main(["node", "hook", "SessionEnd"])).toBe(0);
+
+    const stateDir = resolveStateDir(resolveWorkspaceRoot(workDir));
+    const sessionPath = path.join(stateDir, "session.json");
+    expect(() => readFileSync(sessionPath)).toThrow();
+  });
+});

--- a/tests/unit/scaffold.test.mts
+++ b/tests/unit/scaffold.test.mts
@@ -1,33 +1,45 @@
-import { describe, expect, it, vi } from "vitest";
+import { Writable } from "node:stream";
+import { describe, expect, it } from "vitest";
+
 import { main as companionMain } from "../../plugins/cursor/scripts/cursor-companion.mjs";
 import { main as hookMain } from "../../plugins/cursor/scripts/session-lifecycle-hook.mjs";
 
+function captureIO() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const sink = (sink: string[]): NodeJS.WritableStream =>
+    new Writable({
+      write(chunk, _enc, cb) {
+        sink.push(chunk.toString());
+        cb();
+      },
+    });
+  return {
+    stdout: sink(stdout),
+    stderr: sink(stderr),
+    cwd: () => process.cwd(),
+    env: process.env,
+    captured: { stdout, stderr },
+  };
+}
+
 describe("cursor-companion CLI", () => {
-  it("prints usage and exits 0 with no args", () => {
-    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    expect(companionMain(["node", "cursor-companion"])).toBe(0);
-    expect(log).toHaveBeenCalled();
-    log.mockRestore();
+  it("prints usage and exits 0 with no args", async () => {
+    const io = captureIO();
+    expect(await companionMain(["node", "cursor-companion"], io)).toBe(0);
+    expect(io.captured.stdout.join("")).toMatch(/cursor-companion <command>/);
   });
 
-  it("returns 2 for an unknown command", () => {
-    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    expect(companionMain(["node", "cursor-companion", "bogus"])).toBe(2);
-    err.mockRestore();
-  });
-
-  it("returns 1 for a known command (not implemented yet)", () => {
-    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    expect(companionMain(["node", "cursor-companion", "task"])).toBe(1);
-    err.mockRestore();
+  it("returns 2 for an unknown command", async () => {
+    const io = captureIO();
+    expect(await companionMain(["node", "cursor-companion", "bogus"], io)).toBe(2);
+    expect(io.captured.stderr.join("")).toMatch(/unknown command/);
   });
 });
 
 describe("session-lifecycle-hook", () => {
   it("returns 2 when no event is passed", () => {
-    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(hookMain(["node", "hook"])).toBe(2);
-    err.mockRestore();
   });
 
   it("returns 0 for SessionStart and SessionEnd", () => {


### PR DESCRIPTION
## Summary

Implements PLAN.md Phases 2 (lib follow-ons) → 3 (CLI subcommands) → 4 (plugin wiring) → 5 (tests). Phases 6 (review-gate v2) and 7 (CI/publish) intentionally skipped — they're explicitly v2/polish work.

Cookbook patterns absorbed from [cursor/cookbook coding-agent-cli](https://github.com/cursor/cookbook/tree/main/sdk/coding-agent-cli) where useful: SDKMessage event mapping, model picker dedupe, tool-arg summarizer, capability-checked cancel, GitHub remote normalization. Bun/OpenTUI/TUI scaffolding ignored — we're a Node-ESM plugin backend, not a standalone interactive CLI.

## What's in here

| Commit | Phase | Files |
|--------|-------|-------|
| `9537674` | 2.1 follow-ons | `cursor-agent.mts` — cloud mode, force, capability cancel, `buildPrompt`, `toAgentEvents` |
| `f2f075a` | 2.5 | `lib/git.mts` — diff/status/branch/remote + `detectCloudRepository` (GitHub) |
| `1911e46` | 2.6 | `lib/render.mts` — event renderer, tool-arg summarizer, job table, review formatter |
| `63bfa6a` | 2.4 | `lib/job-control.mts` — job CRUD, state transitions, active-run registry |
| `6cbd409` | 3.1–3.5 | `lib/args.mts`, router, all 7 subcommands |
| `6a257a1` | 4.1–4.4 | slash commands, cursor-rescue subagent, lifecycle hook, three SKILL.md |
| `0faa41d` | 5 | review parser + lifecycle hook tests |
| `83624bd` | self-review | `onRunStart` so jobs actually transition through `running` |

## Stats

- **3500+ lines added** across 34 files
- **159 unit tests** passing across 11 test files
- **Lint, typecheck, build, smoke** all clean
- Token usage tracking from cookbook **deliberately skipped** — `RunResult.usage` is not in the public SDK type and we don't allow `as any`/`@ts-ignore`

## Known follow-ons (out of scope here)

- **`--background` is "background to the user", not detached**: returns the job id immediately to stdout, but the CLI process stays alive until the run completes (Node holds the event loop on the pending Promise). True detach needs `child_process.spawn({ detached: true })`.
- **Cross-process cancel**: the `activeRuns` map is in-process. A `/cursor:cancel` from a different invocation hits `run-not-active` and only marks the persisted record — the underlying Cursor SDK run continues. Documented in the slash command help.
- **Phase 6** (review-gate Stop hook) and **Phase 7** (CI / npm publish / README) remain unchecked in PLAN.md.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome lint + format) — clean
- [x] `npm test` — 159/159 passing
- [x] `npm run build` — emits `plugins/cursor/scripts/dist/{cursor-companion,session-lifecycle-hook,commands/*,lib/*}.mjs`
- [x] CLI smoke: `setup` (without API key → reports failure), `--help`, `status` (empty state dir), `review --help`
- [x] Hook smoke: `SessionStart` writes `session.json` with parsed/generated session id; `SessionEnd` clears it

## Cookbook diff

Direct cookbook → here mapping in PLAN.md's "Reference: Cursor cookbook coding-agent-cli" section. Patterns lifted: `emitSdkMessage` → `toAgentEvents`, `getToolSummaryKeys` → `summarizeToolArgs`, `formatDuration`, `runPlainPrompt`-style streaming in `task`, `detectCloudRepository`/`normalizeGitHubRemote`, `cancelCurrentRun` → `cancelRun(run)` with `run.supports("cancel")`, `modelToChoices` → `setup` model flattening.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mve6N9oybXMVakMCpN1dQ3)_