### PR TITLE
feat(gate): Phase 6 — Stop review gate hook + opt-in toggle

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -485,18 +485,47 @@ After core delegation is solid, add the auto-review gate.
 | Review gate | `Stop` | `stop-review-gate-hook.mjs` | 900s |
 
 Behavior:
-- Fires when Claude Code is about to stop
-- Collects diff of changes Claude made this turn
-- Sends to Cursor agent for independent review
-- Returns JSON: `{ "decision": "block" | "allow", "reason": "..." }`
-- If blocked: Claude sees the review findings and must address them before stopping
+- [x] Fires when Claude Code is about to stop (always-installed hook;
+      short-circuits to "allow" when the per-workspace gate config is off)
+- [x] Collects working-tree diff of changes Claude made this turn
+      (`getDiff(workspaceRoot)`)
+- [x] Sends to Cursor agent for independent review using a strict
+      structured-output contract (same schema as `/cursor:review`)
+- [x] Outputs JSON `{ "decision": "block", "reason": "<formatted findings>" }`
+      on `needs-attention`; emits nothing (allow) on `approve`
+- [x] If blocked: Claude sees `formatBlockReason(review)` (verdict + sorted
+      findings + next steps) and must address them before stopping
+- [x] Honors `stop_hook_active: true` — never blocks on the second stop in
+      the same turn (no infinite loops)
+- [x] Fail-open on every infrastructure failure (SDK throw, non-finished
+      run, unparseable JSON) — surfaces a `cursor-plugin-cc gate:` warning
+      to stderr but always allows
 
 ### 6.2 Enable/Disable via Setup
 
-- [ ] `/cursor:setup` gains a toggle: "Enable review gate?" → writes/removes the Stop hook
-- [ ] Gate is opt-in, not default — it adds latency to every stop
+- [x] `/cursor:setup` gains `--enable-gate` / `--disable-gate` flags that
+      mutate `gate.json` in the workspace state dir. The Stop hook itself
+      stays in `hooks/hooks.json` always — the per-workspace config is the
+      kill switch, so we don't have to mutate the user's settings.json.
+- [x] Setup report (text + `--json`) includes the current gate state +
+      workspace root.
+- [x] Gate is opt-in, not default — it adds latency to every stop. Default
+      `gate.json` is `{ enabled: false }`.
 
-**Exit criteria**: Claude Code is blocked from stopping when Cursor finds critical issues. Gate can be toggled on/off.
+### 6.3 Tests
+
+- [x] `tests/unit/lib/gate.test.mts` — read/write/round-trip, malformed
+      payload, negative timeout, non-boolean enabled coercion
+- [x] `tests/cli/stop-review-gate.test.mts` — gate disabled allows; empty
+      diff allows; `stop_hook_active=true` allows; approve allows;
+      needs-attention emits structured `{ decision: "block", reason }`;
+      SDK throw / non-finished run / non-JSON output all fail-open with
+      stderr warning
+- [x] `tests/cli/setup.test.mts` — gate state in default report;
+      `--enable-gate` / `--disable-gate` persist `gate.json`; mutually
+      exclusive flags rejected with exit 2; `--json` includes `gate`
+
+**Exit criteria**: Claude Code is blocked from stopping when Cursor finds critical issues. Gate can be toggled on/off. ✅ (197 tests pass; 3 live-integration tests auto-skip without `CURSOR_API_KEY`).
 
 ---
 

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,5 +1,5 @@
 ---
-description: Validate the cursor-plugin-cc runtime — Node, API key, account, models.
+description: Validate the cursor-plugin-cc runtime — Node, API key, account, models. Toggle the Stop review gate.
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
@@ -16,3 +16,14 @@ Pass `--json` for machine-readable output. If anything fails (API key missing,
 network error, model catalog empty), the exit code is non-zero and the failure
 rows print on stdout. No further action needed — surface the output verbatim
 to the user.
+
+## Stop review gate
+
+The Stop review gate is opt-in per workspace. When enabled, every time
+Claude Code is about to stop, a Cursor agent reviews the working-tree diff
+and may block the stop with `needs-attention` findings. Toggle it via:
+
+- `--enable-gate` — turn the gate on for the current workspace
+- `--disable-gate` — turn the gate off
+
+The setup output's "Stop gate" row reports the current state.

--- a/plugins/cursor/hooks/hooks.json
+++ b/plugins/cursor/hooks/hooks.json
@@ -21,6 +21,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/stop-review-gate-hook.mjs",
+            "timeout": 900
+          }
+        ]
+      }
     ]
   }
 }

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -1,8 +1,11 @@
 import type { ModelSelection } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, parseArgs } from "../lib/args.mjs";
+import { bool, parseArgs, UsageError } from "../lib/args.mjs";
 import { listModels, resolveApiKey, whoami } from "../lib/cursor-agent.mjs";
+import { readGateConfig, setGateEnabled } from "../lib/gate.mjs";
+import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
+import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const NODE_MIN_MAJOR = 18;
 
@@ -12,13 +15,21 @@ interface ModelChoice {
   description?: string;
 }
 
-const HELP = `cursor-companion setup [--json] [--help]
+const HELP = `cursor-companion setup [flags]
 
 Validates the plugin runtime:
   - Node.js >= ${NODE_MIN_MAJOR}
   - CURSOR_API_KEY is set
   - Cursor.me() succeeds (key is valid)
   - Cursor.models.list() returns at least one model
+
+Stop review gate (per workspace, opt-in):
+  --enable-gate        Turn on the Stop review gate for this workspace
+  --disable-gate       Turn off the Stop review gate for this workspace
+
+flags:
+  --json               Machine-readable output
+  --help, -h
 `;
 
 function nodeMajor(): number {
@@ -74,14 +85,16 @@ interface SetupReport {
   apiKey: { ok: boolean; error?: string };
   account: { ok: boolean; apiKeyName?: string; error?: string };
   models: { ok: boolean; choices: ModelChoice[]; error?: string };
+  gate: { enabled: boolean; workspaceRoot: string };
 }
 
-async function buildReport(): Promise<SetupReport> {
+async function buildReport(workspaceRoot: string, gateEnabled: boolean): Promise<SetupReport> {
   const report: SetupReport = {
     node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
     apiKey: { ok: false },
     account: { ok: false },
     models: { ok: false, choices: [] },
+    gate: { enabled: gateEnabled, workspaceRoot },
   };
 
   try {
@@ -132,12 +145,20 @@ function renderReport(report: SetupReport): string {
   } else if (report.models.error) {
     lines.push(`Models      fail  ${report.models.error}`);
   }
+  lines.push(
+    `Stop gate   ${report.gate.enabled ? "on" : "off"}   (workspace: ${report.gate.workspaceRoot})`,
+  );
   return `${lines.join("\n")}\n`;
 }
 
 export async function runSetup(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   const parsed = parseArgs(args, {
-    long: { json: "boolean", help: "boolean" },
+    long: {
+      json: "boolean",
+      help: "boolean",
+      "enable-gate": "boolean",
+      "disable-gate": "boolean",
+    },
     short: { h: "help" },
   });
   if (bool(parsed, "help")) {
@@ -145,7 +166,24 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     return 0;
   }
 
-  const report = await buildReport();
+  const enableGate = bool(parsed, "enable-gate");
+  const disableGate = bool(parsed, "disable-gate");
+  if (enableGate && disableGate) {
+    throw new UsageError("--enable-gate and --disable-gate are mutually exclusive");
+  }
+
+  const workspaceRoot = resolveWorkspaceRoot(io.cwd());
+  const stateDir = resolveStateDir(workspaceRoot);
+
+  let gateEnabled: boolean;
+  if (enableGate || disableGate) {
+    ensureStateDir(stateDir);
+    gateEnabled = setGateEnabled(stateDir, enableGate).enabled;
+  } else {
+    gateEnabled = readGateConfig(stateDir).enabled;
+  }
+
+  const report = await buildReport(workspaceRoot, gateEnabled);
 
   if (bool(parsed, "json")) {
     io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -179,10 +179,10 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
 
   const workspaceRoot = resolveWorkspaceRoot(io.cwd());
   const stateDir = resolveStateDir(workspaceRoot);
-  const gateEnabled =
-    enableGate || disableGate
-      ? setGateEnabled(stateDir, enableGate).enabled
-      : readGateConfig(stateDir).enabled;
+  const togglingGate = enableGate || disableGate;
+  const gateEnabled = togglingGate
+    ? setGateEnabled(stateDir, enableGate).enabled
+    : readGateConfig(stateDir).enabled;
 
   const report = await buildReport({ workspaceRoot, gateEnabled });
 

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -4,7 +4,7 @@ import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, parseArgs, UsageError } from "../lib/args.mjs";
 import { listModels, resolveApiKey, whoami } from "../lib/cursor-agent.mjs";
 import { readGateConfig, setGateEnabled } from "../lib/gate.mjs";
-import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
+import { resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const NODE_MIN_MAJOR = 18;
@@ -88,13 +88,18 @@ interface SetupReport {
   gate: { enabled: boolean; workspaceRoot: string };
 }
 
-async function buildReport(workspaceRoot: string, gateEnabled: boolean): Promise<SetupReport> {
+interface BuildReportInput {
+  workspaceRoot: string;
+  gateEnabled: boolean;
+}
+
+async function buildReport(input: BuildReportInput): Promise<SetupReport> {
   const report: SetupReport = {
     node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
     apiKey: { ok: false },
     account: { ok: false },
     models: { ok: false, choices: [] },
-    gate: { enabled: gateEnabled, workspaceRoot },
+    gate: { enabled: input.gateEnabled, workspaceRoot: input.workspaceRoot },
   };
 
   try {
@@ -174,16 +179,12 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
 
   const workspaceRoot = resolveWorkspaceRoot(io.cwd());
   const stateDir = resolveStateDir(workspaceRoot);
+  const gateEnabled =
+    enableGate || disableGate
+      ? setGateEnabled(stateDir, enableGate).enabled
+      : readGateConfig(stateDir).enabled;
 
-  let gateEnabled: boolean;
-  if (enableGate || disableGate) {
-    ensureStateDir(stateDir);
-    gateEnabled = setGateEnabled(stateDir, enableGate).enabled;
-  } else {
-    gateEnabled = readGateConfig(stateDir).enabled;
-  }
-
-  const report = await buildReport(workspaceRoot, gateEnabled);
+  const report = await buildReport({ workspaceRoot, gateEnabled });
 
   if (bool(parsed, "json")) {
     io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/plugins/cursor/scripts/lib/gate.mts
+++ b/plugins/cursor/scripts/lib/gate.mts
@@ -1,0 +1,50 @@
+import path from "node:path";
+
+import type { ModelSelection } from "@cursor/sdk";
+
+import { readJson, writeJsonAtomic } from "./state.mjs";
+
+/**
+ * Per-workspace configuration for the Stop review gate. Persisted as
+ * `gate.json` next to `state.json` in the workspace state directory. The
+ * Stop hook short-circuits to "allow" when this file is missing or
+ * `enabled === false`, so the gate stays opt-in even though its hook is
+ * always installed by the plugin manifest.
+ */
+export interface GateConfig {
+  version: 1;
+  enabled: boolean;
+  /** Optional model override for the gate review. Defaults to composer-2. */
+  model?: ModelSelection;
+  /** Cancel the gate review if it exceeds this duration (default: 600s). */
+  timeoutMs?: number;
+}
+
+export const DEFAULT_GATE_CONFIG: GateConfig = { version: 1, enabled: false };
+export const DEFAULT_GATE_TIMEOUT_MS = 600_000;
+
+export function getGatePath(stateDir: string): string {
+  return path.join(stateDir, "gate.json");
+}
+
+export function readGateConfig(stateDir: string): GateConfig {
+  const cfg = readJson<GateConfig>(getGatePath(stateDir));
+  if (!cfg || typeof cfg !== "object") return { ...DEFAULT_GATE_CONFIG };
+  return {
+    version: 1,
+    enabled: cfg.enabled === true,
+    ...(cfg.model ? { model: cfg.model } : {}),
+    ...(typeof cfg.timeoutMs === "number" && cfg.timeoutMs > 0 ? { timeoutMs: cfg.timeoutMs } : {}),
+  };
+}
+
+export function writeGateConfig(stateDir: string, config: GateConfig): void {
+  writeJsonAtomic(getGatePath(stateDir), { ...config, version: 1 });
+}
+
+export function setGateEnabled(stateDir: string, enabled: boolean): GateConfig {
+  const current = readGateConfig(stateDir);
+  const next: GateConfig = { ...current, version: 1, enabled };
+  writeGateConfig(stateDir, next);
+  return next;
+}

--- a/plugins/cursor/scripts/lib/hook-payload.mts
+++ b/plugins/cursor/scripts/lib/hook-payload.mts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+
+/**
+ * Synchronously read the hook's stdin (returns "" on TTY / read errors).
+ *
+ * `readFileSync(0)` blocks on a TTY waiting for input. Claude Code always
+ * pipes JSON via stdin for hooks; the TTY guard keeps a developer running
+ * the hook by hand from hanging forever.
+ */
+export function readHookStdinSync(): string {
+  if (process.stdin.isTTY) return "";
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Parse a hook payload from raw stdin text. Tolerates empty input and
+ * malformed JSON by returning an empty object — hooks must never crash
+ * Claude Code, so unknown payload shapes degrade gracefully.
+ */
+export function parseHookPayload<T extends object>(raw: string): T {
+  if (!raw.trim()) return {} as T;
+  try {
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object") return data as T;
+  } catch {
+    // ignore — fall through to empty payload
+  }
+  return {} as T;
+}

--- a/plugins/cursor/scripts/session-lifecycle-hook.mts
+++ b/plugins/cursor/scripts/session-lifecycle-hook.mts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
+import { parseHookPayload, readHookStdinSync } from "./lib/hook-payload.mjs";
 import {
   clearSession,
   ensureStateDir,
@@ -19,31 +19,8 @@ interface SessionStartPayload {
   source?: string;
 }
 
-function readStdinSync(): string {
-  // readFileSync(0) blocks on a TTY waiting for input. Claude Code always
-  // pipes JSON via stdin for hooks, but a developer running the hook by hand
-  // would otherwise hang forever — guard the interactive case.
-  if (process.stdin.isTTY) return "";
-  try {
-    return readFileSync(0, "utf8");
-  } catch {
-    return "";
-  }
-}
-
-function parseStdin(raw: string): SessionStartPayload {
-  if (!raw.trim()) return {};
-  try {
-    const data = JSON.parse(raw);
-    if (data && typeof data === "object") return data as SessionStartPayload;
-  } catch {
-    // ignore malformed payloads
-  }
-  return {};
-}
-
 function handleSessionStart(): number {
-  const payload = parseStdin(readStdinSync());
+  const payload = parseHookPayload<SessionStartPayload>(readHookStdinSync());
   const cwd = process.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
@@ -61,8 +38,8 @@ function handleSessionStart(): number {
 }
 
 function handleSessionEnd(): number {
-  // Reading stdin is harmless if Claude Code didn't send anything.
-  parseStdin(readStdinSync());
+  // Drain stdin so Claude Code's writer never blocks on the pipe.
+  readHookStdinSync();
   const cwd = process.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = resolveStateDir(workspaceRoot);

--- a/plugins/cursor/scripts/stop-review-gate-hook.mts
+++ b/plugins/cursor/scripts/stop-review-gate-hook.mts
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+import type { ModelSelection } from "@cursor/sdk";
+
+import { parseReview } from "./commands/review.mjs";
+import { oneShot } from "./lib/cursor-agent.mjs";
+import { DEFAULT_GATE_TIMEOUT_MS, readGateConfig } from "./lib/gate.mjs";
+import { getDiff, getStatus } from "./lib/git.mjs";
+import { type ReviewOutput, renderReviewResult } from "./lib/render.mjs";
+import { resolveStateDir } from "./lib/state.mjs";
+import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
+
+/**
+ * Stop hook payload as documented for Claude Code. Only the fields we use
+ * are typed — the SDK may add more over time.
+ */
+interface StopHookPayload {
+  session_id?: string;
+  transcript_path?: string;
+  cwd?: string;
+  hook_event_name?: string;
+  /** True when Claude was already blocked once this turn — never block again. */
+  stop_hook_active?: boolean;
+}
+
+export interface StopHookIO {
+  /** Synchronously read the hook's stdin (returns "" on TTY / errors). */
+  readStdin: () => string;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  cwd: () => string;
+}
+
+export interface BlockDecision {
+  decision: "block";
+  reason: string;
+}
+
+const GATE_INSTRUCTIONS = [
+  "You are an automated review gate. Claude Code is about to stop and return",
+  "  control to the user. Independently review the working-tree diff for",
+  "  issues that would be unsafe to merge as-is.",
+  "Be conservative: do NOT flag style nits, refactors, or speculative concerns.",
+  "Set verdict='needs-attention' ONLY when there is at least one finding with",
+  "  severity 'critical' or 'high'. Otherwise set verdict='approve'.",
+  "Cite file:line for each finding so Claude can locate it.",
+  "Output ONLY a single JSON object matching the schema below — no prose,",
+  "  no markdown fences.",
+].join("\n");
+
+const SCHEMA = `{
+  "verdict": "approve" | "needs-attention",
+  "summary": string,
+  "findings": [{
+    "severity": "critical" | "high" | "medium" | "low",
+    "title": string,
+    "body": string,
+    "file": string,
+    "line_start": number,
+    "line_end": number,
+    "confidence": number,
+    "recommendation": string
+  }],
+  "next_steps": string[]
+}`;
+
+function parsePayload(raw: string): StopHookPayload {
+  if (!raw.trim()) return {};
+  try {
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object") return data as StopHookPayload;
+  } catch {
+    // ignore malformed payloads — fail open
+  }
+  return {};
+}
+
+function readStdinSync(): string {
+  // readFileSync(0) blocks on a TTY waiting for input. Claude Code always
+  // pipes JSON via stdin for hooks; guard the interactive case so a
+  // developer running the hook by hand doesn't hang forever.
+  if (process.stdin.isTTY) return "";
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function buildPrompt(diff: string, status: string): string {
+  return [
+    GATE_INSTRUCTIONS,
+    "",
+    "Output schema:",
+    SCHEMA,
+    "",
+    "Working-tree status:",
+    status || "(clean)",
+    "",
+    "Diff to review:",
+    diff,
+  ].join("\n");
+}
+
+/**
+ * Build the `reason` string Claude sees when the gate blocks. We use the
+ * same renderer as the `review` subcommand so Claude gets a familiar
+ * verdict/findings/next-steps layout.
+ */
+export function formatBlockReason(review: ReviewOutput): string {
+  const header =
+    "cursor-plugin-cc Stop review gate found issues that should be addressed " +
+    "before stopping. Review the findings, fix them (or explain why they are " +
+    "not blocking), then stop again.\n\n";
+  return header + renderReviewResult(review);
+}
+
+/**
+ * Main entry point. Returns the process exit code. Always 0 — the hook
+ * communicates block/allow via stdout JSON, never via exit codes (which
+ * would be interpreted as infrastructure failures by Claude Code).
+ */
+export async function main(io: StopHookIO): Promise<number> {
+  const payload = parsePayload(io.readStdin());
+
+  // Avoid infinite loops: if Claude was already blocked once, allow.
+  if (payload.stop_hook_active === true) return 0;
+
+  const cwd = payload.cwd ?? io.cwd();
+  let workspaceRoot: string;
+  try {
+    workspaceRoot = resolveWorkspaceRoot(cwd);
+  } catch {
+    return 0;
+  }
+
+  const stateDir = resolveStateDir(workspaceRoot);
+  const config = readGateConfig(stateDir);
+  if (!config.enabled) return 0;
+
+  let diff: string;
+  try {
+    diff = getDiff(workspaceRoot);
+  } catch {
+    return 0;
+  }
+  if (!diff) return 0;
+
+  const prompt = buildPrompt(diff, getStatus(workspaceRoot));
+
+  const oneShotOpts: {
+    cwd: string;
+    timeoutMs: number;
+    model?: ModelSelection;
+  } = {
+    cwd: workspaceRoot,
+    timeoutMs: config.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS,
+  };
+  if (config.model) oneShotOpts.model = config.model;
+
+  let result: Awaited<ReturnType<typeof oneShot>>;
+  try {
+    result = await oneShot(prompt, oneShotOpts);
+  } catch (err) {
+    // Never block on infra failure — surface to stderr so the user can see
+    // why the gate didn't run, then allow.
+    io.stderr.write(
+      `cursor-plugin-cc gate: review failed (${err instanceof Error ? err.message : String(err)}); allowing.\n`,
+    );
+    return 0;
+  }
+
+  if (result.status !== "finished") {
+    io.stderr.write(`cursor-plugin-cc gate: review did not finish (${result.status}); allowing.\n`);
+    return 0;
+  }
+
+  let review: ReviewOutput;
+  try {
+    review = parseReview(result.output);
+  } catch (err) {
+    io.stderr.write(
+      `cursor-plugin-cc gate: could not parse review output (${err instanceof Error ? err.message : String(err)}); allowing.\n`,
+    );
+    return 0;
+  }
+
+  if (review.verdict === "approve") return 0;
+
+  const decision: BlockDecision = {
+    decision: "block",
+    reason: formatBlockReason(review),
+  };
+  io.stdout.write(JSON.stringify(decision));
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const code = await main({
+    readStdin: readStdinSync,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    cwd: () => process.cwd(),
+  });
+  process.exit(code);
+}

--- a/plugins/cursor/scripts/stop-review-gate-hook.mts
+++ b/plugins/cursor/scripts/stop-review-gate-hook.mts
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
-import { readFileSync } from "node:fs";
-
-import type { ModelSelection } from "@cursor/sdk";
-
 import { parseReview } from "./commands/review.mjs";
-import { oneShot } from "./lib/cursor-agent.mjs";
+import { type OneShotOptions, oneShot } from "./lib/cursor-agent.mjs";
 import { DEFAULT_GATE_TIMEOUT_MS, readGateConfig } from "./lib/gate.mjs";
 import { getDiff, getStatus } from "./lib/git.mjs";
+import { parseHookPayload, readHookStdinSync } from "./lib/hook-payload.mjs";
 import { type ReviewOutput, renderReviewResult } from "./lib/render.mjs";
 import { resolveStateDir } from "./lib/state.mjs";
 import { resolveWorkspaceRoot } from "./lib/workspace.mjs";
@@ -65,29 +62,6 @@ const SCHEMA = `{
   "next_steps": string[]
 }`;
 
-function parsePayload(raw: string): StopHookPayload {
-  if (!raw.trim()) return {};
-  try {
-    const data = JSON.parse(raw);
-    if (data && typeof data === "object") return data as StopHookPayload;
-  } catch {
-    // ignore malformed payloads — fail open
-  }
-  return {};
-}
-
-function readStdinSync(): string {
-  // readFileSync(0) blocks on a TTY waiting for input. Claude Code always
-  // pipes JSON via stdin for hooks; guard the interactive case so a
-  // developer running the hook by hand doesn't hang forever.
-  if (process.stdin.isTTY) return "";
-  try {
-    return readFileSync(0, "utf8");
-  } catch {
-    return "";
-  }
-}
-
 function buildPrompt(diff: string, status: string): string {
   return [
     GATE_INSTRUCTIONS,
@@ -122,7 +96,7 @@ export function formatBlockReason(review: ReviewOutput): string {
  * would be interpreted as infrastructure failures by Claude Code).
  */
 export async function main(io: StopHookIO): Promise<number> {
-  const payload = parsePayload(io.readStdin());
+  const payload = parseHookPayload<StopHookPayload>(io.readStdin());
 
   // Avoid infinite loops: if Claude was already blocked once, allow.
   if (payload.stop_hook_active === true) return 0;
@@ -149,11 +123,7 @@ export async function main(io: StopHookIO): Promise<number> {
 
   const prompt = buildPrompt(diff, getStatus(workspaceRoot));
 
-  const oneShotOpts: {
-    cwd: string;
-    timeoutMs: number;
-    model?: ModelSelection;
-  } = {
+  const oneShotOpts: OneShotOptions = {
     cwd: workspaceRoot,
     timeoutMs: config.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS,
   };
@@ -198,7 +168,7 @@ export async function main(io: StopHookIO): Promise<number> {
 
 if (import.meta.url === `file://${process.argv[1]}`) {
   const code = await main({
-    readStdin: readStdinSync,
+    readStdin: readHookStdinSync,
     stdout: process.stdout,
     stderr: process.stderr,
     cwd: () => process.cwd(),

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -1,0 +1,86 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { argv, captureIO } from "@test/helpers/io.mjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkMocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  agentResume: vi.fn(),
+  cursorMe: vi.fn(),
+  modelsList: vi.fn(),
+}));
+
+vi.mock("@cursor/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@cursor/sdk")>("@cursor/sdk");
+  return {
+    ...actual,
+    Agent: { create: sdkMocks.agentCreate, resume: sdkMocks.agentResume },
+    Cursor: { me: sdkMocks.cursorMe, models: { list: sdkMocks.modelsList } },
+  };
+});
+
+import { main as companionMain } from "@plugin/cursor-companion.mjs";
+import { readGateConfig } from "@plugin/lib/gate.mjs";
+import { resolveStateDir } from "@plugin/lib/state.mjs";
+
+let workDir: string;
+let stateRoot: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-setup-cwd-"));
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-setup-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+  process.env.CURSOR_API_KEY = "test-key";
+  vi.clearAllMocks();
+  sdkMocks.cursorMe.mockResolvedValue({ apiKeyName: "test-key", userId: "u" });
+  sdkMocks.modelsList.mockResolvedValue([
+    { id: "composer-2", displayName: "Composer 2", variants: [] },
+  ]);
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateRoot, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+  delete process.env.CURSOR_API_KEY;
+});
+
+describe("CLI: setup", () => {
+  it("reports gate state in the default report (off by default)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("Stop gate   off");
+  });
+
+  it("--enable-gate persists enabled=true and reports 'on'", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--enable-gate"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("Stop gate   on");
+    const cfg = readGateConfig(resolveStateDir(workDir));
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it("--disable-gate persists enabled=false and reports 'off'", async () => {
+    const ioOn = captureIO(workDir);
+    await companionMain(argv("setup", "--enable-gate"), ioOn);
+    const ioOff = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--disable-gate"), ioOff)).toBe(0);
+    expect(ioOff.captured.stdout.join("")).toContain("Stop gate   off");
+    expect(readGateConfig(resolveStateDir(workDir)).enabled).toBe(false);
+  });
+
+  it("rejects --enable-gate together with --disable-gate", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--enable-gate", "--disable-gate"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
+  });
+
+  it("--json includes gate state", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--enable-gate", "--json"), io)).toBe(0);
+    const report = JSON.parse(io.captured.stdout.join(""));
+    expect(report.gate.enabled).toBe(true);
+    expect(typeof report.gate.workspaceRoot).toBe("string");
+  });
+});

--- a/tests/cli/stop-review-gate.test.mts
+++ b/tests/cli/stop-review-gate.test.mts
@@ -1,0 +1,215 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { Writable } from "node:stream";
+import { NEEDS_ATTENTION_REVIEW, RAW_APPROVE } from "@test/fixtures/reviews.mjs";
+import { fakeAgent, makeRun } from "@test/helpers/sdk-mock.mjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkMocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  agentResume: vi.fn(),
+  cursorMe: vi.fn(),
+  modelsList: vi.fn(),
+}));
+
+vi.mock("@cursor/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@cursor/sdk")>("@cursor/sdk");
+  return {
+    ...actual,
+    Agent: { create: sdkMocks.agentCreate, resume: sdkMocks.agentResume },
+    Cursor: { me: sdkMocks.cursorMe, models: { list: sdkMocks.modelsList } },
+  };
+});
+
+import { setGateEnabled } from "@plugin/lib/gate.mjs";
+import { ensureStateDir, resolveStateDir } from "@plugin/lib/state.mjs";
+import { main as gateMain } from "@plugin/stop-review-gate-hook.mjs";
+
+let workDir: string;
+let stateRoot: string;
+
+const FOO_TS = "foo.ts";
+const ORIGINAL = "export const x = 1;\n";
+const DIRTY = "export const x = 2;\n";
+
+function initRepo(): void {
+  const env = {
+    ...process.env,
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "t@e",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "t@e",
+  };
+  execFileSync("git", ["init", "-q"], { cwd: workDir, env });
+  execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: workDir, env });
+  writeFileSync(path.join(workDir, FOO_TS), ORIGINAL);
+  execFileSync("git", ["add", "-A"], { cwd: workDir, env });
+  execFileSync(
+    "git",
+    ["-c", "commit.gpgsign=false", "commit", "-q", "--no-gpg-sign", "-m", "init"],
+    { cwd: workDir, env },
+  );
+}
+
+interface CapturedIO {
+  readStdin: () => string;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  cwd: () => string;
+  captured: { stdout: string[]; stderr: string[] };
+}
+
+function captureIO(stdin: string, cwdOverride?: string): CapturedIO {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const sink = (target: string[]): NodeJS.WritableStream =>
+    new Writable({
+      write(chunk, _enc, cb) {
+        target.push(chunk.toString());
+        cb();
+      },
+    });
+  return {
+    readStdin: () => stdin,
+    stdout: sink(stdout),
+    stderr: sink(stderr),
+    cwd: () => cwdOverride ?? workDir,
+    captured: { stdout, stderr },
+  };
+}
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-gate-cwd-"));
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-gate-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+  process.env.CURSOR_API_KEY = "test-key";
+  initRepo();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateRoot, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+  delete process.env.CURSOR_API_KEY;
+});
+
+describe("stop-review-gate-hook", () => {
+  it("allows when the gate is disabled (default)", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows when the working tree has no diff", async () => {
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows when stop_hook_active is true (no infinite loop)", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const io = captureIO(JSON.stringify({ cwd: workDir, stop_hook_active: true }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows on approve verdict", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const run = makeRun({
+      events: [],
+      result: { id: "run-gate-1", status: "finished", result: RAW_APPROVE },
+    });
+    sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(sdkMocks.agentCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks on needs-attention verdict with structured decision JSON", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const payload = JSON.stringify(NEEDS_ATTENTION_REVIEW);
+    const run = makeRun({
+      events: [],
+      result: { id: "run-gate-2", status: "finished", result: payload },
+    });
+    sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    const stdout = io.captured.stdout.join("");
+    expect(stdout.length).toBeGreaterThan(0);
+    const decision = JSON.parse(stdout);
+    expect(decision.decision).toBe("block");
+    expect(decision.reason).toContain("needs-attention");
+    expect(decision.reason).toContain("Stray console.log");
+  });
+
+  it("fail-opens (allows + warns on stderr) when the SDK throws", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    sdkMocks.agentCreate.mockRejectedValue(new Error("network down"));
+
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(io.captured.stderr.join("")).toContain("network down");
+    expect(io.captured.stderr.join("")).toContain("allowing");
+  });
+
+  it("fail-opens when the agent output is not parseable JSON", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const run = makeRun({
+      events: [],
+      result: { id: "run-gate-3", status: "finished", result: "not json at all" },
+    });
+    sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(io.captured.stderr.join("")).toContain("could not parse review");
+  });
+
+  it("fail-opens when the run does not finish", async () => {
+    writeFileSync(path.join(workDir, FOO_TS), DIRTY);
+    const stateDir = resolveStateDir(workDir);
+    ensureStateDir(stateDir);
+    setGateEnabled(stateDir, true);
+    const run = makeRun({
+      events: [],
+      result: { id: "run-gate-4", status: "error" },
+    });
+    sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    expect(await gateMain(io)).toBe(0);
+    expect(io.captured.stdout.join("")).toBe("");
+    expect(io.captured.stderr.join("")).toContain("did not finish");
+  });
+});

--- a/tests/cli/stop-review-gate.test.mts
+++ b/tests/cli/stop-review-gate.test.mts
@@ -53,8 +53,6 @@ function initRepo(): void {
   );
 }
 
-const captureIO = (stdin: string, cwd: string = workDir) => captureHookIO(stdin, cwd);
-
 beforeEach(() => {
   workDir = mkdtempSync(path.join(tmpdir(), "cursor-gate-cwd-"));
   stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-gate-state-"));
@@ -74,7 +72,7 @@ afterEach(() => {
 describe("stop-review-gate-hook", () => {
   it("allows when the gate is disabled (default)", async () => {
     writeFileSync(path.join(workDir, FOO_TS), DIRTY);
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
@@ -84,7 +82,7 @@ describe("stop-review-gate-hook", () => {
     const stateDir = resolveStateDir(workDir);
     ensureStateDir(stateDir);
     setGateEnabled(stateDir, true);
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
@@ -95,7 +93,7 @@ describe("stop-review-gate-hook", () => {
     const stateDir = resolveStateDir(workDir);
     ensureStateDir(stateDir);
     setGateEnabled(stateDir, true);
-    const io = captureIO(JSON.stringify({ cwd: workDir, stop_hook_active: true }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir, stop_hook_active: true }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
@@ -112,7 +110,7 @@ describe("stop-review-gate-hook", () => {
     });
     sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
 
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(sdkMocks.agentCreate).toHaveBeenCalledTimes(1);
@@ -130,7 +128,7 @@ describe("stop-review-gate-hook", () => {
     });
     sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
 
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     const stdout = io.captured.stdout.join("");
     expect(stdout.length).toBeGreaterThan(0);
@@ -147,7 +145,7 @@ describe("stop-review-gate-hook", () => {
     setGateEnabled(stateDir, true);
     sdkMocks.agentCreate.mockRejectedValue(new Error("network down"));
 
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(io.captured.stderr.join("")).toContain("network down");
@@ -165,7 +163,7 @@ describe("stop-review-gate-hook", () => {
     });
     sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
 
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(io.captured.stderr.join("")).toContain("could not parse review");
@@ -182,7 +180,7 @@ describe("stop-review-gate-hook", () => {
     });
     sdkMocks.agentCreate.mockResolvedValue(fakeAgent(run));
 
-    const io = captureIO(JSON.stringify({ cwd: workDir }));
+    const io = captureHookIO(JSON.stringify({ cwd: workDir }));
     expect(await gateMain(io)).toBe(0);
     expect(io.captured.stdout.join("")).toBe("");
     expect(io.captured.stderr.join("")).toContain("did not finish");

--- a/tests/cli/stop-review-gate.test.mts
+++ b/tests/cli/stop-review-gate.test.mts
@@ -2,8 +2,8 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Writable } from "node:stream";
 import { NEEDS_ATTENTION_REVIEW, RAW_APPROVE } from "@test/fixtures/reviews.mjs";
+import { captureHookIO } from "@test/helpers/io.mjs";
 import { fakeAgent, makeRun } from "@test/helpers/sdk-mock.mjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -53,32 +53,7 @@ function initRepo(): void {
   );
 }
 
-interface CapturedIO {
-  readStdin: () => string;
-  stdout: NodeJS.WritableStream;
-  stderr: NodeJS.WritableStream;
-  cwd: () => string;
-  captured: { stdout: string[]; stderr: string[] };
-}
-
-function captureIO(stdin: string, cwdOverride?: string): CapturedIO {
-  const stdout: string[] = [];
-  const stderr: string[] = [];
-  const sink = (target: string[]): NodeJS.WritableStream =>
-    new Writable({
-      write(chunk, _enc, cb) {
-        target.push(chunk.toString());
-        cb();
-      },
-    });
-  return {
-    readStdin: () => stdin,
-    stdout: sink(stdout),
-    stderr: sink(stderr),
-    cwd: () => cwdOverride ?? workDir,
-    captured: { stdout, stderr },
-  };
-}
+const captureIO = (stdin: string, cwd: string = workDir) => captureHookIO(stdin, cwd);
 
 beforeEach(() => {
   workDir = mkdtempSync(path.join(tmpdir(), "cursor-gate-cwd-"));

--- a/tests/helpers/io.mts
+++ b/tests/helpers/io.mts
@@ -2,6 +2,14 @@ import { Writable } from "node:stream";
 import type { SDKAgent, SDKUserMessage } from "@cursor/sdk";
 import { vi } from "vitest";
 
+const sink = (target: string[]): NodeJS.WritableStream =>
+  new Writable({
+    write(chunk, _enc, cb) {
+      target.push(chunk.toString());
+      cb();
+    },
+  });
+
 export interface CapturedIO {
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
@@ -13,13 +21,6 @@ export interface CapturedIO {
 export function captureIO(cwd: string = process.cwd()): CapturedIO {
   const stdout: string[] = [];
   const stderr: string[] = [];
-  const sink = (target: string[]): NodeJS.WritableStream =>
-    new Writable({
-      write(chunk, _enc, cb) {
-        target.push(chunk.toString());
-        cb();
-      },
-    });
   return {
     stdout: sink(stdout),
     stderr: sink(stderr),
@@ -43,13 +44,6 @@ export interface CapturedHookIO {
 export function captureHookIO(stdin: string, cwd: string = process.cwd()): CapturedHookIO {
   const stdout: string[] = [];
   const stderr: string[] = [];
-  const sink = (target: string[]): NodeJS.WritableStream =>
-    new Writable({
-      write(chunk, _enc, cb) {
-        target.push(chunk.toString());
-        cb();
-      },
-    });
   return {
     readStdin: () => stdin,
     stdout: sink(stdout),

--- a/tests/helpers/io.mts
+++ b/tests/helpers/io.mts
@@ -31,6 +31,34 @@ export function captureIO(cwd: string = process.cwd()): CapturedIO {
 
 export const argv = (...rest: string[]): string[] => ["node", "cursor-companion", ...rest];
 
+export interface CapturedHookIO {
+  readStdin: () => string;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  cwd: () => string;
+  captured: { stdout: string[]; stderr: string[] };
+}
+
+/** captureIO sibling for hook entry points that take a `readStdin` instead of argv. */
+export function captureHookIO(stdin: string, cwd: string = process.cwd()): CapturedHookIO {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  const sink = (target: string[]): NodeJS.WritableStream =>
+    new Writable({
+      write(chunk, _enc, cb) {
+        target.push(chunk.toString());
+        cb();
+      },
+    });
+  return {
+    readStdin: () => stdin,
+    stdout: sink(stdout),
+    stderr: sink(stderr),
+    cwd: () => cwd,
+    captured: { stdout, stderr },
+  };
+}
+
 /**
  * Read the prompt the test passed to a mocked `agent.send`, asserting it was
  * a string. `agent.send` accepts `string | SDKUserMessage`, so an unchecked

--- a/tests/unit/lib/gate.test.mts
+++ b/tests/unit/lib/gate.test.mts
@@ -1,0 +1,66 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  DEFAULT_GATE_CONFIG,
+  getGatePath,
+  readGateConfig,
+  setGateEnabled,
+  writeGateConfig,
+} from "@plugin/lib/gate.mjs";
+import { ensureStateDir } from "@plugin/lib/state.mjs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let stateDir: string;
+
+beforeEach(() => {
+  stateDir = mkdtempSync(path.join(tmpdir(), "cursor-gate-"));
+  ensureStateDir(stateDir);
+});
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true });
+});
+
+describe("gate config", () => {
+  it("returns the disabled default when gate.json is missing", () => {
+    expect(readGateConfig(stateDir)).toEqual(DEFAULT_GATE_CONFIG);
+  });
+
+  it("round-trips a written config", () => {
+    writeGateConfig(stateDir, { version: 1, enabled: true, timeoutMs: 12_345 });
+    const cfg = readGateConfig(stateDir);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.timeoutMs).toBe(12_345);
+  });
+
+  it("setGateEnabled flips the flag without losing other fields", () => {
+    writeGateConfig(stateDir, {
+      version: 1,
+      enabled: true,
+      model: { id: "composer-2" },
+      timeoutMs: 5000,
+    });
+    const next = setGateEnabled(stateDir, false);
+    expect(next.enabled).toBe(false);
+    expect(next.model).toEqual({ id: "composer-2" });
+    expect(next.timeoutMs).toBe(5000);
+  });
+
+  it("treats malformed gate.json as disabled default", () => {
+    writeFileSync(getGatePath(stateDir), "{ not json");
+    expect(readGateConfig(stateDir)).toEqual(DEFAULT_GATE_CONFIG);
+  });
+
+  it("rejects negative timeouts (treated as absent)", () => {
+    writeGateConfig(stateDir, { version: 1, enabled: true, timeoutMs: -1 });
+    const cfg = readGateConfig(stateDir);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.timeoutMs).toBeUndefined();
+  });
+
+  it("coerces non-boolean enabled values to false", () => {
+    writeFileSync(getGatePath(stateDir), JSON.stringify({ version: 1, enabled: "yes" }));
+    expect(readGateConfig(stateDir).enabled).toBe(false);
+  });
+});


### PR DESCRIPTION
Adds an opt-in Stop hook that runs an independent Cursor review on the
working-tree diff before Claude stops, and emits
{ "decision": "block", "reason": ... } when the review verdict is
needs-attention. The hook fail-opens on every infrastructure failure so
it never derails Claude's normal flow.

Toggling lives in /cursor:setup via --enable-gate / --disable-gate; the
hook itself is always installed and short-circuits to "allow" when the
per-workspace gate.json is off, so we don't have to touch the user's
settings.json.