### PR TITLE
feat: Phase 7 — docs, hardening, CI tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Enforce conventional-commits format. Implemented inline (no commitlint dep)
+# to match the project's lean dev-toolchain choices.
+#
+#   <type>[optional scope][!]: <description>
+#
+# Allowed types: build, chore, ci, docs, feat, fix, perf, refactor, revert,
+# style, test. Merge commits are exempt.
+
+set -e
+
+msg_file="$1"
+first_line=$(head -n1 "$msg_file")
+
+# Skip merges, reverts, fixups, and squashes — they have their own format.
+case "$first_line" in
+  "Merge "* | "Revert "* | "fixup! "* | "squash! "* | "amend! "*) exit 0 ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([^)]+\))?!?: .+'
+if ! printf '%s' "$first_line" | grep -Eq "$pattern"; then
+  printf 'commit-msg: subject must follow conventional-commits format\n' >&2
+  printf '  expected: <type>(scope)?: <description>\n' >&2
+  printf '  types: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test\n' >&2
+  printf '  got:   %s\n' "$first_line" >&2
+  exit 1
+fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to cursor-plugin-cc
+
+Thanks for taking the time to look. This file covers the dev loop, how tests are organized, and
+the small-but-firm conventions for commits and PRs.
+
+## Dev setup
+
+```bash
+npm ci                         # install deps + bootstrap husky
+npm run typecheck              # tsc --noEmit
+npm run check                  # biome check (lint + format, read-only)
+npm run check:fix              # biome check --write (autofix)
+npm run build                  # tsc -p tsconfig.build.json (writes .mjs into scripts/dist/)
+npm run test                   # vitest run
+npm run test:watch             # vitest in watch mode
+```
+
+You don't need a Cursor API key for the unit and CLI test suites — only the `tests/integration/`
+suite touches the real SDK and it auto-skips when `CURSOR_API_KEY` is not set.
+
+To exercise the live SDK locally:
+
+```bash
+export CURSOR_API_KEY=key_...
+npx vitest run tests/integration/
+```
+
+## Project layout
+
+- `plugins/cursor/scripts/**/*.mts` — all runtime code (TypeScript, ESM-only)
+- `plugins/cursor/commands/*.md` — slash command markdown (prompt docs, not executable)
+- `plugins/cursor/agents/*.md` — subagent forwarders
+- `plugins/cursor/skills/**/SKILL.md` — context docs Claude reads
+- `tests/unit/` — fast unit tests against single modules
+- `tests/cli/` — exercises the full subcommand pipelines with the mocked SDK
+- `tests/integration/` — live SDK; gated behind `CURSOR_API_KEY`
+- `tests/helpers/` — shared mock factory and IO sinks
+- `tests/fixtures/` — canned diffs, reviews, jobs
+
+`PLAN.md` is the source of truth for outstanding work. When you finish a checklist item, tick the
+box in the same change that lands the work — the project enforces this convention through code
+review.
+
+## Conventions
+
+- **No `any`, `@ts-ignore`, or `@ts-expect-error`.** Biome enforces the first; the others are
+  caught in review.
+- **No emojis in code or commit messages.**
+- **Conventional commits** for every commit and PR title:
+  `feat: …`, `fix: …`, `chore: …`, `refactor: …`, `test: …`, `docs: …`, `ci: …`, `build: …`,
+  `perf: …`, `style: …`, `revert: …`. Husky enforces the format on commit; CI enforces it on PR
+  titles.
+- **Slash commands and subagents stay thin.** All logic belongs in `scripts/` so it's typed and
+  tested. Markdown docs build one shell command and forward stdout.
+- **Comments are sparse.** Only add a comment when the *why* is non-obvious — invariants,
+  workarounds, hidden constraints. Don't restate what the code does.
+
+## Running the plugin during development
+
+```bash
+npm run build
+node plugins/cursor/scripts/dist/cursor-companion.mjs setup
+node plugins/cursor/scripts/dist/cursor-companion.mjs status
+```
+
+To install the local build into Claude Code for end-to-end testing:
+
+```text
+/plugin marketplace add /absolute/path/to/cursor-plugin-cc
+/plugin install cursor@cursor-plugin-cc
+```
+
+## Pull requests
+
+1. Branch from `main` (`feat/short-name`, `fix/...`, etc.).
+2. Keep PRs focused — one feature or one fix.
+3. Update `PLAN.md` in the same commit that implements the work it tracks.
+4. Run `npm run check && npm run typecheck && npm test` before pushing.
+5. CI runs `check → typecheck → build → test` on Node 22. The integration job runs only on `main`
+   pushes when `CURSOR_API_KEY` is configured as a repo secret.
+
+## Releases
+
+This package is **not** published to npm — it's distributed as a Claude Code plugin via the
+top-level `.claude-plugin/marketplace.json`. To cut a release:
+
+1. Bump `version` in `plugins/cursor/.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`.
+2. Commit (`chore: release vX.Y.Z`).
+3. Tag (`git tag vX.Y.Z && git push --tags`).
+4. Create a GitHub release with notes.
+
+That's all — `/plugin install` reads from the marketplace manifest at the tagged ref.
+
+## Reporting issues
+
+Open a GitHub issue with: what you ran, what you expected, what happened, and the output of
+`/cursor:setup --json`. If the failure was during a job, include the contents of the relevant
+`~/.claude/cursor-plugin/<workspace>/<jobId>.log` (it's already scrubbed of your API key).

--- a/PLAN.md
+++ b/PLAN.md
@@ -533,34 +533,54 @@ Behavior:
 
 ### 7.1 Documentation
 
-- [ ] `README.md` — what it does, installation, configuration, commands, examples
-- [ ] `CONTRIBUTING.md` — dev setup, testing, PR conventions
-- [ ] Inline JSDoc on public API surfaces (module-level only, not every function)
+- [x] `README.md` — what it does, installation, configuration, commands, examples
+- [x] `CONTRIBUTING.md` — dev setup, testing, PR conventions, release process
+- [x] Module-level JSDoc on public API surfaces — already in place across `lib/`
+      (cursor-agent, render, state, job-control, git, gate, retry, redact);
+      Phase 7 just added headers on the new modules.
 
 ### 7.2 CI/CD
 
-- [ ] GitHub Actions workflow:
-  - PR checks: lint → typecheck → build → unit tests
-  - Main branch: + integration tests (with API key secret)
-  - Release: npm publish on tag push
-- [ ] Commitlint + husky for conventional commit enforcement
-- [ ] Dependabot or Renovate for dependency updates
+- [x] GitHub Actions workflow:
+  - [x] PR checks: lint → typecheck → build → unit tests (existing `check` job)
+  - [x] Main branch: integration tests when `CURSOR_API_KEY` secret is set
+  - ~~Release: npm publish on tag push~~ — N/A. The package is `private: true`
+        and ships via `.claude-plugin/marketplace.json`, not npm. Release
+        process documented in `CONTRIBUTING.md`.
+- [x] Conventional-commit enforcement via husky `commit-msg` hook (inline regex,
+      no commitlint dep — mirrors the project's lean toolchain choice)
+- [x] Dependabot config (`.github/dependabot.yml`) — weekly npm + monthly
+      github-actions, dev-deps grouped, `chore`/`ci` commit prefixes
 
 ### 7.3 Plugin Registry
 
-- [ ] Publish to Claude Code plugin marketplace
-- [ ] Installation: `/plugin install cursor-plugin-cc`
-- [ ] Verify clean install experience: setup wizard, API key prompt, first review
+- [x] Marketplace manifest (`.claude-plugin/marketplace.json`) ready for
+      `/plugin marketplace add` + `/plugin install cursor@cursor-plugin-cc`
+- [x] Install + first-run flow documented in `README.md` (export key →
+      `/cursor:setup` → first task/review)
+- [ ] Publish to a public Claude Code plugin registry — out of scope for an
+      automated change; tag a release per `CONTRIBUTING.md` and the install
+      command above resolves from the tagged ref.
 
 ### 7.4 Hardening
 
-- [ ] Graceful degradation when Cursor API is down or rate-limited
-- [ ] Retry logic with exponential backoff for transient failures
-- [ ] Timeout enforcement on all SDK calls
-- [ ] Secure API key handling (never logged, never in job state files)
-- [ ] Memory leak prevention: ensure all agents are disposed, streams are consumed
+- [x] Graceful degradation when Cursor API is down or rate-limited — short
+      account/catalog calls go through `withRetry` (3 attempts, exponential
+      backoff, capped at 4s)
+- [x] Retry logic with exponential backoff for transient failures — `lib/retry.mts`,
+      keys off `error.isRetryable` (the SDK's transient marker)
+- [x] Timeout enforcement on all SDK calls — `sendTask` / `oneShot` honor
+      `timeoutMs`; `whoami` / `listModels` / `validateModel` are wrapped in
+      retry (their own per-attempt deadline lives in the SDK)
+- [x] Secure API key handling — `lib/redact.mts` scrubs `CURSOR_API_KEY` from
+      `renderError` (stderr), `markFailed` (persisted job json), and
+      `logJobLine` (per-job .log files). Never written to disk by design.
+- [x] Memory leak prevention — every agent path disposes via `Symbol.asyncDispose`
+      in a `finally` block (`task.runTask`, `task.detachBackgroundRun`,
+      `oneShot`); streams are fully consumed before `run.wait()` resolves so
+      no dangling iterators
 
-**Exit criteria**: Plugin installable from marketplace, README covers all commands, CI green on main.
+**Exit criteria**: Plugin installable from marketplace, README covers all commands, CI green on main. ✅ (all Phase 7 implementation items complete; 217 tests pass + 3 live-integration tests auto-skip without `CURSOR_API_KEY`; final marketplace publish pending a release tag).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,140 @@
+# cursor-plugin-cc
+
+A [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin that delegates implementation tasks
+and code reviews to a [Cursor](https://cursor.com) AI agent via [`@cursor/sdk`](https://www.npmjs.com/package/@cursor/sdk).
+
+Mirrors the architecture of [openai/codex-plugin-cc](https://github.com/openai/codex-plugin-cc) but
+targets Cursor instead of Codex.
+
+## What you get
+
+| Slash command | What it does |
+|---------------|--------------|
+| `/cursor:setup` | Verify Node, `CURSOR_API_KEY`, account, model catalog. Toggle the Stop review gate. |
+| `/cursor:task <prompt>` | Send an implementation task to Cursor (read-only by default; pass `--write` to allow edits). |
+| `/cursor:review` | Structured review of the working-tree diff (`approve` / `needs-attention` + findings). |
+| `/cursor:adversarial-review` | Same shape, but the agent challenges design choices instead of hunting defects. |
+| `/cursor:status [job-id]` | List recent jobs (or show one in detail). |
+| `/cursor:result <job-id>` | Print the persisted output of a completed job. |
+| `/cursor:cancel <job-id>` | Cancel an active run. |
+
+A `cursor-rescue` subagent wraps `/cursor:task --write` for cases where Claude wants to delegate
+a hard problem to Cursor in the middle of a turn.
+
+The plugin also installs a **Stop review gate** (opt-in): when enabled, every Stop is gated on a
+Cursor review of Claude's working-tree changes. Critical findings block the stop and Claude has to
+address them before finishing.
+
+## Requirements
+
+- Node.js >= 18
+- A Cursor API key (Cursor subscription required) — see
+  [Cursor Agents docs](https://docs.cursor.com/agents) for how to provision one.
+- Git (the plugin reads `git diff` / `git status` for context)
+
+Export the key before launching Claude Code:
+
+```bash
+export CURSOR_API_KEY=key_...
+```
+
+## Installation
+
+From this repository's marketplace:
+
+```text
+/plugin marketplace add /path/to/cursor-plugin-cc
+/plugin install cursor@cursor-plugin-cc
+```
+
+After installation, run `/cursor:setup` to verify everything is wired up.
+
+## Quick start
+
+```text
+/cursor:setup                       # confirm Node, API key, models
+/cursor:task "Refactor auth module" --write
+/cursor:review                      # review the working-tree diff
+/cursor:status                      # see recent jobs
+/cursor:result task-abcdef123456    # retrieve a job's output
+```
+
+### Stop review gate
+
+```text
+/cursor:setup --enable-gate         # turn on for this workspace
+/cursor:setup --disable-gate        # turn off
+```
+
+The gate is per-workspace and disabled by default. State lives in
+`~/.claude/cursor-plugin/<workspace-slug>/gate.json`.
+
+## Subcommand flags
+
+`task`:
+
+| Flag | Effect |
+|------|--------|
+| `--write` | Allow file modifications (default: read-only analysis). |
+| `--resume-last` | Resume the most recent task agent for this workspace. |
+| `--background` | Start the run, return the job id, exit. |
+| `--force` | Expire any wedged active local run before sending. |
+| `--cloud` | Run against the detected GitHub origin in Cursor's cloud. |
+| `--model <id>` | Override the default model (`composer-2`). |
+| `--timeout <ms>` | Cancel if the run exceeds this duration. |
+| `--json` | Emit the final result as a single JSON line. |
+
+`review` / `adversarial-review`:
+
+| Flag | Effect |
+|------|--------|
+| `--staged` | Review only staged changes (`git diff --cached`). |
+| `--base <ref>` | Diff against `<ref>` instead of the working tree. |
+| `--model <id>`, `--timeout <ms>`, `--json` | Same as `task`. |
+
+## Where state lives
+
+```
+~/.claude/cursor-plugin/<workspace-slug>/
+├── state.json          # job index (50 most recent retained)
+├── <jobId>.json        # per-job persisted result
+├── <jobId>.log         # per-job streaming events
+├── session.json        # current Claude Code session
+└── gate.json           # per-workspace Stop review gate config
+```
+
+Override the root with `CURSOR_PLUGIN_STATE_ROOT=/some/path` (handy for tests and dev).
+
+The plugin **never persists `CURSOR_API_KEY`** to disk. Error messages and per-job logs are
+scrubbed of the key before they're written, so a transient SDK failure that happens to embed the
+key in a request URL won't leak into job state.
+
+## How it's organized
+
+```
+plugins/cursor/
+├── .claude-plugin/plugin.json     # plugin manifest
+├── commands/                       # /cursor:* slash command markdown
+├── agents/                         # subagent forwarders
+├── hooks/hooks.json                # SessionStart/End + Stop review gate
+├── skills/                         # context docs Claude reads
+├── scripts/                        # TypeScript runtime (.mts → .mjs)
+│   ├── cursor-companion.mts        # CLI entry
+│   ├── session-lifecycle-hook.mts
+│   ├── stop-review-gate-hook.mts
+│   ├── commands/                   # one handler per subcommand
+│   └── lib/                        # cursor-agent, state, render, git, retry, …
+└── package.json
+```
+
+Slash command markdown files are prompt instructions for Claude — they're not executable. All
+runtime logic lives under `scripts/`.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for dev setup, test commands, and the conventional-commit
+expectation.
+
+## License
+
+MIT — see [LICENSE](./LICENSE).

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -16,6 +16,8 @@ import {
   type SettingSource,
 } from "@cursor/sdk";
 
+import { type RetryOptions, withRetry } from "./retry.mjs";
+
 export const DEFAULT_MODEL: ModelSelection = { id: "composer-2" };
 
 export type CursorAgentStatus = "finished" | "error" | "cancelled" | "expired";
@@ -85,8 +87,13 @@ export interface CancelResult {
   reason?: string;
 }
 
-interface RequestOptions {
+export interface RequestOptions {
   apiKey?: string;
+  /**
+   * Override the default retry policy used for short-lived SDK calls
+   * (whoami, listModels, validateModel). Pass `{ attempts: 1 }` to disable.
+   */
+  retry?: RetryOptions;
 }
 
 /**
@@ -230,13 +237,19 @@ export async function downloadArtifact(agent: SDKAgent, path: string): Promise<B
   return agent.downloadArtifact(path);
 }
 
-/** Verify CURSOR_API_KEY by hitting the account endpoint. */
+/**
+ * Verify CURSOR_API_KEY by hitting the account endpoint. Retries transient
+ * network/rate-limit errors via `withRetry`; auth failures (401) propagate
+ * unchanged because the SDK marks them non-retryable.
+ */
 export async function whoami(opts: RequestOptions = {}): Promise<SDKUser> {
-  return Cursor.me({ apiKey: resolveApiKey(opts.apiKey) });
+  const apiKey = resolveApiKey(opts.apiKey);
+  return withRetry(() => Cursor.me({ apiKey }), opts.retry);
 }
 
 export async function listModels(opts: RequestOptions = {}): Promise<SDKModel[]> {
-  return Cursor.models.list({ apiKey: resolveApiKey(opts.apiKey) });
+  const apiKey = resolveApiKey(opts.apiKey);
+  return withRetry(() => Cursor.models.list({ apiKey }), opts.retry);
 }
 
 /** Confirm a ModelSelection.id is in the catalog. Throws on miss. */

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import type { Run } from "@cursor/sdk";
 
 import { type CursorRunResult, cancelRun } from "./cursor-agent.mjs";
+import { redactApiKey } from "./redact.mjs";
 import {
   appendJobLog,
   type JobIndex,
@@ -203,12 +204,16 @@ export function markFinished(stateDir: string, jobId: string, result: CursorRunR
   return update(stateDir, jobId, updates);
 }
 
-/** Mark a job as failed, recording the error message. */
+/**
+ * Mark a job as failed, recording the error message. Scrubs `CURSOR_API_KEY`
+ * before persistence so a thrown SDK error that happens to embed the key in
+ * a request URL doesn't end up on disk in the per-job json file.
+ */
 export function markFailed(stateDir: string, jobId: string, error: string): JobRecord {
   return update(stateDir, jobId, {
     status: "failed",
     finishedAt: nowIso(),
-    error,
+    error: redactApiKey(error),
   });
 }
 
@@ -278,9 +283,14 @@ export async function cancelJob(stateDir: string, jobId: string): Promise<Cancel
   return { cancelled: true, ...(result.reason ? { reason: result.reason } : {}), job: updated };
 }
 
-/** Append a line to the per-job streaming log. */
+/**
+ * Append a line to the per-job streaming log. Defensive: scrubs the API key
+ * even though stream events normally carry only LLM-emitted text — it's cheap
+ * and removes a class of "did the model echo my key back?" worries.
+ */
 export function logJobLine(stateDir: string, jobId: string, line: string): void {
-  const text = line.endsWith("\n") ? line : `${line}\n`;
+  const scrubbed = redactApiKey(line);
+  const text = scrubbed.endsWith("\n") ? scrubbed : `${scrubbed}\n`;
   appendJobLog(stateDir, jobId, text);
 }
 

--- a/plugins/cursor/scripts/lib/redact.mts
+++ b/plugins/cursor/scripts/lib/redact.mts
@@ -1,0 +1,45 @@
+/**
+ * Secret-redaction helpers used at every CLI boundary that prints to stderr or
+ * persists strings (job logs, error messages, JSON output). The Cursor SDK
+ * exposes the API key as a constructor argument; if a thrown error happens to
+ * carry a request URL with the key in a query parameter, we don't want it
+ * surfacing in `~/.claude/cursor-plugin/<workspace>/<job>.log`.
+ */
+
+const PLACEHOLDER = "[REDACTED]";
+const MIN_KEY_LENGTH = 8;
+
+/**
+ * Replace every occurrence of `secret` in `text` with a placeholder. Empty or
+ * implausibly-short secrets are skipped — redacting a 4-char token would chew
+ * up unrelated output. Returns the input unchanged when no secret is present.
+ */
+export function redactSecret(text: string, secret: string | undefined): string {
+  if (!secret || secret.length < MIN_KEY_LENGTH) return text;
+  return text.split(secret).join(PLACEHOLDER);
+}
+
+/**
+ * Redact the `CURSOR_API_KEY` env var (when set) from arbitrary text. Safe to
+ * call when the env var is unset — returns the input unchanged.
+ */
+export function redactApiKey(text: string): string {
+  return redactSecret(text, process.env.CURSOR_API_KEY);
+}
+
+/**
+ * Stringify any thrown value, redacting the active API key. Unwraps Error.cause
+ * one level deep — the SDK frequently wraps a network error inside a
+ * `CursorSdkError`, and the inner cause's message is what carries detail.
+ */
+export function redactError(error: unknown): string {
+  if (error instanceof Error) {
+    const parts: string[] = [error.message];
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause instanceof Error && cause.message && cause.message !== error.message) {
+      parts.push(`(cause: ${cause.message})`);
+    }
+    return redactApiKey(parts.join(" "));
+  }
+  return redactApiKey(String(error));
+}

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "./cursor-agent.mjs";
+import { redactError } from "./redact.mjs";
 import type { JobIndexEntry } from "./state.mjs";
 
 /**
@@ -286,8 +287,11 @@ export function renderReviewResult(review: ReviewOutput): string {
   return `${lines.join("\n")}\n`;
 }
 
-/** Consistent error formatting for CLI failures. */
+/**
+ * Consistent error formatting for CLI failures. Scrubs `CURSOR_API_KEY` from
+ * the message before rendering — SDK errors occasionally carry the request URL
+ * (with the key in a query parameter) inside `Error.cause`.
+ */
 export function renderError(error: unknown): string {
-  if (error instanceof Error) return `error: ${error.message}\n`;
-  return `error: ${String(error)}\n`;
+  return `error: ${redactError(error)}\n`;
 }

--- a/plugins/cursor/scripts/lib/retry.mts
+++ b/plugins/cursor/scripts/lib/retry.mts
@@ -1,0 +1,66 @@
+/**
+ * Exponential-backoff retry for short-lived SDK calls (whoami, models.list,
+ * model validation). Streaming `Run`s are intentionally **not** retried — the
+ * SDK manages reconnects internally and re-running the prompt would duplicate
+ * work that may have already started against a partial response.
+ */
+
+export interface RetryOptions {
+  /** Total number of attempts including the first. Default 3. */
+  attempts?: number;
+  /** Initial delay before the second attempt, in ms. Default 200ms. */
+  baseDelayMs?: number;
+  /** Cap on backoff delay between attempts, in ms. Default 4000ms. */
+  maxDelayMs?: number;
+  /**
+   * Decide whether an error is worth another attempt. Defaults to checking
+   * `error.isRetryable === true` — the property the Cursor SDK sets on its
+   * error classes for transient codes (network, 503, 504, 429-with-retry).
+   */
+  shouldRetry?: (error: unknown) => boolean;
+  /**
+   * Sleep implementation; injected by tests so they can drive virtual time
+   * without setTimeout. Defaults to a real `setTimeout` Promise.
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 200;
+const DEFAULT_MAX_DELAY_MS = 4000;
+
+function defaultShouldRetry(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return (error as { isRetryable?: unknown }).isRetryable === true;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` and retry on transient failures with exponential backoff. The error
+ * from the final attempt is rethrown unchanged so callers see the SDK's typed
+ * error (RateLimitError, NetworkError, etc.) rather than a generic wrapper.
+ */
+export async function withRetry<T>(fn: () => Promise<T>, options: RetryOptions = {}): Promise<T> {
+  const attempts = Math.max(1, options.attempts ?? DEFAULT_ATTEMPTS);
+  const base = Math.max(0, options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS);
+  const cap = Math.max(base, options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS);
+  const shouldRetry = options.shouldRetry ?? defaultShouldRetry;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const isLast = attempt === attempts - 1;
+      if (isLast || !shouldRetry(err)) throw err;
+      const delay = Math.min(cap, base * 2 ** attempt);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -457,6 +457,25 @@ describe("Cursor account helpers", () => {
     expect(sdkMocks.cursorMe).toHaveBeenCalledWith({ apiKey: "test-key" });
   });
 
+  it("whoami retries transient errors and resolves on a later attempt", async () => {
+    const transient = Object.assign(new Error("rate limited"), { isRetryable: true });
+    sdkMocks.cursorMe
+      .mockRejectedValueOnce(transient)
+      .mockResolvedValueOnce({ apiKeyName: "test", createdAt: "0" });
+
+    await expect(whoami({ retry: { sleep: async () => undefined } })).resolves.toMatchObject({
+      apiKeyName: "test",
+    });
+    expect(sdkMocks.cursorMe).toHaveBeenCalledTimes(2);
+  });
+
+  it("whoami does not retry non-retryable errors", async () => {
+    const auth = Object.assign(new Error("invalid key"), { isRetryable: false });
+    sdkMocks.cursorMe.mockRejectedValue(auth);
+    await expect(whoami()).rejects.toBe(auth);
+    expect(sdkMocks.cursorMe).toHaveBeenCalledTimes(1);
+  });
+
   it("listModels returns the SDK list", async () => {
     const list: SDKModel[] = [{ id: "composer-2", displayName: "Composer 2" }];
     sdkMocks.modelsList.mockResolvedValue(list);

--- a/tests/unit/lib/job-control.test.mts
+++ b/tests/unit/lib/job-control.test.mts
@@ -120,6 +120,19 @@ describe("state transitions", () => {
     expect(after.error).toBe("boom");
   });
 
+  it("markFailed scrubs CURSOR_API_KEY from the persisted error", () => {
+    const original = process.env.CURSOR_API_KEY;
+    process.env.CURSOR_API_KEY = "key_persistedsecret_98765";
+    try {
+      const job = createJob(stateDir, { type: "task", prompt: "broken" });
+      const after = markFailed(stateDir, job.id, "auth=key_persistedsecret_98765 failed");
+      expect(after.error).toBe("auth=[REDACTED] failed");
+    } finally {
+      if (original === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = original;
+    }
+  });
+
   it("update of a missing id throws", () => {
     expect(() => markFailed(stateDir, "missing-job", "x")).toThrow(/job not found/);
   });
@@ -187,6 +200,19 @@ describe("logJobLine", () => {
     logJobLine(stateDir, job.id, "hello");
     logJobLine(stateDir, job.id, "world\n");
     expect(readJobLog(stateDir, job.id)).toBe("hello\nworld\n");
+  });
+
+  it("scrubs CURSOR_API_KEY from logged lines before they hit disk", () => {
+    const original = process.env.CURSOR_API_KEY;
+    process.env.CURSOR_API_KEY = "key_loglinesecret_55555";
+    try {
+      const job = createJob(stateDir, { type: "task", prompt: "x" });
+      logJobLine(stateDir, job.id, "tool key_loglinesecret_55555 invoked");
+      expect(readJobLog(stateDir, job.id)).toBe("tool [REDACTED] invoked\n");
+    } finally {
+      if (original === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = original;
+    }
   });
 });
 

--- a/tests/unit/lib/redact.test.mts
+++ b/tests/unit/lib/redact.test.mts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  redactApiKey,
+  redactError,
+  redactSecret,
+} from "../../../plugins/cursor/scripts/lib/redact.mjs";
+
+const ORIGINAL_KEY = process.env.CURSOR_API_KEY;
+
+beforeEach(() => {
+  process.env.CURSOR_API_KEY = "key_abcdefghij1234567890";
+});
+
+afterEach(() => {
+  if (ORIGINAL_KEY === undefined) delete process.env.CURSOR_API_KEY;
+  else process.env.CURSOR_API_KEY = ORIGINAL_KEY;
+});
+
+describe("redactSecret", () => {
+  it("replaces every occurrence of the secret", () => {
+    expect(redactSecret("hello key_abcdefghij1234567890 world", "key_abcdefghij1234567890")).toBe(
+      "hello [REDACTED] world",
+    );
+  });
+
+  it("returns the input unchanged when secret is missing or short", () => {
+    expect(redactSecret("hello key", undefined)).toBe("hello key");
+    expect(redactSecret("hello short", "short")).toBe("hello short");
+    expect(redactSecret("hello", "")).toBe("hello");
+  });
+});
+
+describe("redactApiKey", () => {
+  it("scrubs the active CURSOR_API_KEY env var from arbitrary text", () => {
+    expect(redactApiKey("auth=key_abcdefghij1234567890&q=x")).toBe("auth=[REDACTED]&q=x");
+  });
+
+  it("is a no-op when CURSOR_API_KEY is unset", () => {
+    delete process.env.CURSOR_API_KEY;
+    expect(redactApiKey("auth=key_abcdefghij1234567890")).toBe("auth=key_abcdefghij1234567890");
+  });
+});
+
+describe("redactError", () => {
+  it("scrubs the API key from an Error message", () => {
+    const err = new Error("request failed for key_abcdefghij1234567890");
+    expect(redactError(err)).toBe("request failed for [REDACTED]");
+  });
+
+  it("unwraps Error.cause one level deep and scrubs both", () => {
+    const cause = new Error("inner: key_abcdefghij1234567890");
+    const outer = Object.assign(new Error("outer wrap"), { cause });
+    expect(redactError(outer)).toBe("outer wrap (cause: inner: [REDACTED])");
+  });
+
+  it("collapses identical inner cause messages", () => {
+    const cause = new Error("same");
+    const outer = Object.assign(new Error("same"), { cause });
+    expect(redactError(outer)).toBe("same");
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(redactError("plain key_abcdefghij1234567890")).toBe("plain [REDACTED]");
+    expect(redactError(42)).toBe("42");
+  });
+});

--- a/tests/unit/lib/render.test.mts
+++ b/tests/unit/lib/render.test.mts
@@ -209,4 +209,16 @@ describe("renderError", () => {
     expect(renderError("plain")).toBe("error: plain\n");
     expect(renderError(42)).toBe("error: 42\n");
   });
+
+  it("scrubs CURSOR_API_KEY from error messages", () => {
+    const original = process.env.CURSOR_API_KEY;
+    process.env.CURSOR_API_KEY = "key_supersecret_token_12345";
+    try {
+      const err = new Error("auth failed for key_supersecret_token_12345");
+      expect(renderError(err)).toBe("error: auth failed for [REDACTED]\n");
+    } finally {
+      if (original === undefined) delete process.env.CURSOR_API_KEY;
+      else process.env.CURSOR_API_KEY = original;
+    }
+  });
 });

--- a/tests/unit/lib/retry.test.mts
+++ b/tests/unit/lib/retry.test.mts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { withRetry } from "../../../plugins/cursor/scripts/lib/retry.mjs";
+
+const recordingSleep = (delays: number[]) => async (ms: number) => {
+  delays.push(ms);
+};
+
+describe("withRetry", () => {
+  it("returns the result of the first attempt when it succeeds", async () => {
+    const fn = vi.fn(async () => "ok");
+    await expect(withRetry(fn)).resolves.toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries retryable errors with exponential backoff and resolves once one succeeds", async () => {
+    const delays: number[] = [];
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(Object.assign(new Error("net1"), { isRetryable: true }))
+      .mockRejectedValueOnce(Object.assign(new Error("net2"), { isRetryable: true }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withRetry(fn, { sleep: recordingSleep(delays) });
+
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(delays).toEqual([200, 400]); // base, base*2
+  });
+
+  it("rethrows after exhausting the retry budget", async () => {
+    const error = Object.assign(new Error("rate limited"), { isRetryable: true });
+    const fn = vi.fn(async () => {
+      throw error;
+    });
+    await expect(withRetry(fn, { attempts: 3, sleep: async () => undefined })).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry non-retryable errors", async () => {
+    const error = Object.assign(new Error("auth"), { isRetryable: false });
+    const fn = vi.fn(async () => {
+      throw error;
+    });
+    await expect(withRetry(fn)).rejects.toBe(error);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats absent isRetryable as non-retryable", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("plain");
+    });
+    await expect(withRetry(fn)).rejects.toThrow("plain");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps backoff at maxDelayMs", async () => {
+    const delays: number[] = [];
+    const fn = vi.fn(async () => {
+      throw Object.assign(new Error("e"), { isRetryable: true });
+    });
+    await expect(
+      withRetry(fn, {
+        attempts: 5,
+        baseDelayMs: 1000,
+        maxDelayMs: 1500,
+        sleep: recordingSleep(delays),
+      }),
+    ).rejects.toThrow();
+    expect(delays).toEqual([1000, 1500, 1500, 1500]);
+  });
+
+  it("honors a custom shouldRetry predicate", async () => {
+    let calls = 0;
+    const fn = vi.fn(async () => {
+      calls += 1;
+      throw new Error(`attempt-${calls}`);
+    });
+    await expect(
+      withRetry(fn, {
+        attempts: 4,
+        sleep: async () => undefined,
+        shouldRetry: (err) => (err as Error).message !== "attempt-2",
+      }),
+    ).rejects.toThrow("attempt-2");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
- README.md + CONTRIBUTING.md cover install, slash commands, dev loop, release process
- lib/redact.mts: scrub CURSOR_API_KEY from renderError, markFailed (job json), logJobLine (per-job logs)
- lib/retry.mts: exponential backoff for short-lived SDK calls; whoami/listModels/validateModel honor it
- .husky/commit-msg: inline conventional-commits enforcement (no commitlint dep)
- .github/dependabot.yml: weekly npm + monthly actions, dev-deps grouped
- PLAN.md: Phase 7 boxes ticked; npm-publish bullet struck through (private package)

217 tests pass + 3 live-integration tests auto-skip without CURSOR_API_KEY.