### PR TITLE
feat(resume): Phase 8 — /cursor:resume command for durable agents

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -584,6 +584,81 @@ Behavior:
 
 ---
 
+## Phase 8: `/cursor:resume` Command
+
+Surface `Agent.resume()` as a first-class slash command. Until Phase 8, the
+durable-agent capability was reachable only through `task --resume-last` —
+which always picked the most recent agent and offered no discovery story.
+
+### 8.1 Job-control discovery helper
+
+- [x] `findRecentTaskAgents(stateDir, limit?, lookahead?)` in `lib/job-control.mts`
+      returns `{ jobId, agentId, createdAt, summary? }[]` for the most-recent
+      task jobs that have a stamped `agentId`. Reads at most `lookahead` job
+      json files to find `limit` results.
+- [x] `task --resume-last` rewired to use the new helper (drops its inline
+      `findResumeAgentId`).
+
+### 8.2 `resume` Subcommand
+
+```bash
+cursor-companion resume <agent-id> <prompt> [flags]
+cursor-companion resume --last <prompt> [flags]
+cursor-companion resume --list [--limit <n>] [--json]
+```
+
+- [x] `commands/resume.mts` handler with parser that accepts either a
+      positional `<agent-id> <prompt>` pair, `--last <prompt>`, or
+      `--list` (no prompt; returns and exits)
+- [x] `--list` reads `findRecentTaskAgents(stateDir, limit)` and renders
+      either a fixed-width table (`AGENT-ID / JOB-ID / CREATED / SUMMARY`)
+      or a JSON array via `--json`
+- [x] Run path mirrors `task` (write policy, `buildPrompt`, streaming via
+      `toAgentEvents` + `renderStreamEvent`, job tracking via `markRunning`/
+      `markFinished`/`markFailed`, agent dispose in `finally`)
+- [x] Inherits `--write` / `--background` / `--force` / `--cloud` /
+      `--model` / `--timeout` / `--json` from the task surface
+- [x] Stamps `metadata: { resumed: true, resumedAgentId }` on the new job
+      record so `/cursor:status <id>` shows the resume lineage
+- [x] `Agent.resume` failures are recorded via `markFailed` before re-throw
+      so the job record reflects the failed attempt
+
+### 8.3 Plugin Wiring
+
+- [x] `cursor-companion.mts` router routes `resume` → `runResume` and adds
+      it to the help banner
+- [x] `commands/resume.md` slash command markdown (`disable-model-invocation:
+      true`, `allowed-tools: Bash(node:*)`) shells out and surfaces output
+      verbatim — same pattern as `/cursor:status`, `/cursor:cancel`,
+      `/cursor:result`
+- [x] `--list` is the discovery surface; `/cursor:status` table left
+      unchanged (no `agentId` column) to avoid a schema migration on
+      `JobIndexEntry`
+
+### 8.4 Tests
+
+- [x] `tests/unit/lib/job-control.test.mts` — `findRecentTaskAgents`:
+      empty / no agentId, ordering newest-first, `limit` cap, ignores
+      non-task types
+- [x] `tests/cli/resume.test.mts` — explicit agent-id, `--last`,
+      `--last` with no agents, `--list` (text + json + empty), `--write`,
+      `--background`, missing positional, missing prompt, conflicting
+      `--list --last`, `--limit` without `--list`, non-finished exit code,
+      `Agent.resume` rejection persisting a failed job
+- [x] `tests/unit/cli/companion.test.mts` — router help/usage smoke tests
+      for the new subcommand
+
+### 8.5 Documentation
+
+- [x] `README.md` commands table + a new `resume` flags table
+- [x] `PLAN.md` — this section
+
+**Exit criteria**: `/cursor:resume` discovers and reattaches to durable
+agents from any prior session in the workspace; tests cover the full flag
+surface and the failure paths.
+
+---
+
 ## Implementation Order
 
 ```
@@ -594,6 +669,7 @@ Phase 4 (plugin wiring)   ████████░░  ~3 hours
 Phase 5 (testing)         ██████████  ~4 hours
 Phase 6 (review gate)     ██████████  ~2 hours (v2)
 Phase 7 (polish/publish)  ██████████  ~3 hours
+Phase 8 (resume command)  ██████████  ~1 hour
 ```
 
 Phases 1–4 are the critical path. Phase 5 runs alongside 3–4 (write tests as you build). Phase 6 is a clean follow-up. Phase 7 is final polish.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ targets Cursor instead of Codex.
 |---------------|--------------|
 | `/cursor:setup` | Verify Node, `CURSOR_API_KEY`, account, model catalog. Toggle the Stop review gate. |
 | `/cursor:task <prompt>` | Send an implementation task to Cursor (read-only by default; pass `--write` to allow edits). |
+| `/cursor:resume <agent-id\|--last\|--list> [prompt]` | Reattach to an existing Cursor agent and continue the conversation. |
 | `/cursor:review` | Structured review of the working-tree diff (`approve` / `needs-attention` + findings). |
 | `/cursor:adversarial-review` | Same shape, but the agent challenges design choices instead of hunting defects. |
 | `/cursor:status [job-id]` | List recent jobs (or show one in detail). |
@@ -83,6 +84,21 @@ The gate is per-workspace and disabled by default. State lives in
 | `--model <id>` | Override the default model (`composer-2`). |
 | `--timeout <ms>` | Cancel if the run exceeds this duration. |
 | `--json` | Emit the final result as a single JSON line. |
+
+`resume`:
+
+| Flag | Effect |
+|------|--------|
+| `--last` | Resume the most recent task agent for this workspace (skip `<agent-id>`). |
+| `--list` | Print known agent ids for this workspace, then exit. |
+| `--limit <n>` | With `--list`: cap the number of rows (default 10). |
+| `--write`, `--background`, `--force`, `--cloud`, `--model <id>`, `--timeout <ms>`, `--json` | Same as `task`. |
+
+```text
+/cursor:resume --list                       # discover agent ids
+/cursor:resume agent-abc123 "now do X"      # continue a specific agent
+/cursor:resume --last "and then Y" --write  # follow up on the most recent run
+```
 
 `review` / `adversarial-review`:
 

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -1,0 +1,28 @@
+---
+description: Reattach to an existing Cursor agent and continue the conversation.
+allowed-tools: Bash(node:*)
+disable-model-invocation: true
+---
+
+# /cursor:resume
+
+```bash
+node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs resume $ARGUMENTS
+```
+
+Resume a durable Cursor agent. The agent keeps the context from prior runs,
+so follow-up prompts skip rebuilding the workspace map.
+
+Usage:
+
+- `<agent-id> <prompt>` — resume a specific agent with a follow-up prompt
+- `--last <prompt>`     — resume the most recent task agent for this workspace
+- `--list`              — print known agent ids; supports `--limit <n>` and `--json`
+
+Inherits the same flags as `/cursor:task`: `--write`, `--background`, `--force`,
+`--cloud`, `--model <id>`, `--timeout <ms>`, `--json`.
+
+Default policy is read-only — pass `--write` to allow file modifications.
+
+Surface the output verbatim. If `--list` returns `(no resumable agents)`, the
+workspace has no recorded agentIds yet — start with `/cursor:task` first.

--- a/plugins/cursor/scripts/commands/resume.mts
+++ b/plugins/cursor/scripts/commands/resume.mts
@@ -1,28 +1,21 @@
-import type { ModelSelection, SDKMessage } from "@cursor/sdk";
+import type { ModelSelection } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
   buildPrompt,
   type CursorAgentOptions,
-  disposeAgent,
   resumeAgent,
-  sendTask,
-  toAgentEvents,
+  writePolicyText,
 } from "../lib/cursor-agent.mjs";
 import { detectCloudRepository } from "../lib/git.mjs";
 import {
   createJob,
   findRecentTaskAgents,
-  logJobLine,
   markFailed,
-  markFinished,
-  markRunning,
   type RecentTaskAgent,
-  registerActiveRun,
-  unregisterActiveRun,
 } from "../lib/job-control.mjs";
-import { renderStreamEvent } from "../lib/render.mjs";
+import { runAgentTaskBackground, runAgentTaskForeground } from "../lib/run-agent-task.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
@@ -223,10 +216,7 @@ export async function runResume(args: readonly string[], io: CommandIO): Promise
     agentId = flags.target.agentId;
   }
 
-  const writePolicy = flags.write
-    ? "You may modify files in the workspace."
-    : "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
-  const fullPrompt = buildPrompt(`${writePolicy}\n\n${flags.prompt}`);
+  const fullPrompt = buildPrompt(`${writePolicyText(flags.write)}\n\n${flags.prompt}`);
 
   const job = createJob(stateDir, {
     type: "task",
@@ -243,85 +233,24 @@ export async function runResume(args: readonly string[], io: CommandIO): Promise
     throw err;
   }
 
+  const runFlags = {
+    ...(flags.timeoutMs !== undefined ? { timeoutMs: flags.timeoutMs } : {}),
+    ...(flags.force ? { force: true } : {}),
+    json: flags.json,
+  };
+
   if (flags.background) {
-    detachBackgroundRun(agent, fullPrompt, flags, stateDir, job.id);
+    runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });
     io.stdout.write(`${job.id}\n`);
     return 0;
   }
 
-  try {
-    const result = await sendTask(agent, fullPrompt, {
-      ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
-      ...(flags.force ? { force: true } : {}),
-      onRunStart: (run) => {
-        markRunning(stateDir, job.id, { agentId: run.agentId, runId: run.id });
-        registerActiveRun(job.id, run);
-      },
-      onEvent: (event: SDKMessage) => {
-        for (const ae of toAgentEvents(event)) {
-          const rendered = renderStreamEvent(ae, { quietStatus: true });
-          if (rendered.stdout) io.stdout.write(rendered.stdout);
-          if (rendered.stderr) {
-            io.stderr.write(rendered.stderr);
-            logJobLine(stateDir, job.id, rendered.stderr.replace(/\n$/, ""));
-          }
-        }
-      },
-    });
-
-    markFinished(stateDir, job.id, result);
-
-    if (flags.json) {
-      io.stdout.write(`${JSON.stringify({ jobId: job.id, ...result })}\n`);
-    } else if (!result.output.endsWith("\n")) {
-      io.stdout.write("\n");
-    }
-
-    return result.status === "finished" ? 0 : 1;
-  } catch (err) {
-    markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
-    throw err;
-  } finally {
-    unregisterActiveRun(job.id);
-    await disposeAgent(agent).catch(() => undefined);
-  }
-}
-
-/**
- * Background mode: same shape as task.detachBackgroundRun. Routes both stdout
- * and stderr renderings into the per-job log so the caller (which has already
- * exited) can replay them via `/cursor:result --log`.
- */
-function detachBackgroundRun(
-  agent: Awaited<ReturnType<typeof resumeAgent>>,
-  prompt: string,
-  flags: RunFlags,
-  stateDir: string,
-  jobId: string,
-): void {
-  void (async () => {
-    try {
-      const result = await sendTask(agent, prompt, {
-        ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
-        ...(flags.force ? { force: true } : {}),
-        onRunStart: (run) => {
-          markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
-          registerActiveRun(jobId, run);
-        },
-        onEvent: (event: SDKMessage) => {
-          for (const ae of toAgentEvents(event)) {
-            const rendered = renderStreamEvent(ae);
-            if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
-            if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
-          }
-        },
-      });
-      markFinished(stateDir, jobId, result);
-    } catch (err) {
-      markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
-    } finally {
-      unregisterActiveRun(jobId);
-      await disposeAgent(agent).catch(() => undefined);
-    }
-  })();
+  return runAgentTaskForeground({
+    agent,
+    prompt: fullPrompt,
+    flags: runFlags,
+    io,
+    stateDir,
+    jobId: job.id,
+  });
 }

--- a/plugins/cursor/scripts/commands/resume.mts
+++ b/plugins/cursor/scripts/commands/resume.mts
@@ -1,20 +1,20 @@
-import type { ModelSelection } from "@cursor/sdk";
+import type { ModelSelection, SDKAgent } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
+  buildAgentOptionsFromFlags,
   buildPrompt,
-  type CursorAgentOptions,
   resumeAgent,
   writePolicyText,
 } from "../lib/cursor-agent.mjs";
-import { detectCloudRepository } from "../lib/git.mjs";
 import {
   createJob,
   findRecentTaskAgents,
   markFailed,
   type RecentTaskAgent,
 } from "../lib/job-control.mjs";
+import { ageFromIso, compactText } from "../lib/render.mjs";
 import { runAgentTaskBackground, runAgentTaskForeground } from "../lib/run-agent-task.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
@@ -143,35 +143,25 @@ function parseFlags(args: readonly string[]): ResumeFlags {
   return flags;
 }
 
-function buildAgentOptionsForFlags(flags: RunFlags, workspaceRoot: string): CursorAgentOptions {
-  const opts: CursorAgentOptions = { cwd: workspaceRoot };
-  if (flags.model) opts.model = flags.model;
-  if (flags.cloud) {
-    opts.mode = "cloud";
-    opts.cloudRepo = detectCloudRepository(workspaceRoot);
-  }
-  return opts;
-}
-
-function renderListText(rows: RecentTaskAgent[]): string {
+function renderListText(rows: RecentTaskAgent[], now: number = Date.now()): string {
   if (rows.length === 0) return "(no resumable agents)\n";
+  const formatted = rows.map((r) => ({
+    agentId: r.agentId,
+    jobId: r.jobId,
+    age: ageFromIso(r.createdAt, now),
+    summary: r.summary ? compactText(r.summary).slice(0, 60) : "",
+  }));
   const widths = {
-    agentId: "agent-id".length,
-    jobId: "job-id".length,
-    created: "created".length,
+    agentId: Math.max("agent-id".length, ...formatted.map((r) => r.agentId.length)),
+    jobId: Math.max("job-id".length, ...formatted.map((r) => r.jobId.length)),
+    age: Math.max("age".length, ...formatted.map((r) => r.age.length)),
   };
-  for (const r of rows) {
-    widths.agentId = Math.max(widths.agentId, r.agentId.length);
-    widths.jobId = Math.max(widths.jobId, r.jobId.length);
-    widths.created = Math.max(widths.created, r.createdAt.length);
-  }
-  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"JOB-ID".padEnd(widths.jobId)}  ${"CREATED".padEnd(widths.created)}  SUMMARY`;
-  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.jobId)}  ${"-".repeat(widths.created)}  -------`;
-  const body = rows
-    .map((r) => {
-      const line = `${r.agentId.padEnd(widths.agentId)}  ${r.jobId.padEnd(widths.jobId)}  ${r.createdAt.padEnd(widths.created)}  ${r.summary ?? ""}`;
-      return line.trimEnd();
-    })
+  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"JOB-ID".padEnd(widths.jobId)}  ${"AGE".padEnd(widths.age)}  SUMMARY`;
+  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.jobId)}  ${"-".repeat(widths.age)}  -------`;
+  const body = formatted
+    .map((r) =>
+      `${r.agentId.padEnd(widths.agentId)}  ${r.jobId.padEnd(widths.jobId)}  ${r.age.padEnd(widths.age)}  ${r.summary}`.trimEnd(),
+    )
     .join("\n");
   return `${header}\n${separator}\n${body}\n`;
 }
@@ -221,23 +211,19 @@ export async function runResume(args: readonly string[], io: CommandIO): Promise
   const job = createJob(stateDir, {
     type: "task",
     prompt: flags.prompt,
-    metadata: { resumed: true, resumedAgentId: agentId },
+    metadata: { resumedAgentId: agentId },
   });
 
-  let agent: Awaited<ReturnType<typeof resumeAgent>>;
+  let agent: SDKAgent;
   try {
-    agent = await resumeAgent(agentId, buildAgentOptionsForFlags(flags, workspaceRoot));
+    agent = await resumeAgent(agentId, buildAgentOptionsFromFlags(workspaceRoot, flags));
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     markFailed(stateDir, job.id, `resume failed for ${agentId}: ${message}`);
     throw err;
   }
 
-  const runFlags = {
-    ...(flags.timeoutMs !== undefined ? { timeoutMs: flags.timeoutMs } : {}),
-    ...(flags.force ? { force: true } : {}),
-    json: flags.json,
-  };
+  const runFlags = { timeoutMs: flags.timeoutMs, force: flags.force, json: flags.json };
 
   if (flags.background) {
     runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });

--- a/plugins/cursor/scripts/commands/resume.mts
+++ b/plugins/cursor/scripts/commands/resume.mts
@@ -5,13 +5,12 @@ import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
   buildPrompt,
   type CursorAgentOptions,
-  createAgent,
   disposeAgent,
   resumeAgent,
   sendTask,
   toAgentEvents,
 } from "../lib/cursor-agent.mjs";
-import { detectCloudRepository, getBranch, getRecentCommits } from "../lib/git.mjs";
+import { detectCloudRepository } from "../lib/git.mjs";
 import {
   createJob,
   findRecentTaskAgents,
@@ -19,6 +18,7 @@ import {
   markFailed,
   markFinished,
   markRunning,
+  type RecentTaskAgent,
   registerActiveRun,
   unregisterActiveRun,
 } from "../lib/job-control.mjs";
@@ -26,28 +26,41 @@ import { renderStreamEvent } from "../lib/render.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
-const HELP = `cursor-companion task <prompt> [flags]
+const HELP = `cursor-companion resume <agent-id> <prompt> [flags]
+cursor-companion resume --last <prompt> [flags]
+cursor-companion resume --list [--limit <n>] [--json]
 
-Delegate an implementation task to a Cursor agent. Streams events to stdout
-(assistant text) and stderr (annotations).
+Reattach to an existing Cursor agent and continue the conversation. The agent
+keeps its prior context, so follow-up prompts are cheaper than starting fresh.
 
 flags:
+  --last               Resume the most recent task agent (no agent-id needed)
+  --list               Print known agent ids from this workspace, then exit
+  --limit <n>          With --list: cap the number of rows (default 10)
   --write              Allow file modifications (default: read-only)
-  --resume-last        Resume the most-recent task agent for this workspace
   --background         Start the run and exit, returning the job id
   --force              Expire any wedged active local run before sending
   --cloud              Use Cursor cloud against the detected GitHub origin
-  --model <id>         Override the default model
-  -m <id>
+  --model <id>, -m
   --timeout <ms>       Cancel the run if it exceeds this duration
   --json               Print the final result as JSON (single line)
   --help, -h
 `;
 
-interface TaskFlags {
+const DEFAULT_LIST_LIMIT = 10;
+
+interface ListFlags {
+  kind: "list";
+  limit: number;
+  json: boolean;
+}
+
+interface RunFlags {
+  kind: "run";
   prompt: string;
+  /** Either an explicit id (positional) or "last" — resolved at execution time. */
+  target: { kind: "id"; agentId: string } | { kind: "last" };
   write: boolean;
-  resumeLast: boolean;
   background: boolean;
   force: boolean;
   cloud: boolean;
@@ -56,13 +69,17 @@ interface TaskFlags {
   json: boolean;
 }
 
+type ResumeFlags = ListFlags | RunFlags;
+
 class HelpRequested extends Error {}
 
-function parseFlags(args: readonly string[]): TaskFlags {
+function parseFlags(args: readonly string[]): ResumeFlags {
   const parsed = parseArgs(args, {
     long: {
+      last: "boolean",
+      list: "boolean",
+      limit: "string",
       write: "boolean",
-      "resume-last": "boolean",
       background: "boolean",
       force: "boolean",
       cloud: "boolean",
@@ -75,17 +92,52 @@ function parseFlags(args: readonly string[]): TaskFlags {
   });
   if (bool(parsed, "help")) throw new HelpRequested();
 
-  const prompt = parsed.positionals.join(" ").trim();
-  if (!prompt) throw new UsageError("task requires a prompt argument");
+  const last = bool(parsed, "last");
+  const list = bool(parsed, "list");
+  const json = bool(parsed, "json");
 
-  const flags: TaskFlags = {
+  if (list) {
+    if (last) throw new UsageError("--list and --last are mutually exclusive");
+    let limit = DEFAULT_LIST_LIMIT;
+    const limitArg = optionalString(parsed, "limit");
+    if (limitArg !== undefined) {
+      const n = Number(limitArg);
+      if (!Number.isFinite(n) || n < 0) throw new UsageError(`invalid --limit: ${limitArg}`);
+      limit = Math.floor(n);
+    }
+    return { kind: "list", limit, json };
+  }
+
+  if (optionalString(parsed, "limit") !== undefined) {
+    throw new UsageError("--limit requires --list");
+  }
+
+  const positionals = [...parsed.positionals];
+  let target: RunFlags["target"];
+  if (last) {
+    target = { kind: "last" };
+  } else {
+    const agentId = positionals.shift();
+    if (!agentId) {
+      throw new UsageError(
+        "resume requires <agent-id> (or --last to pick the most recent, or --list to discover ids)",
+      );
+    }
+    target = { kind: "id", agentId };
+  }
+
+  const prompt = positionals.join(" ").trim();
+  if (!prompt) throw new UsageError("resume requires a prompt to send to the agent");
+
+  const flags: RunFlags = {
+    kind: "run",
     prompt,
+    target,
     write: bool(parsed, "write"),
-    resumeLast: bool(parsed, "resume-last"),
     background: bool(parsed, "background"),
     force: bool(parsed, "force"),
     cloud: bool(parsed, "cloud"),
-    json: bool(parsed, "json"),
+    json,
   };
   const modelId = optionalString(parsed, "model");
   if (modelId) flags.model = { id: modelId };
@@ -98,21 +150,7 @@ function parseFlags(args: readonly string[]): TaskFlags {
   return flags;
 }
 
-function buildContextHeader(workspaceRoot: string): string {
-  const lines: string[] = [];
-  const branch = getBranch(workspaceRoot);
-  if (branch) lines.push(`Current branch: ${branch}`);
-  const commits = getRecentCommits(workspaceRoot, 5);
-  if (commits.length > 0) {
-    lines.push("Recent commits:");
-    for (const c of commits) {
-      lines.push(`  ${c.hash.slice(0, 8)} ${c.subject}`);
-    }
-  }
-  return lines.join("\n");
-}
-
-function buildAgentOptionsForFlags(flags: TaskFlags, workspaceRoot: string): CursorAgentOptions {
+function buildAgentOptionsForFlags(flags: RunFlags, workspaceRoot: string): CursorAgentOptions {
   const opts: CursorAgentOptions = { cwd: workspaceRoot };
   if (flags.model) opts.model = flags.model;
   if (flags.cloud) {
@@ -122,12 +160,31 @@ function buildAgentOptionsForFlags(flags: TaskFlags, workspaceRoot: string): Cur
   return opts;
 }
 
-function findResumeAgentId(stateDir: string): string | undefined {
-  return findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+function renderListText(rows: RecentTaskAgent[]): string {
+  if (rows.length === 0) return "(no resumable agents)\n";
+  const widths = {
+    agentId: "agent-id".length,
+    jobId: "job-id".length,
+    created: "created".length,
+  };
+  for (const r of rows) {
+    widths.agentId = Math.max(widths.agentId, r.agentId.length);
+    widths.jobId = Math.max(widths.jobId, r.jobId.length);
+    widths.created = Math.max(widths.created, r.createdAt.length);
+  }
+  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"JOB-ID".padEnd(widths.jobId)}  ${"CREATED".padEnd(widths.created)}  SUMMARY`;
+  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.jobId)}  ${"-".repeat(widths.created)}  -------`;
+  const body = rows
+    .map((r) => {
+      const line = `${r.agentId.padEnd(widths.agentId)}  ${r.jobId.padEnd(widths.jobId)}  ${r.createdAt.padEnd(widths.created)}  ${r.summary ?? ""}`;
+      return line.trimEnd();
+    })
+    .join("\n");
+  return `${header}\n${separator}\n${body}\n`;
 }
 
-export async function runTask(args: readonly string[], io: CommandIO): Promise<ExitCode> {
-  let flags: TaskFlags;
+export async function runResume(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  let flags: ResumeFlags;
   try {
     flags = parseFlags(args);
   } catch (err) {
@@ -140,38 +197,50 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
 
   const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
+
+  if (flags.kind === "list") {
+    const stateDir = resolveStateDir(workspaceRoot);
+    const rows = findRecentTaskAgents(stateDir, flags.limit);
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    } else {
+      io.stdout.write(renderListText(rows));
+    }
+    return 0;
+  }
+
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+
+  let agentId: string;
+  if (flags.target.kind === "last") {
+    const top = findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+    if (!top) {
+      io.stderr.write("no previous task agent to resume\n");
+      return 1;
+    }
+    agentId = top;
+  } else {
+    agentId = flags.target.agentId;
+  }
 
   const writePolicy = flags.write
     ? "You may modify files in the workspace."
     : "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
-  // Skip local-workspace context in cloud mode: the cloud agent runs against
-  // `startingRef` of the remote, so local uncommitted state would mislead it.
-  const contextHeader = flags.cloud ? "" : buildContextHeader(workspaceRoot);
-  const sections = [contextHeader, writePolicy, flags.prompt].filter((s) => s.length > 0);
-  const fullPrompt = buildPrompt(sections.join("\n\n"));
+  const fullPrompt = buildPrompt(`${writePolicy}\n\n${flags.prompt}`);
 
-  const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
+  const job = createJob(stateDir, {
+    type: "task",
+    prompt: flags.prompt,
+    metadata: { resumed: true, resumedAgentId: agentId },
+  });
 
-  const agentOpts = buildAgentOptionsForFlags(flags, workspaceRoot);
-  let agent: Awaited<ReturnType<typeof createAgent>>;
-  if (flags.resumeLast) {
-    const agentId = findResumeAgentId(stateDir);
-    if (!agentId) {
-      io.stderr.write("no previous task agent to resume — starting fresh\n");
-      agent = await createAgent(agentOpts);
-    } else {
-      try {
-        agent = await resumeAgent(agentId, agentOpts);
-      } catch (err) {
-        io.stderr.write(
-          `resume failed (${err instanceof Error ? err.message : String(err)}); starting fresh\n`,
-        );
-        agent = await createAgent(agentOpts);
-      }
-    }
-  } else {
-    agent = await createAgent(agentOpts);
+  let agent: Awaited<ReturnType<typeof resumeAgent>>;
+  try {
+    agent = await resumeAgent(agentId, buildAgentOptionsForFlags(flags, workspaceRoot));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    markFailed(stateDir, job.id, `resume failed for ${agentId}: ${message}`);
+    throw err;
   }
 
   if (flags.background) {
@@ -219,18 +288,14 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
 }
 
 /**
- * Background mode: kick off the run, persist its events to the per-job log,
- * and return immediately. The CLI process keeps running until the IIFE
- * resolves (Node won't exit while a Promise is pending), so the run
- * actually completes — but stdout was already returned to the user. Cancel
- * of a background run from a different CLI invocation falls back to
- * `run-not-active` + persisted-mark since the Run object is in this process
- * only.
+ * Background mode: same shape as task.detachBackgroundRun. Routes both stdout
+ * and stderr renderings into the per-job log so the caller (which has already
+ * exited) can replay them via `/cursor:result --log`.
  */
 function detachBackgroundRun(
-  agent: Awaited<ReturnType<typeof createAgent>>,
+  agent: Awaited<ReturnType<typeof resumeAgent>>,
   prompt: string,
-  flags: TaskFlags,
+  flags: RunFlags,
   stateDir: string,
   jobId: string,
 ): void {

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -1,4 +1,4 @@
-import type { ModelSelection, SDKMessage } from "@cursor/sdk";
+import type { ModelSelection } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
@@ -6,23 +6,12 @@ import {
   buildPrompt,
   type CursorAgentOptions,
   createAgent,
-  disposeAgent,
   resumeAgent,
-  sendTask,
-  toAgentEvents,
+  writePolicyText,
 } from "../lib/cursor-agent.mjs";
 import { detectCloudRepository, getBranch, getRecentCommits } from "../lib/git.mjs";
-import {
-  createJob,
-  findRecentTaskAgents,
-  logJobLine,
-  markFailed,
-  markFinished,
-  markRunning,
-  registerActiveRun,
-  unregisterActiveRun,
-} from "../lib/job-control.mjs";
-import { renderStreamEvent } from "../lib/render.mjs";
+import { createJob, findRecentTaskAgents } from "../lib/job-control.mjs";
+import { runAgentTaskBackground, runAgentTaskForeground } from "../lib/run-agent-task.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
@@ -142,13 +131,12 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
 
-  const writePolicy = flags.write
-    ? "You may modify files in the workspace."
-    : "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
   // Skip local-workspace context in cloud mode: the cloud agent runs against
   // `startingRef` of the remote, so local uncommitted state would mislead it.
   const contextHeader = flags.cloud ? "" : buildContextHeader(workspaceRoot);
-  const sections = [contextHeader, writePolicy, flags.prompt].filter((s) => s.length > 0);
+  const sections = [contextHeader, writePolicyText(flags.write), flags.prompt].filter(
+    (s) => s.length > 0,
+  );
   const fullPrompt = buildPrompt(sections.join("\n\n"));
 
   const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
@@ -174,89 +162,24 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
     agent = await createAgent(agentOpts);
   }
 
+  const runFlags = {
+    ...(flags.timeoutMs !== undefined ? { timeoutMs: flags.timeoutMs } : {}),
+    ...(flags.force ? { force: true } : {}),
+    json: flags.json,
+  };
+
   if (flags.background) {
-    detachBackgroundRun(agent, fullPrompt, flags, stateDir, job.id);
+    runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });
     io.stdout.write(`${job.id}\n`);
     return 0;
   }
 
-  try {
-    const result = await sendTask(agent, fullPrompt, {
-      ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
-      ...(flags.force ? { force: true } : {}),
-      onRunStart: (run) => {
-        markRunning(stateDir, job.id, { agentId: run.agentId, runId: run.id });
-        registerActiveRun(job.id, run);
-      },
-      onEvent: (event: SDKMessage) => {
-        for (const ae of toAgentEvents(event)) {
-          const rendered = renderStreamEvent(ae, { quietStatus: true });
-          if (rendered.stdout) io.stdout.write(rendered.stdout);
-          if (rendered.stderr) {
-            io.stderr.write(rendered.stderr);
-            logJobLine(stateDir, job.id, rendered.stderr.replace(/\n$/, ""));
-          }
-        }
-      },
-    });
-
-    markFinished(stateDir, job.id, result);
-
-    if (flags.json) {
-      io.stdout.write(`${JSON.stringify({ jobId: job.id, ...result })}\n`);
-    } else if (!result.output.endsWith("\n")) {
-      io.stdout.write("\n");
-    }
-
-    return result.status === "finished" ? 0 : 1;
-  } catch (err) {
-    markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
-    throw err;
-  } finally {
-    unregisterActiveRun(job.id);
-    await disposeAgent(agent).catch(() => undefined);
-  }
-}
-
-/**
- * Background mode: kick off the run, persist its events to the per-job log,
- * and return immediately. The CLI process keeps running until the IIFE
- * resolves (Node won't exit while a Promise is pending), so the run
- * actually completes — but stdout was already returned to the user. Cancel
- * of a background run from a different CLI invocation falls back to
- * `run-not-active` + persisted-mark since the Run object is in this process
- * only.
- */
-function detachBackgroundRun(
-  agent: Awaited<ReturnType<typeof createAgent>>,
-  prompt: string,
-  flags: TaskFlags,
-  stateDir: string,
-  jobId: string,
-): void {
-  void (async () => {
-    try {
-      const result = await sendTask(agent, prompt, {
-        ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
-        ...(flags.force ? { force: true } : {}),
-        onRunStart: (run) => {
-          markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
-          registerActiveRun(jobId, run);
-        },
-        onEvent: (event: SDKMessage) => {
-          for (const ae of toAgentEvents(event)) {
-            const rendered = renderStreamEvent(ae);
-            if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
-            if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
-          }
-        },
-      });
-      markFinished(stateDir, jobId, result);
-    } catch (err) {
-      markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
-    } finally {
-      unregisterActiveRun(jobId);
-      await disposeAgent(agent).catch(() => undefined);
-    }
-  })();
+  return runAgentTaskForeground({
+    agent,
+    prompt: fullPrompt,
+    flags: runFlags,
+    io,
+    stateDir,
+    jobId: job.id,
+  });
 }

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -1,15 +1,16 @@
-import type { ModelSelection } from "@cursor/sdk";
+import type { ModelSelection, SDKAgent } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
+  buildAgentOptionsFromFlags,
   buildPrompt,
   type CursorAgentOptions,
   createAgent,
   resumeAgent,
   writePolicyText,
 } from "../lib/cursor-agent.mjs";
-import { detectCloudRepository, getBranch, getRecentCommits } from "../lib/git.mjs";
+import { getBranch, getRecentCommits } from "../lib/git.mjs";
 import { createJob, findRecentTaskAgents } from "../lib/job-control.mjs";
 import { runAgentTaskBackground, runAgentTaskForeground } from "../lib/run-agent-task.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
@@ -101,18 +102,25 @@ function buildContextHeader(workspaceRoot: string): string {
   return lines.join("\n");
 }
 
-function buildAgentOptionsForFlags(flags: TaskFlags, workspaceRoot: string): CursorAgentOptions {
-  const opts: CursorAgentOptions = { cwd: workspaceRoot };
-  if (flags.model) opts.model = flags.model;
-  if (flags.cloud) {
-    opts.mode = "cloud";
-    opts.cloudRepo = detectCloudRepository(workspaceRoot);
+async function resolveTaskAgent(
+  flags: TaskFlags,
+  stateDir: string,
+  agentOpts: CursorAgentOptions,
+  io: CommandIO,
+): Promise<SDKAgent> {
+  if (!flags.resumeLast) return createAgent(agentOpts);
+  const agentId = findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+  if (!agentId) {
+    io.stderr.write("no previous task agent to resume — starting fresh\n");
+    return createAgent(agentOpts);
   }
-  return opts;
-}
-
-function findResumeAgentId(stateDir: string): string | undefined {
-  return findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+  try {
+    return await resumeAgent(agentId, agentOpts);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    io.stderr.write(`resume failed (${message}); starting fresh\n`);
+    return createAgent(agentOpts);
+  }
 }
 
 export async function runTask(args: readonly string[], io: CommandIO): Promise<ExitCode> {
@@ -141,32 +149,9 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
 
   const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
 
-  const agentOpts = buildAgentOptionsForFlags(flags, workspaceRoot);
-  let agent: Awaited<ReturnType<typeof createAgent>>;
-  if (flags.resumeLast) {
-    const agentId = findResumeAgentId(stateDir);
-    if (!agentId) {
-      io.stderr.write("no previous task agent to resume — starting fresh\n");
-      agent = await createAgent(agentOpts);
-    } else {
-      try {
-        agent = await resumeAgent(agentId, agentOpts);
-      } catch (err) {
-        io.stderr.write(
-          `resume failed (${err instanceof Error ? err.message : String(err)}); starting fresh\n`,
-        );
-        agent = await createAgent(agentOpts);
-      }
-    }
-  } else {
-    agent = await createAgent(agentOpts);
-  }
-
-  const runFlags = {
-    ...(flags.timeoutMs !== undefined ? { timeoutMs: flags.timeoutMs } : {}),
-    ...(flags.force ? { force: true } : {}),
-    json: flags.json,
-  };
+  const agentOpts = buildAgentOptionsFromFlags(workspaceRoot, flags);
+  const agent = await resolveTaskAgent(flags, stateDir, agentOpts, io);
+  const runFlags = { timeoutMs: flags.timeoutMs, force: flags.force, json: flags.json };
 
   if (flags.background) {
     runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });

--- a/plugins/cursor/scripts/cursor-companion.mts
+++ b/plugins/cursor/scripts/cursor-companion.mts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { runCancel } from "./commands/cancel.mjs";
 import { runResult } from "./commands/result.mjs";
+import { runResume } from "./commands/resume.mjs";
 import { runReview } from "./commands/review.mjs";
 import { runSetup } from "./commands/setup.mjs";
 import { runStatus } from "./commands/status.mjs";
@@ -21,6 +22,8 @@ const HELP = `cursor-companion <command> [args]
 
 commands:
   task <prompt>          Delegate an implementation task to Cursor
+  resume <agent-id|--last|--list> [prompt]
+                         Reattach to an existing Cursor agent and continue
   review                 Review the current diff
   adversarial-review     Challenge design choices, not just defects
   status [<job-id>]      Show job table or single job detail
@@ -47,6 +50,8 @@ export async function main(argv: readonly string[], io: CommandIO): Promise<Exit
     switch (command) {
       case "task":
         return await runTask(rest, io);
+      case "resume":
+        return await runResume(rest, io);
       case "review":
         return await runReview(rest, io, { adversarial: false });
       case "adversarial-review":

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -16,6 +16,7 @@ import {
   type SettingSource,
 } from "@cursor/sdk";
 
+import { detectCloudRepository } from "./git.mjs";
 import { type RetryOptions, withRetry } from "./retry.mjs";
 
 export const DEFAULT_MODEL: ModelSelection = { id: "composer-2" };
@@ -124,14 +125,11 @@ export const DEFAULT_AGENT_INSTRUCTIONS = [
   "Keep progress updates concise and summarize the result clearly at the end.",
 ].join("\n");
 
-/** Inline policy string for prompts that allow file writes (`task --write`, `resume --write`). */
 export const WRITE_POLICY = "You may modify files in the workspace.";
 
-/** Inline policy string for default read-only invocations. */
 export const READ_ONLY_POLICY =
   "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
 
-/** Pick the policy string to embed in a prompt based on the user's `--write` flag. */
 export function writePolicyText(write: boolean): string {
   return write ? WRITE_POLICY : READ_ONLY_POLICY;
 }
@@ -144,6 +142,30 @@ export function writePolicyText(write: boolean): string {
 export function buildPrompt(prompt: string, instructions?: string): string {
   const sys = instructions ?? DEFAULT_AGENT_INSTRUCTIONS;
   return `${sys}\n\nUser task:\n${prompt}`;
+}
+
+/**
+ * Build `CursorAgentOptions` from the subset of flags that command parsers
+ * expose to the user (`--model`, `--cloud`). Centralized so task and resume
+ * don't carry byte-identical copies. Cloud mode auto-detects the repo via
+ * `detectCloudRepository(workspaceRoot)`.
+ */
+export interface AgentOptionFlagInputs {
+  model?: ModelSelection;
+  cloud?: boolean;
+}
+
+export function buildAgentOptionsFromFlags(
+  workspaceRoot: string,
+  flags: AgentOptionFlagInputs,
+): CursorAgentOptions {
+  const opts: CursorAgentOptions = { cwd: workspaceRoot };
+  if (flags.model) opts.model = flags.model;
+  if (flags.cloud) {
+    opts.mode = "cloud";
+    opts.cloudRepo = detectCloudRepository(workspaceRoot);
+  }
+  return opts;
 }
 
 function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -124,6 +124,18 @@ export const DEFAULT_AGENT_INSTRUCTIONS = [
   "Keep progress updates concise and summarize the result clearly at the end.",
 ].join("\n");
 
+/** Inline policy string for prompts that allow file writes (`task --write`, `resume --write`). */
+export const WRITE_POLICY = "You may modify files in the workspace.";
+
+/** Inline policy string for default read-only invocations. */
+export const READ_ONLY_POLICY =
+  "Do NOT modify files. Read and analyze only — produce diffs/suggestions in your response, but do not write to disk.";
+
+/** Pick the policy string to embed in a prompt based on the user's `--write` flag. */
+export function writePolicyText(write: boolean): string {
+  return write ? WRITE_POLICY : READ_ONLY_POLICY;
+}
+
 /**
  * Wrap a user prompt with system instructions. Callers that need raw prompts
  * (e.g. structured-output review) can skip this and pass the prompt directly

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -121,6 +121,41 @@ export function listJobs(stateDir: string, filter: ListJobsFilter = {}): JobInde
   return entries;
 }
 
+export interface RecentTaskAgent {
+  jobId: string;
+  agentId: string;
+  createdAt: string;
+  summary?: string;
+}
+
+/**
+ * Walk the most-recent task jobs (newest first) and return entries that have
+ * a stamped agentId. Used by `task --resume-last` and `/cursor:resume`
+ * (`--last` / `--list`). Reads at most `lookahead` job json files from disk
+ * to find `limit` agentIds.
+ */
+export function findRecentTaskAgents(
+  stateDir: string,
+  limit: number = 10,
+  lookahead: number = Math.max(limit * 2, 20),
+): RecentTaskAgent[] {
+  const recent = listJobs(stateDir, { type: "task", limit: lookahead });
+  const out: RecentTaskAgent[] = [];
+  for (const entry of recent) {
+    if (out.length >= limit) break;
+    const job = readJob(stateDir, entry.id);
+    if (!job?.agentId) continue;
+    const ref: RecentTaskAgent = {
+      jobId: job.id,
+      agentId: job.agentId,
+      createdAt: job.createdAt,
+    };
+    if (entry.summary) ref.summary = entry.summary;
+    out.push(ref);
+  }
+  return out;
+}
+
 interface UpdateInput {
   status?: JobStatus;
   startedAt?: string;

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -176,7 +176,12 @@ function rowsFromJobs(jobs: JobIndexEntry[], now: number): JobTableRow[] {
   });
 }
 
-function formatAge(ms: number): string {
+/**
+ * Compact age string for table columns: `12s` / `5m` / `3h` / `7d`. Returns
+ * `?` for invalid/negative inputs so the table never crashes on unparseable
+ * timestamps.
+ */
+export function formatAge(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return "?";
   const sec = Math.floor(ms / 1000);
   if (sec < 60) return `${sec}s`;
@@ -185,6 +190,12 @@ function formatAge(ms: number): string {
   const hr = Math.floor(min / 60);
   if (hr < 24) return `${hr}h`;
   return `${Math.floor(hr / 24)}d`;
+}
+
+/** Convert an ISO timestamp to a relative age string (returns `?` if unparseable). */
+export function ageFromIso(iso: string, now: number = Date.now()): string {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? formatAge(now - t) : "?";
 }
 
 /**

--- a/plugins/cursor/scripts/lib/run-agent-task.mts
+++ b/plugins/cursor/scripts/lib/run-agent-task.mts
@@ -1,0 +1,121 @@
+import type { SDKAgent, SDKMessage } from "@cursor/sdk";
+
+import { disposeAgent, sendTask, toAgentEvents } from "./cursor-agent.mjs";
+import {
+  logJobLine,
+  markFailed,
+  markFinished,
+  markRunning,
+  registerActiveRun,
+  unregisterActiveRun,
+} from "./job-control.mjs";
+import { renderStreamEvent } from "./render.mjs";
+
+/**
+ * Minimal stdout/stderr surface used by the foreground runner. Defined here
+ * (rather than imported from `cursor-companion.mts`) to keep this lib module
+ * free of cycles with the CLI router.
+ */
+export interface IOSink {
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+}
+
+export interface AgentTaskFlags {
+  timeoutMs?: number;
+  force?: boolean;
+  json?: boolean;
+}
+
+export interface RunAgentTaskOptions {
+  agent: SDKAgent;
+  prompt: string;
+  flags: AgentTaskFlags;
+  io: IOSink;
+  stateDir: string;
+  jobId: string;
+}
+
+/**
+ * Foreground run: stream the agent's events to stdout/stderr, persist job
+ * transitions, dispose the agent on exit. Ownership of the agent passes to
+ * this helper — callers must not dispose it themselves.
+ *
+ * Returns 0 when the SDK reports `finished`, 1 otherwise. `markFailed` is
+ * stamped on the job record before any thrown error is re-raised, so the
+ * persisted state always reflects the failure even when the caller re-throws.
+ */
+export async function runAgentTaskForeground(opts: RunAgentTaskOptions): Promise<0 | 1> {
+  const { agent, prompt, flags, io, stateDir, jobId } = opts;
+  try {
+    const result = await sendTask(agent, prompt, {
+      ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
+      ...(flags.force ? { force: true } : {}),
+      onRunStart: (run) => {
+        markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
+        registerActiveRun(jobId, run);
+      },
+      onEvent: (event: SDKMessage) => {
+        for (const ae of toAgentEvents(event)) {
+          const rendered = renderStreamEvent(ae, { quietStatus: true });
+          if (rendered.stdout) io.stdout.write(rendered.stdout);
+          if (rendered.stderr) {
+            io.stderr.write(rendered.stderr);
+            logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
+          }
+        }
+      },
+    });
+
+    markFinished(stateDir, jobId, result);
+
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify({ jobId, ...result })}\n`);
+    } else if (!result.output.endsWith("\n")) {
+      io.stdout.write("\n");
+    }
+
+    return result.status === "finished" ? 0 : 1;
+  } catch (err) {
+    markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
+    throw err;
+  } finally {
+    unregisterActiveRun(jobId);
+    await disposeAgent(agent).catch(() => undefined);
+  }
+}
+
+/**
+ * Background run: kick off the agent, route both stdout and stderr renderings
+ * into the per-job log file, dispose the agent in the IIFE's finally. The
+ * caller has already returned the job id to the user, so this is fire-and-
+ * forget — Node keeps the process alive until the IIFE resolves.
+ */
+export function runAgentTaskBackground(opts: Omit<RunAgentTaskOptions, "io">): void {
+  const { agent, prompt, flags, stateDir, jobId } = opts;
+  void (async () => {
+    try {
+      const result = await sendTask(agent, prompt, {
+        ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
+        ...(flags.force ? { force: true } : {}),
+        onRunStart: (run) => {
+          markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
+          registerActiveRun(jobId, run);
+        },
+        onEvent: (event: SDKMessage) => {
+          for (const ae of toAgentEvents(event)) {
+            const rendered = renderStreamEvent(ae);
+            if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
+            if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
+          }
+        },
+      });
+      markFinished(stateDir, jobId, result);
+    } catch (err) {
+      markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
+    } finally {
+      unregisterActiveRun(jobId);
+      await disposeAgent(agent).catch(() => undefined);
+    }
+  })();
+}

--- a/plugins/cursor/scripts/lib/run-agent-task.mts
+++ b/plugins/cursor/scripts/lib/run-agent-task.mts
@@ -11,11 +11,6 @@ import {
 } from "./job-control.mjs";
 import { renderStreamEvent } from "./render.mjs";
 
-/**
- * Minimal stdout/stderr surface used by the foreground runner. Defined here
- * (rather than imported from `cursor-companion.mts`) to keep this lib module
- * free of cycles with the CLI router.
- */
 export interface IOSink {
   stdout: NodeJS.WritableStream;
   stderr: NodeJS.WritableStream;
@@ -49,7 +44,7 @@ export async function runAgentTaskForeground(opts: RunAgentTaskOptions): Promise
   const { agent, prompt, flags, io, stateDir, jobId } = opts;
   try {
     const result = await sendTask(agent, prompt, {
-      ...(flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {}),
+      ...(flags.timeoutMs !== undefined ? { timeoutMs: flags.timeoutMs } : {}),
       ...(flags.force ? { force: true } : {}),
       onRunStart: (run) => {
         markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });

--- a/tests/cli/resume.test.mts
+++ b/tests/cli/resume.test.mts
@@ -76,7 +76,6 @@ describe("CLI: resume", () => {
     const resumeJob = listJobs(stateDir).find((j) => j.summary === "next step");
     expect(resumeJob?.status).toBe("completed");
     const persisted = readJob(stateDir, resumeJob?.id ?? "");
-    expect(persisted?.metadata?.resumed).toBe(true);
     expect(persisted?.metadata?.resumedAgentId).toBe("agent-keep-going");
     expect(persisted?.agentId).toBe("agent-test");
   });

--- a/tests/cli/resume.test.mts
+++ b/tests/cli/resume.test.mts
@@ -1,0 +1,221 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { argv, captureIO, sentPrompt } from "@test/helpers/io.mjs";
+import { assistantText, fakeAgent, makeRun } from "@test/helpers/sdk-mock.mjs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const sdkMocks = vi.hoisted(() => ({
+  agentCreate: vi.fn(),
+  agentResume: vi.fn(),
+  cursorMe: vi.fn(),
+  modelsList: vi.fn(),
+}));
+
+vi.mock("@cursor/sdk", async () => {
+  const actual = await vi.importActual<typeof import("@cursor/sdk")>("@cursor/sdk");
+  return {
+    ...actual,
+    Agent: { create: sdkMocks.agentCreate, resume: sdkMocks.agentResume },
+    Cursor: { me: sdkMocks.cursorMe, models: { list: sdkMocks.modelsList } },
+  };
+});
+
+import { main as companionMain } from "@plugin/cursor-companion.mjs";
+import { createJob, listJobs, markRunning } from "@plugin/lib/job-control.mjs";
+import { ensureStateDir, readJob, resolveStateDir } from "@plugin/lib/state.mjs";
+
+let workDir: string;
+let stateRoot: string;
+let stateDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-resume-cwd-"));
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-resume-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+  process.env.CURSOR_API_KEY = "test-key";
+  stateDir = ensureStateDir(resolveStateDir(workDir));
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateRoot, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+  delete process.env.CURSOR_API_KEY;
+});
+
+function seedAgent(jobPrompt: string, agentId: string): string {
+  const job = createJob(stateDir, { type: "task", prompt: jobPrompt });
+  markRunning(stateDir, job.id, { agentId, runId: `${agentId}-r` });
+  return job.id;
+}
+
+describe("CLI: resume", () => {
+  it("resumes the supplied agent id and streams the follow-up output", async () => {
+    seedAgent("first turn", "agent-keep-going");
+
+    const run = makeRun({
+      events: [assistantText("run-resume-1", "continued")],
+      result: { id: "run-resume-1", status: "finished", durationMs: 7 },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentResume.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-keep-going", "next", "step"), io)).toBe(0);
+
+    expect(sdkMocks.agentResume).toHaveBeenCalledTimes(1);
+    expect(sdkMocks.agentResume.mock.calls[0]?.[0]).toBe("agent-keep-going");
+    expect(io.captured.stdout.join("")).toContain("continued");
+
+    const prompt = sentPrompt(agent);
+    expect(prompt).toContain("next step");
+    expect(prompt).toContain("Do NOT modify files");
+
+    const resumeJob = listJobs(stateDir).find((j) => j.summary === "next step");
+    expect(resumeJob?.status).toBe("completed");
+    const persisted = readJob(stateDir, resumeJob?.id ?? "");
+    expect(persisted?.metadata?.resumed).toBe(true);
+    expect(persisted?.metadata?.resumedAgentId).toBe("agent-keep-going");
+    expect(persisted?.agentId).toBe("agent-test");
+  });
+
+  it("--last picks the most recent task agent for this workspace", async () => {
+    seedAgent("first", "agent-old");
+    await new Promise((r) => setTimeout(r, 5));
+    seedAgent("second", "agent-new");
+
+    const run = makeRun({
+      events: [assistantText("run-last", "ok")],
+      result: { id: "run-last", status: "finished" },
+    });
+    sdkMocks.agentResume.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--last", "follow", "up"), io)).toBe(0);
+
+    expect(sdkMocks.agentResume).toHaveBeenCalledTimes(1);
+    expect(sdkMocks.agentResume.mock.calls[0]?.[0]).toBe("agent-new");
+  });
+
+  it("--last with no prior agents exits 1 with a diagnostic", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--last", "anything"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("no previous task agent to resume");
+    expect(sdkMocks.agentResume).not.toHaveBeenCalled();
+  });
+
+  it("--list prints recent agent ids and skips the SDK", async () => {
+    seedAgent("alpha", "agent-alpha");
+    await new Promise((r) => setTimeout(r, 5));
+    seedAgent("beta", "agent-beta");
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("AGENT-ID");
+    expect(out).toContain("agent-alpha");
+    expect(out).toContain("agent-beta");
+    expect(sdkMocks.agentResume).not.toHaveBeenCalled();
+  });
+
+  it("--list --json emits the structured rows", async () => {
+    seedAgent("alpha", "agent-alpha");
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--json"), io)).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].agentId).toBe("agent-alpha");
+    expect(parsed[0].summary).toBe("alpha");
+  });
+
+  it("--list with no jobs prints '(no resumable agents)'", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("(no resumable agents)");
+  });
+
+  it("--write flips the policy and is reflected in the prompt", async () => {
+    seedAgent("first", "agent-x");
+    const run = makeRun({
+      events: [assistantText("run-write", "edited")],
+      result: { id: "run-write", status: "finished" },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentResume.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(
+      await companionMain(argv("resume", "agent-x", "fix", "the", "thing", "--write"), io),
+    ).toBe(0);
+    const prompt = sentPrompt(agent);
+    expect(prompt).toContain("You may modify files");
+  });
+
+  it("--background returns the new job id immediately", async () => {
+    seedAgent("first", "agent-bg");
+    const run = makeRun({
+      events: [assistantText("run-bg", "later")],
+      result: { id: "run-bg", status: "finished" },
+    });
+    sdkMocks.agentResume.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-bg", "--background", "go"), io)).toBe(0);
+    const out = io.captured.stdout.join("").trim();
+    expect(out).toMatch(/^task-[a-f0-9]+$/);
+  });
+
+  it("missing agent-id without --last/--list exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("resume requires <agent-id>");
+  });
+
+  it("agent-id without a prompt exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-x"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("requires a prompt");
+  });
+
+  it("--list and --last together exit 2", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--last", "x"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
+  });
+
+  it("--limit without --list is rejected", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-x", "--limit", "3", "go"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--limit requires --list");
+  });
+
+  it("propagates a non-finished status as exit 1", async () => {
+    seedAgent("first", "agent-err");
+    const run = makeRun({
+      events: [],
+      result: { id: "run-err", status: "error" },
+    });
+    sdkMocks.agentResume.mockResolvedValue(fakeAgent(run));
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-err", "do", "x"), io)).toBe(1);
+  });
+
+  it("records markFailed when SDK Agent.resume throws", async () => {
+    seedAgent("first", "agent-bad");
+    sdkMocks.agentResume.mockRejectedValue(new Error("session expired"));
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "agent-bad", "go"), io)).toBe(1);
+    const err = io.captured.stderr.join("");
+    expect(err).toContain("session expired");
+
+    const failed = listJobs(stateDir).find((j) => j.status === "failed");
+    expect(failed).toBeDefined();
+    const persisted = readJob(stateDir, failed?.id ?? "");
+    expect(persisted?.error).toContain("resume failed for agent-bad");
+  });
+});

--- a/tests/unit/cli/companion.test.mts
+++ b/tests/unit/cli/companion.test.mts
@@ -89,6 +89,18 @@ describe("cursor-companion router", () => {
     expect(await companionMain(argv("status", "--type", "task"), io)).toBe(0);
   });
 
+  it("resume without args exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("resume requires <agent-id>");
+  });
+
+  it("--help on resume prints subcommand help and exits 0", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--help"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("Reattach to an existing Cursor agent");
+  });
+
   it("setup without API key exits 1 with diagnostic", async () => {
     const io = captureIO(workDir);
     const original = process.env.CURSOR_API_KEY;

--- a/tests/unit/lib/job-control.test.mts
+++ b/tests/unit/lib/job-control.test.mts
@@ -7,6 +7,7 @@ import type { CursorRunResult } from "../../../plugins/cursor/scripts/lib/cursor
 import {
   cancelJob,
   createJob,
+  findRecentTaskAgents,
   getActiveRun,
   getJob,
   listJobs,
@@ -191,6 +192,39 @@ describe("cancelJob", () => {
     expect(r.cancelled).toBe(false);
     expect(r.reason).toBe("already finished");
     unregisterActiveRun(job.id);
+  });
+});
+
+describe("findRecentTaskAgents", () => {
+  it("returns empty when there are no task jobs with agent ids", () => {
+    expect(findRecentTaskAgents(stateDir)).toEqual([]);
+    createJob(stateDir, { type: "task", prompt: "no-agent-yet" });
+    expect(findRecentTaskAgents(stateDir)).toEqual([]);
+  });
+
+  it("returns task jobs with agent ids, newest first, capped by limit", async () => {
+    const a = createJob(stateDir, { type: "task", prompt: "first" });
+    markRunning(stateDir, a.id, { agentId: "agent-a", runId: "run-a" });
+    await new Promise((r) => setTimeout(r, 5));
+    const b = createJob(stateDir, { type: "task", prompt: "second" });
+    markRunning(stateDir, b.id, { agentId: "agent-b", runId: "run-b" });
+    await new Promise((r) => setTimeout(r, 5));
+    const c = createJob(stateDir, { type: "task", prompt: "third" });
+    markRunning(stateDir, c.id, { agentId: "agent-c", runId: "run-c" });
+
+    const all = findRecentTaskAgents(stateDir, 5);
+    expect(all.map((r) => r.agentId)).toEqual(["agent-c", "agent-b", "agent-a"]);
+    expect(all[0]?.summary).toBe("third");
+
+    const top1 = findRecentTaskAgents(stateDir, 1);
+    expect(top1).toHaveLength(1);
+    expect(top1[0]?.agentId).toBe("agent-c");
+  });
+
+  it("ignores non-task jobs", () => {
+    const r = createJob(stateDir, { type: "review", prompt: "diff" });
+    markRunning(stateDir, r.id, { agentId: "agent-review", runId: "run-r" });
+    expect(findRecentTaskAgents(stateDir)).toEqual([]);
   });
 });
 


### PR DESCRIPTION
Surface @cursor/sdk's Agent.resume() as a first-class slash command. Until
now the durable-agent capability was reachable only through `task --resume-last`
which always picked the most recent agent and offered no discovery story.

- New `cursor-companion resume <agent-id>|--last|--list` subcommand
- `--list` renders a fixed-width table (or JSON) of recent task agentIds
  read via a shared `findRecentTaskAgents` helper hoisted into job-control;
  `task --resume-last` rewired to use the same helper
- Run path mirrors task: write policy, buildPrompt, streaming, job
  tracking, dispose-in-finally; new job records carry
  `metadata: { resumed: true, resumedAgentId }`
- Inherits `--write` / `--background` / `--force` / `--cloud` / `--model`
  / `--timeout` / `--json` from the task surface
- Slash command markdown follows the deterministic-passthrough pattern
  used by status/cancel/result (`disable-model-invocation: true`)
- 19 new tests cover the full flag matrix incl. Agent.resume rejection,
  conflicting flags, and the empty-list discovery case