### PR TITLE
feat: Phase 9 — codex feature parity (review scope, status --wait, prompt-file, durable-agent listing)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -659,6 +659,108 @@ surface and the failure paths.
 
 ---
 
+## Phase 9: Codex feature parity — review scope, status --wait, prompt-file, durable-agent listing
+
+Close the remaining feature gaps with `openai/codex-plugin-cc`. Each item
+maps to a codex capability we lacked but can implement on top of `@cursor/sdk`
+without new abstractions.
+
+### 9.1 Review scope semantics
+
+- [x] `lib/git.mts` `detectDefaultBranch(cwd)` — picks `main`/`master`/`trunk`,
+      preferring local refs over `origin/<name>`. Mirrors codex heuristic.
+- [x] `lib/git.mts` `resolveReviewTarget(cwd, { scope, baseRef })` returning
+      `{ mode, baseRef?, label, explicit }`. Semantics match codex:
+      explicit `baseRef` → branch; `scope: working-tree` → working-tree;
+      `scope: branch` → branch vs detected default; `scope: auto` (default)
+      → working-tree if dirty else branch vs default. `auto` falls back to
+      working-tree when no default branch is found instead of throwing,
+      so a fresh repo never blocks a review.
+- [x] `commands/review.mts` accepts `--scope <auto|working-tree|branch>`
+      and rejects `--staged --scope branch` as mutually exclusive. Prompt
+      now includes `Review target: <label>`.
+- [x] Adversarial-review accepts free-form positional **focus text**
+      (e.g. `/cursor:adversarial-review concurrency and atomicity`),
+      pumped into the prompt as `Reviewer focus (priority axis): ...`.
+      Plain `/cursor:review` rejects positional args (UsageError, exit 2).
+
+### 9.2 `status --wait`
+
+- [x] `commands/status.mts` accepts `--wait` with `<job-id>`, polling the
+      persisted record until terminal (`completed`/`failed`/`cancelled`).
+      `--timeout-ms <ms>` (default 240000) and `--poll-ms <ms>` (default
+      1000) tune the loop. Timeout exits 1 with the last-known state on
+      stdout. `--wait`/`--timeout-ms`/`--poll-ms` without `<job-id>` is
+      a UsageError.
+
+### 9.3 `task --prompt-file`
+
+- [x] `commands/task.mts` accepts `--prompt-file <path>`, reading the body
+      from disk and concatenating it after any positional prompt
+      (positional first, blank line, file contents). Either source alone
+      is sufficient. Missing file → UsageError.
+
+### 9.4 Durable-agent listing via `Agent.list`
+
+- [x] `lib/cursor-agent.mts` `listRemoteAgents(...)` wraps `Agent.list`
+      with a `RemoteAgentRow` projection (agentId, name, summary,
+      lastModified, status, archived, runtime). Defaults runtime to
+      `local` for the current cwd; pass `runtime: "cloud"` for cloud.
+- [x] `commands/resume.mts` `--list --remote` queries the SDK instead of
+      the local job index. Combine with `--cloud` to list cloud-runtime
+      agents. `--list --json --remote` emits the structured rows.
+      `--remote` without `--list`, and `--list --cloud` without `--remote`,
+      are both UsageErrors.
+- [x] Renderer `renderRemoteListText(rows)` shows
+      AGENT-ID / AGE / STATUS / SUMMARY with the SDK-reported
+      `lastModified` formatted via existing `ageFromIso`.
+
+### 9.5 Tests
+
+- [x] `tests/unit/lib/git.test.mts` — `detectDefaultBranch` + the full
+      `resolveReviewTarget` matrix (auto-clean, auto-dirty, explicit
+      scopes, explicit base, invalid scope).
+- [x] `tests/cli/review.test.mts` — adversarial focus, plain-review
+      rejecting positionals, `--scope working-tree`/`branch`, invalid
+      scope, `--staged --scope branch` mutually exclusive.
+- [x] `tests/cli/status.test.mts` — already-terminal returns immediately,
+      polls until terminal, times out → exit 1, `--json --wait` emits
+      final record.
+- [x] `tests/cli/task.test.mts` — `--prompt-file` body, positional+file
+      concatenation, missing file → exit 2, no prompt + no file → exit 2.
+- [x] `tests/cli/resume.test.mts` — `--list --remote` (text + json),
+      `--list --remote --cloud` switches runtime, `--remote` without
+      `--list` rejected, `--list --cloud` without `--remote` rejected.
+- [x] `tests/unit/cli/companion.test.mts` — `status --wait` without id
+      and `status <missing-id> --wait` smoke tests.
+
+### 9.6 Documentation
+
+- [x] `commands/review.md` — `--scope` flag entry
+- [x] `commands/adversarial-review.md` — focus-text usage
+- [x] `commands/status.md` — `--wait`/`--timeout-ms`/`--poll-ms`
+- [x] `commands/task.md` — mention `--prompt-file`
+- [x] `commands/resume.md` — `--list --remote [--cloud]` discovery
+- [x] `PLAN.md` — this section
+
+### 9.7 Deliberately deferred
+
+- ~~Detached `task-worker` (codex pattern: `spawn(node, ["task-worker"...],
+      { detached: true })`)~~ — current `--background` is in-process; the
+      Cursor SDK keeps the run alive server-side regardless, so the local
+      stream-consumer dying is the only real cost. A true detached worker
+      would require persisting a serialized request payload and reloading
+      it from a child process. Worth its own phase if/when users hit
+      shell-blocking issues on long runs.
+- ~~`task-resume-candidate` (Claude-session-scoped resume discovery)~~ —
+      we don't currently stamp `CLAUDE_SESSION_ID` onto job records.
+      Lift this when a downstream rescue-style command actually needs it.
+
+**Exit criteria**: All five gaps closed; existing 236-test baseline grows
+to cover the new flags; typecheck + lint stay green.
+
+---
+
 ## Implementation Order
 
 ```
@@ -670,6 +772,7 @@ Phase 5 (testing)         ██████████  ~4 hours
 Phase 6 (review gate)     ██████████  ~2 hours (v2)
 Phase 7 (polish/publish)  ██████████  ~3 hours
 Phase 8 (resume command)  ██████████  ~1 hour
+Phase 9 (codex parity)    ██████████  ~2 hours
 ```
 
 Phases 1–4 are the critical path. Phase 5 runs alongside 3–4 (write tests as you build). Phase 6 is a clean follow-up. Phase 7 is final polish.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The gate is per-workspace and disabled by default. State lives in
 | `--background` | Start the run, return the job id, exit. |
 | `--force` | Expire any wedged active local run before sending. |
 | `--cloud` | Run against the detected GitHub origin in Cursor's cloud. |
+| `--prompt-file <path>` | Read the prompt body from disk (concatenated after any positional prompt). |
 | `--model <id>` | Override the default model (`composer-2`). |
 | `--timeout <ms>` | Cancel if the run exceeds this duration. |
 | `--json` | Emit the final result as a single JSON line. |
@@ -91,6 +92,7 @@ The gate is per-workspace and disabled by default. State lives in
 |------|--------|
 | `--last` | Resume the most recent task agent for this workspace (skip `<agent-id>`). |
 | `--list` | Print known agent ids for this workspace, then exit. |
+| `--list --remote` | With `--list`: query the SDK for durable agents instead of the local job index. Combine with `--cloud` to list cloud-runtime agents. |
 | `--limit <n>` | With `--list`: cap the number of rows (default 10). |
 | `--write`, `--background`, `--force`, `--cloud`, `--model <id>`, `--timeout <ms>`, `--json` | Same as `task`. |
 
@@ -104,9 +106,24 @@ The gate is per-workspace and disabled by default. State lives in
 
 | Flag | Effect |
 |------|--------|
-| `--staged` | Review only staged changes (`git diff --cached`). |
-| `--base <ref>` | Diff against `<ref>` instead of the working tree. |
+| `--staged` | Review only staged changes (`git diff --cached`). Mutually exclusive with `--scope branch`. |
+| `--scope <auto\|working-tree\|branch>` | `auto` (default) picks working-tree if dirty, else branch vs detected default branch (`main`/`master`/`trunk`). |
+| `--base <ref>` | Diff against `<ref>`. Implies branch scope. |
 | `--model <id>`, `--timeout <ms>`, `--json` | Same as `task`. |
+
+`/cursor:adversarial-review` additionally accepts free-form positional **focus
+text** that becomes the priority axis for the reviewer (e.g.
+`/cursor:adversarial-review concurrency and atomicity`).
+
+`status`:
+
+| Flag | Effect |
+|------|--------|
+| `--type`, `--status`, `--limit <n>` | Filter the job table. |
+| `<job-id> --wait` | Block until the job reaches a terminal state. |
+| `--timeout-ms <ms>` | Max time to wait (default 240000). |
+| `--poll-ms <ms>` | Poll interval (default 1000). |
+| `--json` | Emit JSON instead of the rendered table/detail. |
 
 ## Where state lives
 

--- a/plugins/cursor/commands/adversarial-review.md
+++ b/plugins/cursor/commands/adversarial-review.md
@@ -14,6 +14,11 @@ unnecessary state, and brittle assumptions.
 node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs adversarial-review $ARGUMENTS
 ```
 
-Same output shape as `/cursor:review`. If the change is genuinely simple and
-correct, the review will say so — adversarial framing is not "always find
-fault." Surface the output verbatim to the user.
+Same output shape and flags as `/cursor:review`, plus free-form positional
+**focus text** that becomes the priority axis for the reviewer (e.g.
+`/cursor:adversarial-review concurrency and atomicity` or
+`--scope branch -- security`).
+
+If the change is genuinely simple and correct, the review will say so —
+adversarial framing is not "always find fault." Surface the output verbatim
+to the user.

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -17,7 +17,11 @@ Usage:
 
 - `<agent-id> <prompt>` — resume a specific agent with a follow-up prompt
 - `--last <prompt>`     — resume the most recent task agent for this workspace
-- `--list`              — print known agent ids; supports `--limit <n>` and `--json`
+- `--list`              — print known agent ids from the local job index
+- `--list --remote`     — query the SDK for durable agents (local runtime by
+                          default; combine with `--cloud` for cloud-runtime
+                          agents — that needs `CURSOR_API_KEY`)
+- `--limit <n>` and `--json` apply to `--list`
 
 Inherits the same flags as `/cursor:task`: `--write`, `--background`, `--force`,
 `--cloud`, `--model <id>`, `--timeout <ms>`, `--json`.

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -13,8 +13,11 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs review $ARGUMENTS
 ```
 
 Useful flags:
-- `--staged` — review staged changes only (default: working tree)
-- `--base <ref>` — diff against a specific ref instead of HEAD
+- `--staged` — review staged changes only
+- `--scope <auto|working-tree|branch>` — review scope. `auto` (default) picks
+  working-tree when the tree is dirty, otherwise diffs against the detected
+  default branch (`main`/`master`/`trunk`).
+- `--base <ref>` — diff against a specific ref. Implies branch scope.
 - `--json` — emit the structured ReviewOutput JSON unchanged
 
 The CLI prints a verdict (`approve` / `needs-attention`), a summary, and

--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -17,4 +17,9 @@ Filters available: `--type <task|review|adversarial-review>`,
 `--status <pending|running|completed|failed|cancelled>`, `--limit <n>`.
 `--json` emits machine-readable output.
 
+When passing a `<job-id>`, `--wait` blocks until the job reaches a terminal
+state (`completed`/`failed`/`cancelled`). Tune with `--timeout-ms <ms>`
+(default 240000) and `--poll-ms <ms>` (default 1000). On timeout, exit code
+is 1 and the last-known job state is still printed.
+
 Surface the output verbatim.

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -17,8 +17,10 @@ Default invocation:
 
 > Use the cursor-rescue subagent with: `$ARGUMENTS`
 
-If the user passed `--write`, `--cloud`, `--background`, `--force`, or
-`--model`, include them verbatim in the prompt to the subagent.
+If the user passed `--write`, `--cloud`, `--background`, `--force`,
+`--model`, or `--prompt-file <path>`, include them verbatim in the prompt
+to the subagent. `--prompt-file` is useful when the task description is
+long enough to be cumbersome inline.
 
 When the result comes back, follow `cursor-result-handling/SKILL.md` —
 present the deliverables and any caveats clearly, do not silently accept

--- a/plugins/cursor/scripts/commands/resume.mts
+++ b/plugins/cursor/scripts/commands/resume.mts
@@ -5,6 +5,8 @@ import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import {
   buildAgentOptionsFromFlags,
   buildPrompt,
+  listRemoteAgents,
+  type RemoteAgentRow,
   resumeAgent,
   writePolicyText,
 } from "../lib/cursor-agent.mjs";
@@ -29,6 +31,9 @@ keeps its prior context, so follow-up prompts are cheaper than starting fresh.
 flags:
   --last               Resume the most recent task agent (no agent-id needed)
   --list               Print known agent ids from this workspace, then exit
+  --remote             With --list: query the SDK for durable agents instead
+                       of the local job index. Combine with --cloud to list
+                       cloud-runtime agents (requires CURSOR_API_KEY).
   --limit <n>          With --list: cap the number of rows (default 10)
   --write              Allow file modifications (default: read-only)
   --background         Start the run and exit, returning the job id
@@ -46,6 +51,8 @@ interface ListFlags {
   kind: "list";
   limit: number;
   json: boolean;
+  remote: boolean;
+  cloud: boolean;
 }
 
 interface RunFlags {
@@ -71,6 +78,7 @@ function parseFlags(args: readonly string[]): ResumeFlags {
     long: {
       last: "boolean",
       list: "boolean",
+      remote: "boolean",
       limit: "string",
       write: "boolean",
       background: "boolean",
@@ -89,6 +97,9 @@ function parseFlags(args: readonly string[]): ResumeFlags {
   const list = bool(parsed, "list");
   const json = bool(parsed, "json");
 
+  const remote = bool(parsed, "remote");
+  const cloud = bool(parsed, "cloud");
+
   if (list) {
     if (last) throw new UsageError("--list and --last are mutually exclusive");
     let limit = DEFAULT_LIST_LIMIT;
@@ -98,8 +109,13 @@ function parseFlags(args: readonly string[]): ResumeFlags {
       if (!Number.isFinite(n) || n < 0) throw new UsageError(`invalid --limit: ${limitArg}`);
       limit = Math.floor(n);
     }
-    return { kind: "list", limit, json };
+    if (cloud && !remote) {
+      throw new UsageError("--list --cloud requires --remote (cloud listing goes through the SDK)");
+    }
+    return { kind: "list", limit, json, remote, cloud };
   }
+
+  if (remote) throw new UsageError("--remote requires --list");
 
   if (optionalString(parsed, "limit") !== undefined) {
     throw new UsageError("--limit requires --list");
@@ -129,7 +145,7 @@ function parseFlags(args: readonly string[]): ResumeFlags {
     write: bool(parsed, "write"),
     background: bool(parsed, "background"),
     force: bool(parsed, "force"),
-    cloud: bool(parsed, "cloud"),
+    cloud,
     json,
   };
   const modelId = optionalString(parsed, "model");
@@ -166,6 +182,29 @@ function renderListText(rows: RecentTaskAgent[], now: number = Date.now()): stri
   return `${header}\n${separator}\n${body}\n`;
 }
 
+export function renderRemoteListText(rows: RemoteAgentRow[], now: number = Date.now()): string {
+  if (rows.length === 0) return "(no durable agents reported by the SDK)\n";
+  const formatted = rows.map((r) => ({
+    agentId: r.agentId,
+    age: ageFromIso(new Date(r.lastModified).toISOString(), now),
+    status: r.status ?? "—",
+    summary: r.summary ? compactText(r.summary).slice(0, 60) : compactText(r.name).slice(0, 60),
+  }));
+  const widths = {
+    agentId: Math.max("agent-id".length, ...formatted.map((r) => r.agentId.length)),
+    age: Math.max("age".length, ...formatted.map((r) => r.age.length)),
+    status: Math.max("status".length, ...formatted.map((r) => r.status.length)),
+  };
+  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"AGE".padEnd(widths.age)}  ${"STATUS".padEnd(widths.status)}  SUMMARY`;
+  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.age)}  ${"-".repeat(widths.status)}  -------`;
+  const body = formatted
+    .map((r) =>
+      `${r.agentId.padEnd(widths.agentId)}  ${r.age.padEnd(widths.age)}  ${r.status.padEnd(widths.status)}  ${r.summary}`.trimEnd(),
+    )
+    .join("\n");
+  return `${header}\n${separator}\n${body}\n`;
+}
+
 export async function runResume(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   let flags: ResumeFlags;
   try {
@@ -182,6 +221,19 @@ export async function runResume(args: readonly string[], io: CommandIO): Promise
   const workspaceRoot = resolveWorkspaceRoot(cwd);
 
   if (flags.kind === "list") {
+    if (flags.remote) {
+      const rows = await listRemoteAgents(
+        flags.cloud
+          ? { runtime: "cloud", limit: flags.limit }
+          : { cwd: workspaceRoot, limit: flags.limit },
+      );
+      if (flags.json) {
+        io.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+      } else {
+        io.stdout.write(renderRemoteListText(rows));
+      }
+      return 0;
+    }
     const stateDir = resolveStateDir(workspaceRoot);
     const rows = findRecentTaskAgents(stateDir, flags.limit);
     if (flags.json) {

--- a/plugins/cursor/scripts/commands/review.mts
+++ b/plugins/cursor/scripts/commands/review.mts
@@ -3,26 +3,34 @@ import type { ModelSelection } from "@cursor/sdk";
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import { oneShot } from "../lib/cursor-agent.mjs";
-import { getDiff, getStatus } from "../lib/git.mjs";
+import { getDiff, getStatus, type ReviewScope, resolveReviewTarget } from "../lib/git.mjs";
 import { createJob, markFailed, markFinished, markRunning } from "../lib/job-control.mjs";
 import { type ReviewOutput, renderReviewResult } from "../lib/render.mjs";
 import { ensureStateDir, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const HELP = `cursor-companion review [flags]
-cursor-companion adversarial-review [flags]
+cursor-companion adversarial-review [flags] [focus text...]
 
-Review the working-tree diff (or staged diff with --staged). Returns a
-structured ReviewOutput JSON: verdict, summary, findings[], next_steps[].
+Review a git diff. Returns a structured ReviewOutput JSON: verdict, summary,
+findings[], next_steps[]. Adversarial-review additionally accepts free-form
+focus text as positional arguments — those are passed to the reviewer as the
+priority axis.
 
 flags:
   --staged             Review staged changes only (git diff --cached)
-  --base <ref>         Diff against this ref instead of working tree
+  --scope <auto|working-tree|branch>
+                       Review scope. 'auto' (default) picks working-tree when
+                       the tree is dirty, otherwise branch-vs-default-branch.
+                       Mutually exclusive with --staged.
+  --base <ref>         Diff against this ref. Implies branch scope.
   --model <id>         Override the default model
   --timeout <ms>       Cancel the review if it exceeds this duration
   --json               Print the raw structured review JSON
   --help, -h
 `;
+
+const VALID_SCOPES = new Set<ReviewScope>(["auto", "working-tree", "branch"]);
 
 const REVIEW_INSTRUCTIONS = [
   "You are a senior code reviewer doing a focused review of a small change.",
@@ -60,10 +68,12 @@ const SCHEMA = `{
 
 interface ReviewFlags {
   staged: boolean;
+  scope: ReviewScope;
   baseRef?: string;
   model?: ModelSelection;
   timeoutMs?: number;
   json: boolean;
+  focus: string;
 }
 
 class HelpRequested extends Error {}
@@ -72,6 +82,7 @@ function parseFlags(args: readonly string[]): ReviewFlags {
   const parsed = parseArgs(args, {
     long: {
       staged: "boolean",
+      scope: "string",
       base: "string",
       model: "string",
       timeout: "string",
@@ -81,9 +92,21 @@ function parseFlags(args: readonly string[]): ReviewFlags {
     short: { h: "help", m: "model" },
   });
   if (bool(parsed, "help")) throw new HelpRequested();
+  const staged = bool(parsed, "staged");
+  const scopeRaw = optionalString(parsed, "scope");
+  if (scopeRaw && !VALID_SCOPES.has(scopeRaw as ReviewScope)) {
+    throw new UsageError(
+      `invalid --scope: ${scopeRaw} (expected one of ${[...VALID_SCOPES].join(", ")})`,
+    );
+  }
+  if (staged && scopeRaw && scopeRaw !== "working-tree") {
+    throw new UsageError("--staged is only compatible with --scope working-tree");
+  }
   const flags: ReviewFlags = {
-    staged: bool(parsed, "staged"),
+    staged,
+    scope: (scopeRaw as ReviewScope | undefined) ?? "auto",
     json: bool(parsed, "json"),
+    focus: parsed.positionals.join(" ").trim(),
   };
   const base = optionalString(parsed, "base");
   if (base) flags.baseRef = base;
@@ -98,19 +121,30 @@ function parseFlags(args: readonly string[]): ReviewFlags {
   return flags;
 }
 
-function buildReviewPrompt(diff: string, status: string, instructions: string): string {
-  return [
-    instructions,
+interface ReviewPromptInput {
+  diff: string;
+  status: string;
+  instructions: string;
+  targetLabel: string;
+  focus: string;
+}
+
+function buildReviewPrompt(input: ReviewPromptInput): string {
+  const sections: string[] = [
+    input.instructions,
     "",
     "Output schema:",
     SCHEMA,
     "",
-    "Working-tree status:",
-    status || "(clean)",
+    `Review target: ${input.targetLabel}`,
     "",
-    "Diff to review:",
-    diff,
-  ].join("\n");
+  ];
+  if (input.focus) {
+    sections.push("Reviewer focus (priority axis):", input.focus, "");
+  }
+  sections.push("Working-tree status:", input.status || "(clean)", "");
+  sections.push("Diff to review:", input.diff);
+  return sections.join("\n");
 }
 
 /**
@@ -165,13 +199,29 @@ export async function runReview(
     throw err;
   }
 
+  if (flags.focus && !options.adversarial) {
+    throw new UsageError(
+      "free-form focus text is only accepted for adversarial-review (got positional args)",
+    );
+  }
+
   const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
 
   const diffOpts: { staged?: boolean; baseRef?: string } = {};
-  if (flags.staged) diffOpts.staged = true;
-  if (flags.baseRef) diffOpts.baseRef = flags.baseRef;
+  let targetLabel: string;
+  if (flags.staged) {
+    diffOpts.staged = true;
+    targetLabel = "staged diff";
+  } else {
+    const target = resolveReviewTarget(workspaceRoot, {
+      scope: flags.scope,
+      ...(flags.baseRef ? { baseRef: flags.baseRef } : {}),
+    });
+    if (target.baseRef) diffOpts.baseRef = target.baseRef;
+    targetLabel = target.label;
+  }
   const diff = getDiff(workspaceRoot, diffOpts);
   if (!diff) {
     io.stderr.write("nothing to review (empty diff)\n");
@@ -179,11 +229,17 @@ export async function runReview(
   }
 
   const instructions = options.adversarial ? ADVERSARIAL_INSTRUCTIONS : REVIEW_INSTRUCTIONS;
-  const prompt = buildReviewPrompt(diff, getStatus(workspaceRoot), instructions);
+  const prompt = buildReviewPrompt({
+    diff,
+    status: getStatus(workspaceRoot),
+    instructions,
+    targetLabel,
+    focus: flags.focus,
+  });
 
   const job = createJob(stateDir, {
     type: options.adversarial ? "adversarial-review" : "review",
-    prompt: `${options.adversarial ? "adversarial-" : ""}review of ${flags.staged ? "staged" : "working-tree"} diff`,
+    prompt: `${options.adversarial ? "adversarial-" : ""}review (${targetLabel})`,
   });
 
   const oneShotOpts: Parameters<typeof oneShot>[1] = {

--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -1,3 +1,5 @@
+import { setTimeout as sleep } from "node:timers/promises";
+
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import { getJob, type ListJobsFilter, listJobs } from "../lib/job-control.mjs";
@@ -7,18 +9,34 @@ import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const VALID_TYPES = new Set<string>(["task", "review", "adversarial-review"]);
 const VALID_STATUSES = new Set<string>(["pending", "running", "completed", "failed", "cancelled"]);
+const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set(["completed", "failed", "cancelled"]);
+
+const DEFAULT_WAIT_TIMEOUT_MS = 240_000;
+const DEFAULT_WAIT_POLL_MS = 1_000;
 
 const HELP = `cursor-companion status [<job-id>] [flags]
 
-Show the job table for the current workspace, or detail for one job.
+Show the job table for the current workspace, or detail for one job. With
+a job id, --wait polls until the job reaches a terminal state.
 
 flags:
   --type <task|review|adversarial-review>  Filter by type
   --status <pending|running|completed|failed|cancelled>
   --limit <n>                              Cap number of rows
+  --wait                                   With <job-id>: block until terminal
+  --timeout-ms <ms>                        Max time to wait (default 240000)
+  --poll-ms <ms>                           Poll interval (default 1000)
   --json                                   Print as JSON
   --help, -h
 `;
+
+function parsePositiveMs(parsed: ReturnType<typeof parseArgs>, key: string): number | undefined {
+  const raw = optionalString(parsed, key);
+  if (!raw) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) throw new UsageError(`invalid --${key}: ${raw}`);
+  return Math.floor(n);
+}
 
 export async function runStatus(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   const parsed = parseArgs(args, {
@@ -26,6 +44,9 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
       type: "string",
       status: "string",
       limit: "string",
+      wait: "boolean",
+      "timeout-ms": "string",
+      "poll-ms": "string",
       json: "boolean",
       help: "boolean",
     },
@@ -40,13 +61,35 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = resolveStateDir(workspaceRoot);
   const json = bool(parsed, "json");
+  const wait = bool(parsed, "wait");
+  const timeoutMs = parsePositiveMs(parsed, "timeout-ms");
+  const pollMs = parsePositiveMs(parsed, "poll-ms");
 
   const jobId = parsed.positionals[0];
   if (jobId) {
-    const job = getJob(stateDir, jobId);
+    let job = getJob(stateDir, jobId);
     if (!job) {
       io.stderr.write(`job not found: ${jobId}\n`);
       return 1;
+    }
+    if (wait && !TERMINAL_STATUSES.has(job.status)) {
+      const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+      const interval = pollMs ?? DEFAULT_WAIT_POLL_MS;
+      while (Date.now() < deadline) {
+        await sleep(interval);
+        const fresh = getJob(stateDir, jobId);
+        if (fresh) job = fresh;
+        if (TERMINAL_STATUSES.has(job.status)) break;
+      }
+      if (!TERMINAL_STATUSES.has(job.status)) {
+        io.stderr.write(`status --wait timed out (job still ${job.status})\n`);
+        if (json) {
+          io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
+        } else {
+          io.stdout.write(renderJobDetail(job));
+        }
+        return 1;
+      }
     }
     if (json) {
       io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
@@ -54,6 +97,10 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
       io.stdout.write(renderJobDetail(job));
     }
     return 0;
+  }
+
+  if (wait || timeoutMs || pollMs) {
+    throw new UsageError("--wait/--timeout-ms/--poll-ms require a positional <job-id>");
   }
 
   const filter: ListJobsFilter = {};

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+
 import type { ModelSelection, SDKAgent } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
@@ -27,6 +30,9 @@ flags:
   --background         Start the run and exit, returning the job id
   --force              Expire any wedged active local run before sending
   --cloud              Use Cursor cloud against the detected GitHub origin
+  --prompt-file <path> Read the prompt from a file. Concatenated with any
+                       positional prompt text (positional first, file body
+                       second, separated by a blank line).
   --model <id>         Override the default model
   -m <id>
   --timeout <ms>       Cancel the run if it exceeds this duration
@@ -48,7 +54,17 @@ interface TaskFlags {
 
 class HelpRequested extends Error {}
 
-function parseFlags(args: readonly string[]): TaskFlags {
+function readPromptFile(cwd: string, path: string): string {
+  const abs = resolvePath(cwd, path);
+  try {
+    return readFileSync(abs, "utf8").trim();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new UsageError(`failed to read --prompt-file ${path}: ${detail}`);
+  }
+}
+
+function parseFlags(args: readonly string[], cwd: string): TaskFlags {
   const parsed = parseArgs(args, {
     long: {
       write: "boolean",
@@ -56,6 +72,7 @@ function parseFlags(args: readonly string[]): TaskFlags {
       background: "boolean",
       force: "boolean",
       cloud: "boolean",
+      "prompt-file": "string",
       model: "string",
       timeout: "string",
       json: "boolean",
@@ -65,8 +82,11 @@ function parseFlags(args: readonly string[]): TaskFlags {
   });
   if (bool(parsed, "help")) throw new HelpRequested();
 
-  const prompt = parsed.positionals.join(" ").trim();
-  if (!prompt) throw new UsageError("task requires a prompt argument");
+  const positionalPrompt = parsed.positionals.join(" ").trim();
+  const promptFilePath = optionalString(parsed, "prompt-file");
+  const filePrompt = promptFilePath ? readPromptFile(cwd, promptFilePath) : "";
+  const prompt = [positionalPrompt, filePrompt].filter((s) => s.length > 0).join("\n\n");
+  if (!prompt) throw new UsageError("task requires a prompt argument or --prompt-file");
 
   const flags: TaskFlags = {
     prompt,
@@ -124,9 +144,10 @@ async function resolveTaskAgent(
 }
 
 export async function runTask(args: readonly string[], io: CommandIO): Promise<ExitCode> {
+  const cwd = io.cwd();
   let flags: TaskFlags;
   try {
-    flags = parseFlags(args);
+    flags = parseFlags(args, cwd);
   } catch (err) {
     if (err instanceof HelpRequested) {
       io.stdout.write(HELP);
@@ -135,7 +156,6 @@ export async function runTask(args: readonly string[], io: CommandIO): Promise<E
     throw err;
   }
 
-  const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
 

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -267,6 +267,48 @@ export async function listArtifacts(agent: SDKAgent): Promise<SDKArtifact[]> {
   return agent.listArtifacts();
 }
 
+export interface RemoteAgentRow {
+  agentId: string;
+  name: string;
+  summary: string;
+  /** ms since epoch from the SDK; pass through unchanged. */
+  lastModified: number;
+  status?: "running" | "finished" | "error";
+  archived?: boolean;
+  runtime?: "local" | "cloud";
+}
+
+/**
+ * Enumerate durable agents the SDK knows about for this workspace. Used by
+ * `/cursor:resume --list --remote` to surface agents that aren't in our local
+ * job index (e.g. created by a previous cursor-plugin-cc install or directly
+ * via the SDK).
+ *
+ * `runtime` defaults to "local" + the supplied cwd. Use `runtime: "cloud"` to
+ * list cloud agents — note cloud listing always requires `CURSOR_API_KEY`.
+ */
+export async function listRemoteAgents(
+  options:
+    | { cwd: string; runtime?: "local"; limit?: number }
+    | { runtime: "cloud"; limit?: number },
+): Promise<RemoteAgentRow[]> {
+  const limit = options.limit ?? 25;
+  const listOpts =
+    options.runtime === "cloud"
+      ? ({ runtime: "cloud", limit } as const)
+      : ({ runtime: "local", cwd: options.cwd, limit } as const);
+  const { items } = await Agent.list(listOpts);
+  return items.map((info) => ({
+    agentId: info.agentId,
+    name: info.name,
+    summary: info.summary,
+    lastModified: info.lastModified,
+    ...(info.status ? { status: info.status } : {}),
+    ...(info.archived !== undefined ? { archived: info.archived } : {}),
+    ...(info.runtime ? { runtime: info.runtime } : {}),
+  }));
+}
+
 export async function downloadArtifact(agent: SDKAgent, path: string): Promise<Buffer> {
   return agent.downloadArtifact(path);
 }

--- a/plugins/cursor/scripts/lib/git.mts
+++ b/plugins/cursor/scripts/lib/git.mts
@@ -80,6 +80,109 @@ export function getBranch(cwd: string): string | undefined {
   return out;
 }
 
+/**
+ * Detect the repository default branch (`main`, `master`, `trunk`), preferring
+ * a local ref over `origin/<name>`. Returns `undefined` when none of the
+ * conventional names resolve — callers should treat that as "pass an explicit
+ * --base ref or fall back to working-tree review".
+ *
+ * Mirrors the codex-plugin-cc heuristic so review-scope behavior stays in
+ * sync between the two plugins.
+ */
+export function detectDefaultBranch(cwd: string): string | undefined {
+  for (const candidate of ["main", "master", "trunk"]) {
+    const local = runGit(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${candidate}`]);
+    if (local !== undefined) return candidate;
+    const remote = runGit(cwd, [
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/remotes/origin/${candidate}`,
+    ]);
+    if (remote !== undefined) return `origin/${candidate}`;
+  }
+  return undefined;
+}
+
+export type ReviewScope = "auto" | "working-tree" | "branch";
+
+export interface ReviewTarget {
+  /** "working-tree" → diff against index/HEAD; "branch" → diff against baseRef. */
+  mode: "working-tree" | "branch";
+  /** Set when `mode === "branch"`. */
+  baseRef?: string;
+  /** Human-readable label, e.g. "branch diff against main". */
+  label: string;
+  /** False when auto-resolved, true when the user passed --base or --scope explicitly. */
+  explicit: boolean;
+}
+
+/**
+ * Resolve what a review should diff. Mirrors codex-plugin-cc's `resolveReviewTarget`:
+ *
+ *   - explicit `baseRef`         → branch mode against that ref
+ *   - `scope === "working-tree"` → working-tree (staged + unstaged)
+ *   - `scope === "branch"`       → branch mode against detected default branch
+ *   - `scope === "auto"`         → working-tree if dirty, else branch against default
+ *
+ * Throws on unsupported scope or when branch mode can't find a default branch.
+ */
+export function resolveReviewTarget(
+  cwd: string,
+  options: { scope?: ReviewScope; baseRef?: string } = {},
+): ReviewTarget {
+  const scope = options.scope ?? "auto";
+  const baseRef = options.baseRef;
+
+  if (baseRef) {
+    return { mode: "branch", baseRef, label: `branch diff against ${baseRef}`, explicit: true };
+  }
+
+  if (scope === "working-tree") {
+    return { mode: "working-tree", label: "working tree diff", explicit: true };
+  }
+
+  if (scope === "branch") {
+    const detected = detectDefaultBranch(cwd);
+    if (!detected) {
+      throw new Error(
+        "Unable to detect default branch (looked for main/master/trunk). " +
+          "Pass --base <ref> or use --scope working-tree.",
+      );
+    }
+    return {
+      mode: "branch",
+      baseRef: detected,
+      label: `branch diff against ${detected}`,
+      explicit: true,
+    };
+  }
+
+  if (scope !== "auto") {
+    throw new Error(
+      `Unsupported review scope "${scope}". Use one of: auto, working-tree, branch, or pass --base <ref>.`,
+    );
+  }
+
+  if (isDirty(cwd)) {
+    return { mode: "working-tree", label: "working tree diff", explicit: false };
+  }
+  const detected = detectDefaultBranch(cwd);
+  if (!detected) {
+    return {
+      mode: "working-tree",
+      label: "working tree diff (no default branch)",
+      explicit: false,
+    };
+  }
+  return {
+    mode: "branch",
+    baseRef: detected,
+    label: `branch diff against ${detected}`,
+    explicit: false,
+  };
+}
+
 /** `remote.origin.url` if set; otherwise `undefined`. */
 export function getRemoteUrl(cwd: string): string | undefined {
   return runGit(cwd, ["config", "--get", "remote.origin.url"]) || undefined;

--- a/tests/cli/resume.test.mts
+++ b/tests/cli/resume.test.mts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const sdkMocks = vi.hoisted(() => ({
   agentCreate: vi.fn(),
   agentResume: vi.fn(),
+  agentList: vi.fn(),
   cursorMe: vi.fn(),
   modelsList: vi.fn(),
 }));
@@ -16,7 +17,11 @@ vi.mock("@cursor/sdk", async () => {
   const actual = await vi.importActual<typeof import("@cursor/sdk")>("@cursor/sdk");
   return {
     ...actual,
-    Agent: { create: sdkMocks.agentCreate, resume: sdkMocks.agentResume },
+    Agent: {
+      create: sdkMocks.agentCreate,
+      resume: sdkMocks.agentResume,
+      list: sdkMocks.agentList,
+    },
     Cursor: { me: sdkMocks.cursorMe, models: { list: sdkMocks.modelsList } },
   };
 });
@@ -216,5 +221,70 @@ describe("CLI: resume", () => {
     expect(failed).toBeDefined();
     const persisted = readJob(stateDir, failed?.id ?? "");
     expect(persisted?.error).toContain("resume failed for agent-bad");
+  });
+
+  it("--list --remote queries the SDK and renders the durable rows", async () => {
+    sdkMocks.agentList.mockResolvedValue({
+      items: [
+        {
+          agentId: "agent-remote-1",
+          name: "Remote agent A",
+          summary: "Refactor module foo",
+          lastModified: 1_700_000_000_000,
+          status: "finished",
+          runtime: "local",
+        },
+      ],
+    });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--remote"), io)).toBe(0);
+    expect(sdkMocks.agentList).toHaveBeenCalledTimes(1);
+    expect(sdkMocks.agentList).toHaveBeenCalledWith(
+      expect.objectContaining({ runtime: "local", cwd: workDir }),
+    );
+    const stdout = io.captured.stdout.join("");
+    expect(stdout).toContain("agent-remote-1");
+    expect(stdout).toContain("Refactor module foo");
+    expect(stdout).toContain("finished");
+  });
+
+  it("--list --remote --json passes through the SDK rows as JSON", async () => {
+    sdkMocks.agentList.mockResolvedValue({
+      items: [
+        {
+          agentId: "agent-remote-json",
+          name: "x",
+          summary: "y",
+          lastModified: 1,
+        },
+      ],
+    });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--remote", "--json"), io)).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(parsed[0].agentId).toBe("agent-remote-json");
+  });
+
+  it("--list --remote --cloud passes runtime: cloud to Agent.list", async () => {
+    sdkMocks.agentList.mockResolvedValue({ items: [] });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--remote", "--cloud"), io)).toBe(0);
+    expect(sdkMocks.agentList).toHaveBeenCalledWith(expect.objectContaining({ runtime: "cloud" }));
+    expect(io.captured.stdout.join("")).toContain("(no durable agents reported by the SDK)");
+  });
+
+  it("--remote without --list is rejected", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--remote", "agent-x", "go"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--remote requires --list");
+  });
+
+  it("--list --cloud without --remote is rejected", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--cloud"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--list --cloud requires --remote");
   });
 });

--- a/tests/cli/review.test.mts
+++ b/tests/cli/review.test.mts
@@ -160,4 +160,99 @@ describe("CLI: review", () => {
     expect(prompt).toContain("adversarial reviewer");
     expect(prompt).toContain("challenge design choices");
   });
+
+  it("adversarial-review forwards positional focus text to the prompt", async () => {
+    const run = makeRun({
+      events: [],
+      result: { id: "run-review-6", status: "finished", result: RAW_APPROVE },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(
+      await companionMain(argv("adversarial-review", "concurrency", "and", "atomicity"), io),
+    ).toBe(0);
+    const prompt = sentPrompt(agent);
+    expect(prompt).toContain("Reviewer focus (priority axis):");
+    expect(prompt).toContain("concurrency and atomicity");
+  });
+
+  it("review rejects positional focus text (only adversarial-review accepts it)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("review", "look", "at", "auth"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("focus text is only accepted");
+    expect(sdkMocks.agentCreate).not.toHaveBeenCalled();
+  });
+
+  it("--scope working-tree is honored even on a clean tree (forces working-tree mode)", async () => {
+    const run = makeRun({
+      events: [],
+      result: { id: "run-review-scope-wt", status: "finished", result: RAW_APPROVE },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("review", "--scope", "working-tree"), io)).toBe(0);
+    const prompt = sentPrompt(agent);
+    expect(prompt).toContain("Review target: working tree diff");
+  });
+
+  it("--scope branch picks the detected default branch as the diff base", async () => {
+    // commit the dirty change so working tree is clean — branch mode then
+    // diffs against detected default branch (master/main)
+    const env = {
+      ...process.env,
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "t@e",
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "t@e",
+    };
+    execFileSync("git", ["checkout", "-q", "-b", "feature"], {
+      cwd: workDir,
+      env,
+      stdio: "ignore",
+    });
+    execFileSync("git", ["add", "-A"], { cwd: workDir, env, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["-c", "commit.gpgsign=false", "commit", "-q", "--no-gpg-sign", "-m", "feat"],
+      { cwd: workDir, env, stdio: "ignore" },
+    );
+
+    const run = makeRun({
+      events: [],
+      result: { id: "run-review-scope-br", status: "finished", result: RAW_APPROVE },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    try {
+      expect(await companionMain(argv("review", "--scope", "branch"), io)).toBe(0);
+      const prompt = sentPrompt(agent);
+      expect(prompt).toMatch(/Review target: branch diff against (main|master|trunk)/);
+    } finally {
+      // restore master/main as HEAD so other tests in this suite are unaffected
+      execFileSync("git", ["checkout", "-q", "-"], { cwd: workDir, env, stdio: "ignore" });
+      execFileSync("git", ["branch", "-q", "-D", "feature"], {
+        cwd: workDir,
+        env,
+        stdio: "ignore",
+      });
+    }
+  });
+
+  it("--scope rejects an invalid value", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("review", "--scope", "bogus"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("invalid --scope");
+  });
+
+  it("--staged is mutually exclusive with --scope branch", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("review", "--staged", "--scope", "branch"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--staged is only compatible");
+  });
 });

--- a/tests/cli/status.test.mts
+++ b/tests/cli/status.test.mts
@@ -1,0 +1,88 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { main as companionMain } from "@plugin/cursor-companion.mjs";
+import { createJob, markFailed, markRunning } from "@plugin/lib/job-control.mjs";
+import { ensureStateDir, resolveStateDir } from "@plugin/lib/state.mjs";
+import { argv, captureIO } from "@test/helpers/io.mjs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let workDir: string;
+let stateRoot: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-status-cwd-"));
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-status-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateRoot, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+});
+
+describe("CLI: status --wait", () => {
+  it("returns immediately when the job is already terminal", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "done" });
+    markFailed(stateDir, job.id, "boom");
+
+    const io = captureIO(workDir);
+    const code = await companionMain(
+      argv("status", job.id, "--wait", "--timeout-ms", "5000", "--poll-ms", "10"),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("status:     failed");
+  });
+
+  it("polls until the job becomes terminal", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "running" });
+    markRunning(stateDir, job.id, { agentId: "agent-x", runId: "run-x" });
+
+    setTimeout(() => {
+      markFailed(stateDir, job.id, "later failure");
+    }, 25);
+
+    const io = captureIO(workDir);
+    const code = await companionMain(
+      argv("status", job.id, "--wait", "--timeout-ms", "2000", "--poll-ms", "10"),
+      io,
+    );
+    expect(code).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("status:     failed");
+  });
+
+  it("times out and returns 1 when the job stays non-terminal", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "stuck" });
+    markRunning(stateDir, job.id, { agentId: "agent-y", runId: "run-y" });
+
+    const io = captureIO(workDir);
+    const code = await companionMain(
+      argv("status", job.id, "--wait", "--timeout-ms", "30", "--poll-ms", "10"),
+      io,
+    );
+    expect(code).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("status --wait timed out");
+    expect(io.captured.stdout.join("")).toContain("status:     running");
+  });
+
+  it("--json with --wait emits the final job record on stdout", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "json" });
+    markFailed(stateDir, job.id, "nope");
+
+    const io = captureIO(workDir);
+    const code = await companionMain(
+      argv("status", job.id, "--wait", "--json", "--timeout-ms", "100", "--poll-ms", "10"),
+      io,
+    );
+    expect(code).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(parsed.id).toBe(job.id);
+    expect(parsed.status).toBe("failed");
+  });
+});

--- a/tests/cli/task.test.mts
+++ b/tests/cli/task.test.mts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import type { SDKMessage } from "@cursor/sdk";
@@ -116,5 +116,59 @@ describe("CLI: task", () => {
 
     const io = captureIO(workDir);
     expect(await companionMain(argv("task", "do thing"), io)).toBe(1);
+  });
+
+  it("--prompt-file reads the prompt body from disk", async () => {
+    const promptPath = path.join(workDir, "prompt.txt");
+    writeFileSync(promptPath, "Body from file: refactor module X\n");
+
+    const run = makeRun({
+      events: [assistantText("run-pfile", "ok")],
+      result: { id: "run-pfile", status: "finished" },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("task", "--prompt-file", promptPath), io)).toBe(0);
+    expect(sentPrompt(agent)).toContain("Body from file: refactor module X");
+  });
+
+  it("--prompt-file concatenates with positional prompt (positional first)", async () => {
+    const promptPath = path.join(workDir, "tail.txt");
+    writeFileSync(promptPath, "FILE-BODY-MARKER");
+
+    const run = makeRun({
+      events: [],
+      result: { id: "run-pfile-cat", status: "finished" },
+    });
+    const agent = fakeAgent(run);
+    sdkMocks.agentCreate.mockResolvedValue(agent);
+
+    const io = captureIO(workDir);
+    expect(
+      await companionMain(argv("task", "POS-PROMPT-MARKER", "--prompt-file", promptPath), io),
+    ).toBe(0);
+    const prompt = sentPrompt(agent);
+    const posIdx = prompt.indexOf("POS-PROMPT-MARKER");
+    const fileIdx = prompt.indexOf("FILE-BODY-MARKER");
+    expect(posIdx).toBeGreaterThanOrEqual(0);
+    expect(fileIdx).toBeGreaterThan(posIdx);
+  });
+
+  it("--prompt-file with a missing path exits 2 with usage error", async () => {
+    const io = captureIO(workDir);
+    expect(
+      await companionMain(argv("task", "--prompt-file", path.join(workDir, "nope.txt")), io),
+    ).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("failed to read --prompt-file");
+  });
+
+  it("no prompt and no --prompt-file exits 2", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("task"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain(
+      "task requires a prompt argument or --prompt-file",
+    );
   });
 });

--- a/tests/unit/cli/companion.test.mts
+++ b/tests/unit/cli/companion.test.mts
@@ -61,7 +61,7 @@ describe("cursor-companion router", () => {
   it("task without a prompt exits 2 (UsageError)", async () => {
     const io = captureIO(workDir);
     expect(await companionMain(argv("task"), io)).toBe(2);
-    expect(io.captured.stderr.join("")).toContain("task requires a prompt argument");
+    expect(io.captured.stderr.join("")).toContain("task requires a prompt");
   });
 
   it("--help on a subcommand prints subcommand help and exits 0", async () => {
@@ -99,6 +99,18 @@ describe("cursor-companion router", () => {
     const io = captureIO(workDir);
     expect(await companionMain(argv("resume", "--help"), io)).toBe(0);
     expect(io.captured.stdout.join("")).toContain("Reattach to an existing Cursor agent");
+  });
+
+  it("status --wait without a job-id exits 2 (UsageError)", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status", "--wait"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--wait/--timeout-ms/--poll-ms require");
+  });
+
+  it("status <missing-id> --wait exits 1 with not-found diagnostic", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("status", "no-such-job", "--wait"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("job not found");
   });
 
   it("setup without API key exits 1 with diagnostic", async () => {

--- a/tests/unit/lib/git.test.mts
+++ b/tests/unit/lib/git.test.mts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   detectCloudRepository,
+  detectDefaultBranch,
   getBranch,
   getChangedFiles,
   getDiff,
@@ -14,6 +15,7 @@ import {
   getStatus,
   isDirty,
   normalizeGitHubRemote,
+  resolveReviewTarget,
 } from "../../../plugins/cursor/scripts/lib/git.mjs";
 
 function git(cwd: string, args: string[]): void {
@@ -158,6 +160,64 @@ describe("git helpers (in a real temp repo)", () => {
   it("detectCloudRepository throws on non-GitHub origins", () => {
     git(repo, ["remote", "add", "origin", "https://gitlab.com/foo/bar"]);
     expect(() => detectCloudRepository(repo)).toThrow(/GitHub/);
+  });
+});
+
+describe("resolveReviewTarget", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = makeRepo();
+    writeFileSync(path.join(repo, "f.txt"), "1\n");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("auto + clean tree → branch mode against detected default branch", () => {
+    const t = resolveReviewTarget(repo, { scope: "auto" });
+    expect(t.mode).toBe("branch");
+    expect(t.baseRef).toBe("main");
+    expect(t.explicit).toBe(false);
+  });
+
+  it("auto + dirty tree → working-tree mode (implicit)", () => {
+    writeFileSync(path.join(repo, "f.txt"), "2\n");
+    const t = resolveReviewTarget(repo, { scope: "auto" });
+    expect(t.mode).toBe("working-tree");
+    expect(t.baseRef).toBeUndefined();
+    expect(t.explicit).toBe(false);
+  });
+
+  it("explicit working-tree forces working-tree even when clean", () => {
+    const t = resolveReviewTarget(repo, { scope: "working-tree" });
+    expect(t.mode).toBe("working-tree");
+    expect(t.explicit).toBe(true);
+  });
+
+  it("explicit baseRef wins over scope", () => {
+    const t = resolveReviewTarget(repo, { scope: "auto", baseRef: "HEAD~0" });
+    expect(t.mode).toBe("branch");
+    expect(t.baseRef).toBe("HEAD~0");
+    expect(t.explicit).toBe(true);
+  });
+
+  it("scope=branch detects default branch", () => {
+    const t = resolveReviewTarget(repo, { scope: "branch" });
+    expect(t.mode).toBe("branch");
+    expect(t.baseRef).toBe("main");
+  });
+
+  it("rejects an unknown scope", () => {
+    // @ts-expect-error testing runtime guard
+    expect(() => resolveReviewTarget(repo, { scope: "yolo" })).toThrow(/Unsupported review scope/);
+  });
+
+  it("detectDefaultBranch returns 'main' for the conventional repo", () => {
+    expect(detectDefaultBranch(repo)).toBe("main");
   });
 });
 


### PR DESCRIPTION
Closes the remaining feature gaps with openai/codex-plugin-cc using
capabilities already exposed by @cursor/sdk@1.0.9. No new dependencies.

- review: --scope auto|working-tree|branch with codex-style auto detection
  (working-tree if dirty, otherwise branch vs detected default branch via
  detectDefaultBranch). adversarial-review now accepts free-form positional
  focus text; plain review rejects positionals. Prompt records the resolved
  review-target label.
- status: --wait blocks until <job-id> reaches a terminal state, with
  --timeout-ms (default 240000) and --poll-ms (default 1000) tuning the
  loop. Timeout exits 1 with the last-known state on stdout.
- task: --prompt-file <path> reads the prompt body from disk; concatenates
  after any positional prompt. Either source alone is sufficient.
- resume: --list --remote queries Agent.list (cursor SDK) for durable
  agents instead of the local job index. Combine with --cloud for
  cloud-runtime listing. New listRemoteAgents helper in lib/cursor-agent.

Tests: +28 new cases across review/status/task/resume CLI suites and the
git unit suite covering the resolveReviewTarget matrix. 264 tests pass.
PLAN.md gains a Phase 9 section recording the work and the deliberately
deferred items (detached task-worker; CLAUDE_SESSION_ID-scoped resume
candidate).