### PR TITLE
feat: persistent default model selection via /cursor:setup

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -772,7 +772,9 @@ to pass `--model` on every command.
       persisted as `<state-root>/config.json` (sibling of per-workspace dirs).
       Exposes `readUserConfig`/`writeUserConfig`/`setDefaultModel`/
       `clearDefaultModel` plus `resolveDefaultModel(fallback)` returning
-      `{ model, source }` where `source ∈ "flag" | "env" | "config" | "fallback"`.
+      `{ model, source }` where `source ∈ "env" | "config" | "fallback"`.
+      The `--model` flag short-circuits at the call site (`opts.model ??
+      resolveDefaultModel(...)`), so it never reaches the resolver.
 - [x] `lib/cursor-agent.mts` `buildAgentOptions` calls `resolveDefaultModel`
       so `createAgent`/`resumeAgent`/`oneShot` honor (in order):
       explicit `--model` → `CURSOR_MODEL` env → persisted config → built-in
@@ -783,7 +785,7 @@ to pass `--model` on every command.
       a `Default` row plus `defaultModel: { id, source }` in `--json`.
 - [x] `commands/setup.md` documents the resolution order and the new flags.
 - [x] Tests: `tests/unit/lib/user-config.test.mts` (round-trip, malformed
-      config, resolution priority including override and whitespace env),
+      config, resolution priority including whitespace env),
       `tests/cli/setup.test.mts` (built-in row text, `--set-model` happy
       path, unknown id rejected, `--clear-model`, mutual exclusion, env
       wins over config), and `tests/unit/lib/cursor-agent.test.mts` covers

--- a/PLAN.md
+++ b/PLAN.md
@@ -761,6 +761,40 @@ to cover the new flags; typecheck + lint stay green.
 
 ---
 
+## Phase 10: Persistent default model selection
+
+Per-invocation `--model <id>` already worked everywhere, but every run that
+omits the flag fell back to the hardcoded `composer-2`. Phase 10 adds a
+user-wide persisted default so users who want a different model don't have
+to pass `--model` on every command.
+
+- [x] `lib/user-config.mts` — `UserConfig` (`{ version: 1, defaultModel? }`)
+      persisted as `<state-root>/config.json` (sibling of per-workspace dirs).
+      Exposes `readUserConfig`/`writeUserConfig`/`setDefaultModel`/
+      `clearDefaultModel` plus `resolveDefaultModel(fallback)` returning
+      `{ model, source }` where `source ∈ "flag" | "env" | "config" | "fallback"`.
+- [x] `lib/cursor-agent.mts` `buildAgentOptions` calls `resolveDefaultModel`
+      so `createAgent`/`resumeAgent`/`oneShot` honor (in order):
+      explicit `--model` → `CURSOR_MODEL` env → persisted config → built-in
+      `composer-2` fallback.
+- [x] `commands/setup.mts` accepts `--set-model <id>` (validates against
+      `Cursor.models.list()` before writing) and `--clear-model`. Mutually
+      exclusive; empty `--set-model` value is a UsageError. Setup report adds
+      a `Default` row plus `defaultModel: { id, source }` in `--json`.
+- [x] `commands/setup.md` documents the resolution order and the new flags.
+- [x] Tests: `tests/unit/lib/user-config.test.mts` (round-trip, malformed
+      config, resolution priority including override and whitespace env),
+      `tests/cli/setup.test.mts` (built-in row text, `--set-model` happy
+      path, unknown id rejected, `--clear-model`, mutual exclusion, env
+      wins over config), and `tests/unit/lib/cursor-agent.test.mts` covers
+      env / persisted-config paths through `createAgent`.
+
+**Exit criteria**: 285 unit/CLI tests pass, lint+typecheck stay green, and
+`/cursor:setup --set-model <id>` followed by `/cursor:task "..."` runs the
+selected model with no per-invocation flag.
+
+---
+
 ## Implementation Order
 
 ```
@@ -773,6 +807,7 @@ Phase 6 (review gate)     ██████████  ~2 hours (v2)
 Phase 7 (polish/publish)  ██████████  ~3 hours
 Phase 8 (resume command)  ██████████  ~1 hour
 Phase 9 (codex parity)    ██████████  ~2 hours
+Phase 10 (model default)  ██████████  ~1 hour
 ```
 
 Phases 1–4 are the critical path. Phase 5 runs alongside 3–4 (write tests as you build). Phase 6 is a clean follow-up. Phase 7 is final polish.
@@ -788,4 +823,4 @@ Phases 1–4 are the critical path. Phase 5 runs alongside 3–4 (write tests as
 | Job persistence | Filesystem JSON | Matches codex plugin pattern; no DB dependency; human-readable |
 | Broker pattern | Skip for v1 | SDK handles concurrency internally; add if we hit issues |
 | Review gate | v2 (opt-in) | Core delegation must work first; gate adds complexity |
-| Model default | `composer-2` | Best available Cursor model; overridable per-command |
+| Model default | `composer-2` (built-in fallback) | Best available Cursor model; overridable per-command via `--model`, per-shell via `CURSOR_MODEL`, or persisted user-wide via `/cursor:setup --set-model <id>` |

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -27,3 +27,25 @@ and may block the stop with `needs-attention` findings. Toggle it via:
 - `--disable-gate` — turn the gate off
 
 The setup output's "Stop gate" row reports the current state.
+
+## Default model
+
+When `/cursor:task`, `/cursor:resume`, or any other command runs without an
+explicit `--model <id>`, the plugin resolves a default in this order:
+
+1. `--model <id>` flag on the command (per-invocation override)
+2. `CURSOR_MODEL` environment variable
+3. The persisted user-wide default (set via `--set-model`)
+4. Built-in fallback (`composer-2`)
+
+Manage the persisted default via `/cursor:setup`:
+
+- `--set-model <id>` — validate `<id>` against the live catalog and persist
+  it as the default for every workspace. Subsequent runs use it unless
+  overridden.
+- `--clear-model` — remove the persisted default and revert to the built-in
+  fallback.
+
+The setup output's "Default" row shows the active model id and where it
+came from (`from --model`, `from CURSOR_MODEL env`, `from persisted default`,
+or `built-in fallback`).

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -1,4 +1,4 @@
-import type { ModelSelection } from "@cursor/sdk";
+import type { ModelSelection, SDKModel } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
@@ -111,6 +111,12 @@ interface SetupReport {
 interface BuildReportInput {
   workspaceRoot: string;
   gateEnabled: boolean;
+  /** Catalog already fetched by the caller — skips the duplicate list call. */
+  prefetchedCatalog?: SDKModel[];
+}
+
+function errorMessage(reason: unknown): string {
+  return reason instanceof Error ? reason.message : String(reason);
 }
 
 async function buildReport(input: BuildReportInput): Promise<SetupReport> {
@@ -128,24 +134,27 @@ async function buildReport(input: BuildReportInput): Promise<SetupReport> {
     resolveApiKey();
     report.apiKey.ok = true;
   } catch (err) {
-    report.apiKey.error = err instanceof Error ? err.message : String(err);
+    report.apiKey.error = errorMessage(err);
     return report;
   }
 
-  try {
-    const me = await whoami();
+  const modelsPromise = input.prefetchedCatalog
+    ? Promise.resolve(input.prefetchedCatalog)
+    : listModels();
+  const [accountResult, modelsResult] = await Promise.allSettled([whoami(), modelsPromise]);
+
+  if (accountResult.status === "fulfilled") {
     report.account.ok = true;
-    report.account.apiKeyName = me.apiKeyName;
-  } catch (err) {
-    report.account.error = err instanceof Error ? err.message : String(err);
+    report.account.apiKeyName = accountResult.value.apiKeyName;
+  } else {
+    report.account.error = errorMessage(accountResult.reason);
   }
 
-  try {
-    const models = await listModels();
-    report.models.choices = modelChoices(models);
+  if (modelsResult.status === "fulfilled") {
+    report.models.choices = modelChoices(modelsResult.value);
     report.models.ok = report.models.choices.length > 0;
-  } catch (err) {
-    report.models.error = err instanceof Error ? err.message : String(err);
+  } else {
+    report.models.error = errorMessage(modelsResult.reason);
   }
 
   return report;
@@ -183,8 +192,6 @@ function renderReport(report: SetupReport): string {
 
 function describeSource(source: DefaultModelSource): string {
   switch (source) {
-    case "flag":
-      return "from --model";
     case "env":
       return "from CURSOR_MODEL env";
     case "config":
@@ -226,10 +233,12 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     throw new UsageError("--set-model requires a non-empty model id");
   }
 
+  // Pre-fetch the catalog when validating --set-model so buildReport can
+  // reuse it instead of listing models a second time.
+  let prefetchedCatalog: SDKModel[] | undefined;
   if (setModelId) {
-    // Validate against the live catalog so we fail fast on typos rather than
-    // letting the next /cursor:task surface "Model 'foo' is not available".
-    await validateModel({ id: setModelId });
+    prefetchedCatalog = await listModels();
+    await validateModel({ id: setModelId }, { catalog: prefetchedCatalog });
     setDefaultModel({ id: setModelId });
   } else if (clearModel) {
     clearDefaultModel();
@@ -242,7 +251,11 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     ? setGateEnabled(stateDir, enableGate).enabled
     : readGateConfig(stateDir).enabled;
 
-  const report = await buildReport({ workspaceRoot, gateEnabled });
+  const report = await buildReport({
+    workspaceRoot,
+    gateEnabled,
+    ...(prefetchedCatalog ? { prefetchedCatalog } : {}),
+  });
 
   if (bool(parsed, "json")) {
     io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -1,10 +1,22 @@
 import type { ModelSelection } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
-import { bool, parseArgs, UsageError } from "../lib/args.mjs";
-import { listModels, resolveApiKey, whoami } from "../lib/cursor-agent.mjs";
+import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
+import {
+  DEFAULT_MODEL,
+  listModels,
+  resolveApiKey,
+  validateModel,
+  whoami,
+} from "../lib/cursor-agent.mjs";
 import { readGateConfig, setGateEnabled } from "../lib/gate.mjs";
 import { resolveStateDir } from "../lib/state.mjs";
+import {
+  clearDefaultModel,
+  type DefaultModelSource,
+  resolveDefaultModel,
+  setDefaultModel,
+} from "../lib/user-config.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const NODE_MIN_MAJOR = 18;
@@ -26,6 +38,13 @@ Validates the plugin runtime:
 Stop review gate (per workspace, opt-in):
   --enable-gate        Turn on the Stop review gate for this workspace
   --disable-gate       Turn off the Stop review gate for this workspace
+
+Default model (user-wide, used when --model is not passed):
+  --set-model <id>     Persist <id> as the default for new agent runs.
+                       Validated against Cursor.models.list().
+  --clear-model        Remove the persisted default (revert to ${DEFAULT_MODEL.id}).
+                       Resolution order: --model flag > CURSOR_MODEL env >
+                       persisted default > ${DEFAULT_MODEL.id} fallback.
 
 flags:
   --json               Machine-readable output
@@ -85,6 +104,7 @@ interface SetupReport {
   apiKey: { ok: boolean; error?: string };
   account: { ok: boolean; apiKeyName?: string; error?: string };
   models: { ok: boolean; choices: ModelChoice[]; error?: string };
+  defaultModel: { id: string; source: DefaultModelSource };
   gate: { enabled: boolean; workspaceRoot: string };
 }
 
@@ -94,11 +114,13 @@ interface BuildReportInput {
 }
 
 async function buildReport(input: BuildReportInput): Promise<SetupReport> {
+  const resolved = resolveDefaultModel(DEFAULT_MODEL);
   const report: SetupReport = {
     node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
     apiKey: { ok: false },
     account: { ok: false },
     models: { ok: false, choices: [] },
+    defaultModel: { id: resolved.model.id, source: resolved.source },
     gate: { enabled: input.gateEnabled, workspaceRoot: input.workspaceRoot },
   };
 
@@ -151,9 +173,25 @@ function renderReport(report: SetupReport): string {
     lines.push(`Models      fail  ${report.models.error}`);
   }
   lines.push(
+    `Default     ${report.defaultModel.id}  (${describeSource(report.defaultModel.source)})`,
+  );
+  lines.push(
     `Stop gate   ${report.gate.enabled ? "on" : "off"}   (workspace: ${report.gate.workspaceRoot})`,
   );
   return `${lines.join("\n")}\n`;
+}
+
+function describeSource(source: DefaultModelSource): string {
+  switch (source) {
+    case "flag":
+      return "from --model";
+    case "env":
+      return "from CURSOR_MODEL env";
+    case "config":
+      return "from persisted default";
+    case "fallback":
+      return "built-in fallback";
+  }
 }
 
 export async function runSetup(args: readonly string[], io: CommandIO): Promise<ExitCode> {
@@ -163,6 +201,8 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
       help: "boolean",
       "enable-gate": "boolean",
       "disable-gate": "boolean",
+      "set-model": "string",
+      "clear-model": "boolean",
     },
     short: { h: "help" },
   });
@@ -175,6 +215,24 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
   const disableGate = bool(parsed, "disable-gate");
   if (enableGate && disableGate) {
     throw new UsageError("--enable-gate and --disable-gate are mutually exclusive");
+  }
+
+  const setModelId = optionalString(parsed, "set-model");
+  const clearModel = bool(parsed, "clear-model");
+  if (setModelId && clearModel) {
+    throw new UsageError("--set-model and --clear-model are mutually exclusive");
+  }
+  if (setModelId !== undefined && setModelId.trim() === "") {
+    throw new UsageError("--set-model requires a non-empty model id");
+  }
+
+  if (setModelId) {
+    // Validate against the live catalog so we fail fast on typos rather than
+    // letting the next /cursor:task surface "Model 'foo' is not available".
+    await validateModel({ id: setModelId });
+    setDefaultModel({ id: setModelId });
+  } else if (clearModel) {
+    clearDefaultModel();
   }
 
   const workspaceRoot = resolveWorkspaceRoot(io.cwd());

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -329,12 +329,17 @@ export async function listModels(opts: RequestOptions = {}): Promise<SDKModel[]>
   return withRetry(() => Cursor.models.list({ apiKey }), opts.retry);
 }
 
-/** Confirm a ModelSelection.id is in the catalog. Throws on miss. */
+/**
+ * Confirm a ModelSelection.id is in the catalog. Throws on miss. Pass
+ * `catalog` when you've already fetched the list (e.g. to share one fetch
+ * between validation and a subsequent report) — otherwise the catalog is
+ * fetched fresh.
+ */
 export async function validateModel(
   model: ModelSelection,
-  opts: RequestOptions = {},
+  opts: RequestOptions & { catalog?: SDKModel[] } = {},
 ): Promise<SDKModel> {
-  const models = await listModels(opts);
+  const models = opts.catalog ?? (await listModels(opts));
   const match = models.find((m) => m.id === model.id);
   if (!match) {
     const known = models.map((m) => m.id).join(", ") || "(none)";

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -18,6 +18,7 @@ import {
 
 import { detectCloudRepository } from "./git.mjs";
 import { type RetryOptions, withRetry } from "./retry.mjs";
+import { resolveDefaultModel } from "./user-config.mjs";
 
 export const DEFAULT_MODEL: ModelSelection = { id: "composer-2" };
 
@@ -170,7 +171,7 @@ export function buildAgentOptionsFromFlags(
 
 function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
   const apiKey = resolveApiKey(opts.apiKey);
-  const model = opts.model ?? DEFAULT_MODEL;
+  const model = opts.model ?? resolveDefaultModel(DEFAULT_MODEL).model;
   const mode: AgentMode = opts.mode ?? "local";
 
   const base: AgentOptions = {

--- a/plugins/cursor/scripts/lib/user-config.mts
+++ b/plugins/cursor/scripts/lib/user-config.mts
@@ -1,0 +1,81 @@
+import path from "node:path";
+
+import type { ModelSelection } from "@cursor/sdk";
+
+import { readJson, resolveStateRoot, type StateLocator, writeJsonAtomic } from "./state.mjs";
+
+/**
+ * User-wide plugin config. Persisted as `config.json` at the root of the
+ * state tree (sibling to per-workspace directories), so settings set by
+ * `/cursor:setup --set-model` apply across every workspace until cleared.
+ *
+ * Workspace-scoped settings (gate enabled flag, gate model override) live
+ * in `gate.json` inside each workspace directory; this file is the place
+ * for cross-workspace user preferences.
+ */
+export interface UserConfig {
+  version: 1;
+  /** Default model for new agent runs when no per-invocation override is set. */
+  defaultModel?: ModelSelection;
+}
+
+export const USER_CONFIG_ENV_MODEL = "CURSOR_MODEL";
+
+export function getUserConfigPath(opts: StateLocator = {}): string {
+  return path.join(resolveStateRoot(opts), "config.json");
+}
+
+export function readUserConfig(opts: StateLocator = {}): UserConfig {
+  const data = readJson<UserConfig>(getUserConfigPath(opts));
+  if (!data || typeof data !== "object") return { version: 1 };
+  const out: UserConfig = { version: 1 };
+  if (data.defaultModel && typeof data.defaultModel === "object" && data.defaultModel.id) {
+    out.defaultModel = data.defaultModel;
+  }
+  return out;
+}
+
+export function writeUserConfig(config: UserConfig, opts: StateLocator = {}): void {
+  writeJsonAtomic(getUserConfigPath(opts), { ...config, version: 1 });
+}
+
+export function setDefaultModel(model: ModelSelection, opts: StateLocator = {}): UserConfig {
+  const next: UserConfig = { ...readUserConfig(opts), version: 1, defaultModel: model };
+  writeUserConfig(next, opts);
+  return next;
+}
+
+export function clearDefaultModel(opts: StateLocator = {}): UserConfig {
+  const { defaultModel: _drop, ...rest } = readUserConfig(opts);
+  const next: UserConfig = { ...rest, version: 1 };
+  writeUserConfig(next, opts);
+  return next;
+}
+
+export type DefaultModelSource = "flag" | "env" | "config" | "fallback";
+
+export interface ResolvedDefaultModel {
+  model: ModelSelection;
+  source: DefaultModelSource;
+}
+
+/**
+ * Resolve the default model honoring (in order): explicit flag override,
+ * `CURSOR_MODEL` env var, persisted user config, and a hardcoded fallback.
+ * The flag path is only used by callers that want to surface the resolution
+ * source — runtime callers normally only pass `fallback`.
+ */
+export function resolveDefaultModel(
+  fallback: ModelSelection,
+  opts: { override?: ModelSelection } & StateLocator = {},
+): ResolvedDefaultModel {
+  if (opts.override) return { model: opts.override, source: "flag" };
+
+  const envId = process.env[USER_CONFIG_ENV_MODEL]?.trim();
+  if (envId) return { model: { id: envId }, source: "env" };
+
+  const cfg = readUserConfig(opts);
+  if (cfg.defaultModel) return { model: cfg.defaultModel, source: "config" };
+
+  return { model: fallback, source: "fallback" };
+}

--- a/plugins/cursor/scripts/lib/user-config.mts
+++ b/plugins/cursor/scripts/lib/user-config.mts
@@ -4,18 +4,8 @@ import type { ModelSelection } from "@cursor/sdk";
 
 import { readJson, resolveStateRoot, type StateLocator, writeJsonAtomic } from "./state.mjs";
 
-/**
- * User-wide plugin config. Persisted as `config.json` at the root of the
- * state tree (sibling to per-workspace directories), so settings set by
- * `/cursor:setup --set-model` apply across every workspace until cleared.
- *
- * Workspace-scoped settings (gate enabled flag, gate model override) live
- * in `gate.json` inside each workspace directory; this file is the place
- * for cross-workspace user preferences.
- */
 export interface UserConfig {
   version: 1;
-  /** Default model for new agent runs when no per-invocation override is set. */
   defaultModel?: ModelSelection;
 }
 
@@ -40,37 +30,28 @@ export function writeUserConfig(config: UserConfig, opts: StateLocator = {}): vo
 }
 
 export function setDefaultModel(model: ModelSelection, opts: StateLocator = {}): UserConfig {
-  const next: UserConfig = { ...readUserConfig(opts), version: 1, defaultModel: model };
+  const next: UserConfig = { ...readUserConfig(opts), defaultModel: model };
   writeUserConfig(next, opts);
   return next;
 }
 
 export function clearDefaultModel(opts: StateLocator = {}): UserConfig {
   const { defaultModel: _drop, ...rest } = readUserConfig(opts);
-  const next: UserConfig = { ...rest, version: 1 };
-  writeUserConfig(next, opts);
-  return next;
+  writeUserConfig(rest, opts);
+  return rest;
 }
 
-export type DefaultModelSource = "flag" | "env" | "config" | "fallback";
+export type DefaultModelSource = "env" | "config" | "fallback";
 
 export interface ResolvedDefaultModel {
   model: ModelSelection;
   source: DefaultModelSource;
 }
 
-/**
- * Resolve the default model honoring (in order): explicit flag override,
- * `CURSOR_MODEL` env var, persisted user config, and a hardcoded fallback.
- * The flag path is only used by callers that want to surface the resolution
- * source — runtime callers normally only pass `fallback`.
- */
 export function resolveDefaultModel(
   fallback: ModelSelection,
-  opts: { override?: ModelSelection } & StateLocator = {},
+  opts: StateLocator = {},
 ): ResolvedDefaultModel {
-  if (opts.override) return { model: opts.override, source: "flag" };
-
   const envId = process.env[USER_CONFIG_ENV_MODEL]?.trim();
   if (envId) return { model: { id: envId }, source: "env" };
 

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -23,19 +23,25 @@ vi.mock("@cursor/sdk", async () => {
 import { main as companionMain } from "@plugin/cursor-companion.mjs";
 import { readGateConfig } from "@plugin/lib/gate.mjs";
 import { resolveStateDir } from "@plugin/lib/state.mjs";
+import { readUserConfig, USER_CONFIG_ENV_MODEL } from "@plugin/lib/user-config.mjs";
 
 let workDir: string;
 let stateRoot: string;
+
+let savedModelEnv: string | undefined;
 
 beforeEach(() => {
   workDir = mkdtempSync(path.join(tmpdir(), "cursor-setup-cwd-"));
   stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-setup-state-"));
   process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
   process.env.CURSOR_API_KEY = "test-key";
+  savedModelEnv = process.env[USER_CONFIG_ENV_MODEL];
+  delete process.env[USER_CONFIG_ENV_MODEL];
   vi.clearAllMocks();
   sdkMocks.cursorMe.mockResolvedValue({ apiKeyName: "test-key", userId: "u" });
   sdkMocks.modelsList.mockResolvedValue([
     { id: "composer-2", displayName: "Composer 2", variants: [] },
+    { id: "gpt-5", displayName: "GPT 5", variants: [] },
   ]);
 });
 
@@ -44,6 +50,8 @@ afterEach(() => {
   rmSync(stateRoot, { recursive: true, force: true });
   delete process.env.CURSOR_PLUGIN_STATE_ROOT;
   delete process.env.CURSOR_API_KEY;
+  if (savedModelEnv === undefined) delete process.env[USER_CONFIG_ENV_MODEL];
+  else process.env[USER_CONFIG_ENV_MODEL] = savedModelEnv;
 });
 
 describe("CLI: setup", () => {
@@ -82,5 +90,58 @@ describe("CLI: setup", () => {
     const report = JSON.parse(io.captured.stdout.join(""));
     expect(report.gate.enabled).toBe(true);
     expect(typeof report.gate.workspaceRoot).toBe("string");
+  });
+
+  it("reports the built-in default model when nothing is configured", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("Default     composer-2");
+    expect(out).toContain("built-in fallback");
+  });
+
+  it("--set-model validates the id and persists the default", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--set-model", "gpt-5"), io)).toBe(0);
+    expect(readUserConfig().defaultModel).toEqual({ id: "gpt-5" });
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("Default     gpt-5");
+    expect(out).toContain("from persisted default");
+  });
+
+  it("--set-model rejects ids absent from the catalog", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--set-model", "imaginary"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("imaginary");
+    expect(readUserConfig().defaultModel).toBeUndefined();
+  });
+
+  it("--clear-model removes the persisted default", async () => {
+    const setIo = captureIO(workDir);
+    await companionMain(argv("setup", "--set-model", "gpt-5"), setIo);
+    expect(readUserConfig().defaultModel).toEqual({ id: "gpt-5" });
+
+    const clearIo = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--clear-model"), clearIo)).toBe(0);
+    expect(readUserConfig().defaultModel).toBeUndefined();
+    expect(clearIo.captured.stdout.join("")).toContain("built-in fallback");
+  });
+
+  it("rejects --set-model together with --clear-model", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--set-model", "gpt-5", "--clear-model"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
+  });
+
+  it("CURSOR_MODEL env var wins over the persisted default", async () => {
+    const setIo = captureIO(workDir);
+    await companionMain(argv("setup", "--set-model", "gpt-5"), setIo);
+
+    process.env[USER_CONFIG_ENV_MODEL] = "composer-2";
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("Default     composer-2");
+    expect(out).toContain("from CURSOR_MODEL env");
   });
 });

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -1,3 +1,7 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import type {
   Run,
   RunOperation,
@@ -48,6 +52,11 @@ import {
   validateModel,
   whoami,
 } from "../../../plugins/cursor/scripts/lib/cursor-agent.mjs";
+import { STATE_ROOT_ENV } from "../../../plugins/cursor/scripts/lib/state.mjs";
+import {
+  setDefaultModel,
+  USER_CONFIG_ENV_MODEL,
+} from "../../../plugins/cursor/scripts/lib/user-config.mjs";
 
 function makeRun(events: SDKMessage[], result: RunResult): Run {
   let status: RunStatus = "running";
@@ -107,13 +116,27 @@ function fakeAgent(run: Run): SDKAgent {
   };
 }
 
+let stateRoot: string;
+let savedStateRoot: string | undefined;
+let savedModelEnv: string | undefined;
+
 beforeEach(() => {
   process.env.CURSOR_API_KEY = "test-key";
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-agent-state-"));
+  savedStateRoot = process.env[STATE_ROOT_ENV];
+  savedModelEnv = process.env[USER_CONFIG_ENV_MODEL];
+  process.env[STATE_ROOT_ENV] = stateRoot;
+  delete process.env[USER_CONFIG_ENV_MODEL];
 });
 
 afterEach(() => {
   vi.clearAllMocks();
   delete process.env.CURSOR_API_KEY;
+  rmSync(stateRoot, { recursive: true, force: true });
+  if (savedStateRoot === undefined) delete process.env[STATE_ROOT_ENV];
+  else process.env[STATE_ROOT_ENV] = savedStateRoot;
+  if (savedModelEnv === undefined) delete process.env[USER_CONFIG_ENV_MODEL];
+  else process.env[USER_CONFIG_ENV_MODEL] = savedModelEnv;
 });
 
 describe("resolveApiKey", () => {
@@ -161,6 +184,40 @@ describe("createAgent / resumeAgent", () => {
       model: DEFAULT_MODEL,
       local: { cwd: "/tmp/repo" },
     });
+  });
+
+  it("createAgent uses CURSOR_MODEL when no model is passed", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+    process.env[USER_CONFIG_ENV_MODEL] = "from-env";
+
+    await createAgent({ cwd: "/tmp/repo" });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.model).toEqual({ id: "from-env" });
+  });
+
+  it("createAgent uses the persisted user-config default when env is unset", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+    setDefaultModel({ id: "from-config" });
+
+    await createAgent({ cwd: "/tmp/repo" });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.model).toEqual({ id: "from-config" });
+  });
+
+  it("createAgent prefers explicit model over env and config", async () => {
+    const fake = fakeAgent(makeRun([], { id: "r1", status: "finished" }));
+    sdkMocks.agentCreate.mockResolvedValue(fake);
+    process.env[USER_CONFIG_ENV_MODEL] = "from-env";
+    setDefaultModel({ id: "from-config" });
+
+    await createAgent({ cwd: "/tmp/repo", model: { id: "from-flag" } });
+
+    const call = sdkMocks.agentCreate.mock.calls[0]?.[0];
+    expect(call?.model).toEqual({ id: "from-flag" });
   });
 
   it("createAgent honors model override and settingSources", async () => {

--- a/tests/unit/lib/user-config.test.mts
+++ b/tests/unit/lib/user-config.test.mts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { STATE_ROOT_ENV } from "@plugin/lib/state.mjs";
+import {
+  clearDefaultModel,
+  getUserConfigPath,
+  readUserConfig,
+  resolveDefaultModel,
+  setDefaultModel,
+  USER_CONFIG_ENV_MODEL,
+  writeUserConfig,
+} from "@plugin/lib/user-config.mjs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let stateRoot: string;
+let savedRoot: string | undefined;
+let savedModelEnv: string | undefined;
+
+beforeEach(() => {
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-user-config-"));
+  savedRoot = process.env[STATE_ROOT_ENV];
+  savedModelEnv = process.env[USER_CONFIG_ENV_MODEL];
+  process.env[STATE_ROOT_ENV] = stateRoot;
+  delete process.env[USER_CONFIG_ENV_MODEL];
+});
+
+afterEach(() => {
+  rmSync(stateRoot, { recursive: true, force: true });
+  if (savedRoot === undefined) delete process.env[STATE_ROOT_ENV];
+  else process.env[STATE_ROOT_ENV] = savedRoot;
+  if (savedModelEnv === undefined) delete process.env[USER_CONFIG_ENV_MODEL];
+  else process.env[USER_CONFIG_ENV_MODEL] = savedModelEnv;
+});
+
+describe("user-config persistence", () => {
+  it("returns the empty default when config.json is missing", () => {
+    expect(readUserConfig()).toEqual({ version: 1 });
+  });
+
+  it("getUserConfigPath sits at the root state dir", () => {
+    expect(getUserConfigPath()).toBe(path.join(stateRoot, "config.json"));
+  });
+
+  it("setDefaultModel persists and round-trips via readUserConfig", () => {
+    setDefaultModel({ id: "gpt-5" });
+    expect(readUserConfig()).toEqual({ version: 1, defaultModel: { id: "gpt-5" } });
+  });
+
+  it("setDefaultModel overwrites a previous default", () => {
+    setDefaultModel({ id: "gpt-5" });
+    setDefaultModel({ id: "composer-2" });
+    expect(readUserConfig().defaultModel).toEqual({ id: "composer-2" });
+  });
+
+  it("clearDefaultModel removes the persisted default", () => {
+    setDefaultModel({ id: "gpt-5" });
+    clearDefaultModel();
+    expect(readUserConfig().defaultModel).toBeUndefined();
+  });
+
+  it("treats malformed config.json as the empty default", () => {
+    writeFileSync(getUserConfigPath(), "{ not json");
+    expect(readUserConfig()).toEqual({ version: 1 });
+  });
+
+  it("ignores defaultModel entries that lack an id", () => {
+    writeUserConfig({ version: 1, defaultModel: { id: "" } as { id: string } });
+    expect(readUserConfig().defaultModel).toBeUndefined();
+  });
+});
+
+describe("resolveDefaultModel resolution order", () => {
+  const fallback = { id: "composer-2" };
+
+  it("prefers the explicit override over everything", () => {
+    setDefaultModel({ id: "from-config" });
+    process.env[USER_CONFIG_ENV_MODEL] = "from-env";
+    const resolved = resolveDefaultModel(fallback, { override: { id: "from-flag" } });
+    expect(resolved).toEqual({ model: { id: "from-flag" }, source: "flag" });
+  });
+
+  it("uses CURSOR_MODEL when no override is supplied", () => {
+    setDefaultModel({ id: "from-config" });
+    process.env[USER_CONFIG_ENV_MODEL] = "from-env";
+    const resolved = resolveDefaultModel(fallback);
+    expect(resolved).toEqual({ model: { id: "from-env" }, source: "env" });
+  });
+
+  it("falls through to persisted config when env is unset", () => {
+    setDefaultModel({ id: "from-config" });
+    const resolved = resolveDefaultModel(fallback);
+    expect(resolved).toEqual({ model: { id: "from-config" }, source: "config" });
+  });
+
+  it("returns the fallback when nothing else is configured", () => {
+    const resolved = resolveDefaultModel(fallback);
+    expect(resolved).toEqual({ model: fallback, source: "fallback" });
+  });
+
+  it("treats whitespace-only CURSOR_MODEL as unset", () => {
+    process.env[USER_CONFIG_ENV_MODEL] = "   ";
+    const resolved = resolveDefaultModel(fallback);
+    expect(resolved.source).toBe("fallback");
+  });
+});

--- a/tests/unit/lib/user-config.test.mts
+++ b/tests/unit/lib/user-config.test.mts
@@ -74,14 +74,7 @@ describe("user-config persistence", () => {
 describe("resolveDefaultModel resolution order", () => {
   const fallback = { id: "composer-2" };
 
-  it("prefers the explicit override over everything", () => {
-    setDefaultModel({ id: "from-config" });
-    process.env[USER_CONFIG_ENV_MODEL] = "from-env";
-    const resolved = resolveDefaultModel(fallback, { override: { id: "from-flag" } });
-    expect(resolved).toEqual({ model: { id: "from-flag" }, source: "flag" });
-  });
-
-  it("uses CURSOR_MODEL when no override is supplied", () => {
+  it("uses CURSOR_MODEL when set", () => {
     setDefaultModel({ id: "from-config" });
     process.env[USER_CONFIG_ENV_MODEL] = "from-env";
     const resolved = resolveDefaultModel(fallback);


### PR DESCRIPTION
Adds a user-wide persisted default so users can pick their preferred
Cursor model once instead of passing --model on every /cursor:task.

- lib/user-config.mts persists { defaultModel } to <state-root>/config.json
- createAgent / resumeAgent / oneShot resolve the model in priority:
  --model flag > CURSOR_MODEL env > persisted config > composer-2 fallback
- /cursor:setup gains --set-model <id> (validated against the live catalog)
  and --clear-model; the report shows the active default and its source