### PR TITLE
docs: document model resolution chain in task and resume commands

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -740,7 +740,9 @@ without new abstractions.
 - [x] `commands/adversarial-review.md` — focus-text usage
 - [x] `commands/status.md` — `--wait`/`--timeout-ms`/`--poll-ms`
 - [x] `commands/task.md` — mention `--prompt-file`
+- [x] `commands/task.md` — document model resolution chain (flag > env > config > fallback)
 - [x] `commands/resume.md` — `--list --remote [--cloud]` discovery
+- [x] `commands/resume.md` — document model resolution chain
 - [x] `PLAN.md` — this section
 
 ### 9.7 Deliberately deferred

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -26,6 +26,9 @@ Usage:
 Inherits the same flags as `/cursor:task`: `--write`, `--background`, `--force`,
 `--cloud`, `--model <id>`, `--timeout <ms>`, `--json`.
 
+Model resolution: `--model` flag > `CURSOR_MODEL` env > persisted default
+(set via `/cursor:setup --set-model <id>`) > built-in fallback.
+
 Default policy is read-only — pass `--write` to allow file modifications.
 
 Surface the output verbatim. If `--list` returns `(no resumable agents)`, the

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -22,6 +22,9 @@ If the user passed `--write`, `--cloud`, `--background`, `--force`,
 to the subagent. `--prompt-file` is useful when the task description is
 long enough to be cumbersome inline.
 
+Model resolution: `--model` flag > `CURSOR_MODEL` env > persisted default
+(set via `/cursor:setup --set-model <id>`) > built-in fallback.
+
 When the result comes back, follow `cursor-result-handling/SKILL.md` —
 present the deliverables and any caveats clearly, do not silently accept
 the output.


### PR DESCRIPTION
Surfaces the flag > env > persisted-default > built-in precedence in the
slash command markdown so users discovering the plugin via /cursor:task or
/cursor:resume see the override path without having to read --help.

https://claude.ai/code/session_01V9LpYTpSzmbrRm2eQpeqhy