### PR TITLE
feat: esbuild bundle + bootstrap for plugin installability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 .env
 CLAUDE.local.md
 .claude/settings.local.json
+
+# Plugin bundle is committed (needed at install time)
+!plugins/cursor/scripts/bundle/

--- a/biome.json
+++ b/biome.json
@@ -6,7 +6,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": ["**", "!**/node_modules", "!**/dist", "!**/*.log"]
+    "includes": ["**", "!**/node_modules", "!**/dist", "!**/bundle", "!**/*.log"]
   },
   "formatter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
         "@types/node": "^25.6.0",
+        "esbuild": "^0.28.0",
         "husky": "^9.1.7",
         "typescript": "^6.0.3",
         "vitest": "^4.1.5"
@@ -334,6 +335,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -1237,6 +1680,48 @@
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json && node scripts/bundle.mjs",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "format": "biome format --write .",
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.13",
     "@types/node": "^25.6.0",
+    "esbuild": "^0.28.0",
     "husky": "^9.1.7",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"

--- a/plugins/cursor/agents/cursor-rescue.md
+++ b/plugins/cursor/agents/cursor-rescue.md
@@ -10,7 +10,7 @@ You are a thin forwarder. Your job is to:
 1. Take the prompt the parent passed in (`$ARGUMENTS`).
 2. Build exactly one shell command:
    ```bash
-   node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs task "<prompt>" --write
+   node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs task "<prompt>" --write
    ```
    Quote-escape the prompt; preserve any extra flags the caller passed
    (`--cloud`, `--force`, `--model`, `--background`, `--timeout`).

--- a/plugins/cursor/commands/adversarial-review.md
+++ b/plugins/cursor/commands/adversarial-review.md
@@ -11,7 +11,7 @@ defects, this prompt pushes back on premature abstractions, hidden coupling,
 unnecessary state, and brittle assumptions.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs adversarial-review $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs adversarial-review $ARGUMENTS
 ```
 
 Same output shape and flags as `/cursor:review`, plus free-form positional

--- a/plugins/cursor/commands/cancel.md
+++ b/plugins/cursor/commands/cancel.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 # /cursor:cancel
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs cancel $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs cancel $ARGUMENTS
 ```
 
 Required: a job id.

--- a/plugins/cursor/commands/result.md
+++ b/plugins/cursor/commands/result.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 # /cursor:result
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs result $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs result $ARGUMENTS
 ```
 
 Required: a job id (from `/cursor:status`).

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 # /cursor:resume
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs resume $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs resume $ARGUMENTS
 ```
 
 Resume a durable Cursor agent. The agent keeps the context from prior runs,

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 Run a Cursor-driven structured review of the current diff.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs review $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs review $ARGUMENTS
 ```
 
 Useful flags:

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 Run the plugin's self-check.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs setup $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs setup $ARGUMENTS
 ```
 
 Pass `--json` for machine-readable output. If anything fails (API key missing,

--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -7,7 +7,7 @@ disable-model-invocation: true
 # /cursor:status
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/cursor-companion.mjs status $ARGUMENTS
+node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs status $ARGUMENTS
 ```
 
 With no arguments: prints a table of recent jobs (id, type, status, age,

--- a/plugins/cursor/hooks/hooks.json
+++ b/plugins/cursor/hooks/hooks.json
@@ -5,8 +5,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/session-lifecycle-hook.mjs SessionStart",
-            "timeout": 5
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\" && node \"${CLAUDE_PLUGIN_ROOT}/scripts/bundle/session-lifecycle-hook.mjs\" SessionStart",
+            "timeout": 90
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/session-lifecycle-hook.mjs SessionEnd",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bundle/session-lifecycle-hook.mjs\" SessionEnd",
             "timeout": 5
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/dist/stop-review-gate-hook.mjs",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/bootstrap.mjs\" && node \"${CLAUDE_PLUGIN_ROOT}/scripts/bundle/stop-review-gate-hook.mjs\"",
             "timeout": 900
           }
         ]

--- a/plugins/cursor/package-lock.json
+++ b/plugins/cursor/package-lock.json
@@ -1,0 +1,1620 @@
+{
+  "name": "@cursor-plugin-cc/cursor",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cursor-plugin-cc/cursor",
+      "version": "0.1.0",
+      "dependencies": {
+        "@cursor/sdk": "^1.0.9"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+      "integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+      "integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+      "integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.4"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.10.0",
+        "@connectrpc/connect": "1.7.0"
+      }
+    },
+    "node_modules/@cursor/sdk": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.11.tgz",
+      "integrity": "sha512-DkTwOAuao9wIeUioaM0aQi6hkWLC8oLAnqlR4HR9hn5xytd9A4cEB2fZpSHd8pJ2YRN0VJVkxnggxLRNT7ghuQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@bufbuild/protobuf": "1.10.0",
+        "@connectrpc/connect": "^1.6.1",
+        "@connectrpc/connect-node": "^1.6.1",
+        "@statsig/js-client": "3.31.0",
+        "sqlite3": "^5.1.7",
+        "zod": "^3.25.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@cursor/sdk-darwin-arm64": "1.0.11",
+        "@cursor/sdk-darwin-x64": "1.0.11",
+        "@cursor/sdk-linux-arm64": "1.0.11",
+        "@cursor/sdk-linux-x64": "1.0.11",
+        "@cursor/sdk-win32-x64": "1.0.11"
+      }
+    },
+    "node_modules/@cursor/sdk-darwin-arm64": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.11.tgz",
+      "integrity": "sha512-jbbdt4k1Wjjzsye9kfJtn7nPHd1QgBtOA1tbmLVbXIVb5UeAu+q7uT/8aggm8qN8R151m/GNW2ntK29+Q8y/XQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-darwin-x64": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.11.tgz",
+      "integrity": "sha512-2352S+tGbaDgj2qb3oNN2FUG5250cn3cD+aKluETFd7jI7Pm3ctwInFN+/NWWnzwftibjKnwcc8ghm9q4xYfWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-arm64": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.11.tgz",
+      "integrity": "sha512-SGnwU1caprU6L7XCMUH48pyGdrZz1YQhPNUzrUyixHpdfM951KJmAQyuW9Hj2J4J3C1PG4XwIYRHsGN8/EOF2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-linux-x64": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.11.tgz",
+      "integrity": "sha512-zzVwEMc9ykyyFgxaXwfiB0Nuqnp0PkKqiWSt6Iubmi7ADY87dtVS67qwtmVQ+FJVA7iXV+c7LY2sQ2qfQ4aP2w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cursor/sdk-win32-x64": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.11.tgz",
+      "integrity": "sha512-iWvGDFhpW+C6/zah7feY3oURozJxQ78qjld+9ejOaRuuC6p33Q6D/3l6Ihst18lEH9WSjEJClydDFUbm7aPf5A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
+      "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
+      "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@statsig/client-core": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/client-core/-/client-core-3.31.0.tgz",
+      "integrity": "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ==",
+      "license": "ISC"
+    },
+    "node_modules/@statsig/js-client": {
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@statsig/js-client/-/js-client-3.31.0.tgz",
+      "integrity": "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g==",
+      "license": "ISC",
+      "dependencies": {
+        "@statsig/client-core": "3.31.0"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
+      "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "@npmcli/fs": "^1.0.0",
+        "@npmcli/move-file": "^1.0.1",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "glob": "^7.1.4",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.1",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.2",
+        "mkdirp": "^1.0.3",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^8.0.1",
+        "tar": "^6.0.2",
+        "unique-filename": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
+      "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "agentkeepalive": "^4.1.3",
+        "cacache": "^15.2.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "minipass": "^3.1.3",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^1.3.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.2",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^6.0.0",
+        "ssri": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
+      "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.0",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.12"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-gyp": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
+      "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^9.1.0",
+        "nopt": "^5.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
+      "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
+      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
+      "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/sqlite3": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
+      "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^7.0.0",
+        "prebuild-install": "^7.1.1",
+        "tar": "^6.1.11"
+      },
+      "optionalDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependencies": {
+        "node-gyp": "8.x"
+      },
+      "peerDependenciesMeta": {
+        "node-gyp": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ssri": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "integrity": "sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/unique-filename": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
+      "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "unique-slug": "^2.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -4,5 +4,8 @@
   "private": true,
   "description": "Claude Code plugin entry — see scripts/ for the CLI.",
   "type": "module",
-  "main": "scripts/dist/cursor-companion.mjs"
+  "main": "scripts/bundle/cursor-companion.mjs",
+  "dependencies": {
+    "@cursor/sdk": "^1.0.9"
+  }
 }

--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pluginRoot =
+  process.env.CLAUDE_PLUGIN_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
+
+const marker = join(pluginRoot, "node_modules", "@cursor", "sdk");
+
+if (!existsSync(marker)) {
+  try {
+    execSync("npm install --omit=dev --ignore-scripts=false", {
+      cwd: pluginRoot,
+      stdio: "pipe",
+      timeout: 60_000,
+    });
+  } catch {
+    // Best-effort — hooks must never crash Claude Code.
+  }
+}

--- a/plugins/cursor/scripts/bundle/chunk-AUSOW76U.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-AUSOW76U.mjs
@@ -1,0 +1,1267 @@
+import {
+  appendJobLog,
+  ensureStateDir,
+  readJob,
+  readJson,
+  readStateIndex,
+  resolveStateDir,
+  resolveStateRoot,
+  resolveWorkspaceRoot,
+  writeJob,
+  writeJsonAtomic,
+  writeStateIndex
+} from "./chunk-P7QODZNJ.mjs";
+
+// plugins/cursor/scripts/lib/args.mts
+var UsageError = class extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "UsageError";
+  }
+};
+function parseArgs(argv, spec = {}) {
+  const long = spec.long ?? {};
+  const short = spec.short ?? {};
+  const flags = {};
+  const positionals = [];
+  let stopParsing = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === void 0) continue;
+    if (stopParsing) {
+      positionals.push(arg);
+      continue;
+    }
+    if (arg === "--") {
+      stopParsing = true;
+      continue;
+    }
+    if (arg.startsWith("--")) {
+      const eqIdx = arg.indexOf("=");
+      const name = eqIdx === -1 ? arg.slice(2) : arg.slice(2, eqIdx);
+      const inlineValue = eqIdx === -1 ? void 0 : arg.slice(eqIdx + 1);
+      const kind = long[name];
+      if (kind === "boolean") {
+        if (inlineValue === "false") {
+          delete flags[name];
+        } else {
+          flags[name] = true;
+        }
+      } else if (kind === "string") {
+        if (inlineValue !== void 0) {
+          flags[name] = inlineValue;
+        } else {
+          const next = argv[i + 1];
+          if (next === void 0 || next.startsWith("-")) {
+            throw new UsageError(`expected value after --${name}`);
+          }
+          flags[name] = next;
+          i += 1;
+        }
+      } else {
+        if (inlineValue !== void 0) flags[name] = inlineValue;
+        else flags[name] = true;
+      }
+      continue;
+    }
+    if (arg.startsWith("-") && arg.length > 1) {
+      const shortName = arg.slice(1);
+      const longName = short[shortName];
+      if (!longName) {
+        throw new UsageError(`unknown short flag: ${arg}`);
+      }
+      const kind = long[longName];
+      if (kind === "string") {
+        const next = argv[i + 1];
+        if (next === void 0 || next.startsWith("-")) {
+          throw new UsageError(`expected value after ${arg}`);
+        }
+        flags[longName] = next;
+        i += 1;
+      } else {
+        flags[longName] = true;
+      }
+      continue;
+    }
+    positionals.push(arg);
+  }
+  return { positionals, flags };
+}
+function optionalString(parsed, name) {
+  const v = parsed.flags[name];
+  return typeof v === "string" ? v : void 0;
+}
+function bool(parsed, name) {
+  return parsed.flags[name] === true;
+}
+
+// plugins/cursor/scripts/lib/git.mts
+import { execFileSync } from "node:child_process";
+function runGit(cwd, args) {
+  try {
+    const out = execFileSync("git", ["-C", cwd, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    return out.replace(/\n+$/, "");
+  } catch {
+    return void 0;
+  }
+}
+function getDiff(cwd, options = {}) {
+  const args = ["diff", "--no-color"];
+  if (options.staged) args.push("--cached");
+  if (options.baseRef) args.push(options.baseRef);
+  return runGit(cwd, args) ?? "";
+}
+function getStatus(cwd) {
+  return runGit(cwd, ["status", "--short"]) ?? "";
+}
+function isDirty(cwd) {
+  return getStatus(cwd).length > 0;
+}
+function getRecentCommits(cwd, n) {
+  if (n <= 0) return [];
+  const out = runGit(cwd, ["log", `-${Math.floor(n)}`, "--pretty=format:%H%x09%s"]);
+  if (!out) return [];
+  return out.split("\n").filter((line) => line.length > 0).map((line) => {
+    const [hash, ...rest] = line.split("	");
+    return { hash: hash ?? "", subject: rest.join("	") };
+  });
+}
+function getBranch(cwd) {
+  const out = runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  if (!out || out === "HEAD") return void 0;
+  return out;
+}
+function detectDefaultBranch(cwd) {
+  for (const candidate of ["main", "master", "trunk"]) {
+    const local = runGit(cwd, ["show-ref", "--verify", "--quiet", `refs/heads/${candidate}`]);
+    if (local !== void 0) return candidate;
+    const remote = runGit(cwd, [
+      "show-ref",
+      "--verify",
+      "--quiet",
+      `refs/remotes/origin/${candidate}`
+    ]);
+    if (remote !== void 0) return `origin/${candidate}`;
+  }
+  return void 0;
+}
+function resolveReviewTarget(cwd, options = {}) {
+  const scope = options.scope ?? "auto";
+  const baseRef = options.baseRef;
+  if (baseRef) {
+    return { mode: "branch", baseRef, label: `branch diff against ${baseRef}`, explicit: true };
+  }
+  if (scope === "working-tree") {
+    return { mode: "working-tree", label: "working tree diff", explicit: true };
+  }
+  if (scope === "branch") {
+    const detected2 = detectDefaultBranch(cwd);
+    if (!detected2) {
+      throw new Error(
+        "Unable to detect default branch (looked for main/master/trunk). Pass --base <ref> or use --scope working-tree."
+      );
+    }
+    return {
+      mode: "branch",
+      baseRef: detected2,
+      label: `branch diff against ${detected2}`,
+      explicit: true
+    };
+  }
+  if (scope !== "auto") {
+    throw new Error(
+      `Unsupported review scope "${scope}". Use one of: auto, working-tree, branch, or pass --base <ref>.`
+    );
+  }
+  if (isDirty(cwd)) {
+    return { mode: "working-tree", label: "working tree diff", explicit: false };
+  }
+  const detected = detectDefaultBranch(cwd);
+  if (!detected) {
+    return {
+      mode: "working-tree",
+      label: "working tree diff (no default branch)",
+      explicit: false
+    };
+  }
+  return {
+    mode: "branch",
+    baseRef: detected,
+    label: `branch diff against ${detected}`,
+    explicit: false
+  };
+}
+function getRemoteUrl(cwd) {
+  return runGit(cwd, ["config", "--get", "remote.origin.url"]) || void 0;
+}
+function normalizeGitHubRemote(remote) {
+  const trimmed = remote.trim().replace(/\.git$/, "");
+  const sshMatch = trimmed.match(/^git@github\.com:(.+\/.+)$/);
+  const sshUrlMatch = trimmed.match(/^ssh:\/\/git@github\.com\/(.+\/.+)$/);
+  const httpsMatch = trimmed.match(/^https:\/\/github\.com\/(.+\/.+)$/);
+  const repoPath = sshMatch?.[1] ?? sshUrlMatch?.[1] ?? httpsMatch?.[1];
+  return repoPath ? `https://github.com/${repoPath}` : void 0;
+}
+function detectCloudRepository(cwd) {
+  const remote = getRemoteUrl(cwd);
+  if (!remote) {
+    throw new Error(
+      "Cloud mode requires a git repository with remote.origin.url set. Configure a remote or run in --local mode."
+    );
+  }
+  const url = normalizeGitHubRemote(remote);
+  if (!url) {
+    throw new Error(
+      `Cloud mode currently expects remote.origin.url to point at GitHub. Got: ${remote}`
+    );
+  }
+  const branch = getBranch(cwd);
+  return branch ? { url, startingRef: branch } : { url };
+}
+
+// plugins/cursor/scripts/lib/cursor-agent.mts
+import {
+  Agent,
+  ConfigurationError,
+  Cursor
+} from "@cursor/sdk";
+
+// plugins/cursor/scripts/lib/retry.mts
+var DEFAULT_ATTEMPTS = 3;
+var DEFAULT_BASE_DELAY_MS = 200;
+var DEFAULT_MAX_DELAY_MS = 4e3;
+function defaultShouldRetry(error) {
+  if (!error || typeof error !== "object") return false;
+  return error.isRetryable === true;
+}
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+async function withRetry(fn, options = {}) {
+  const attempts = Math.max(1, options.attempts ?? DEFAULT_ATTEMPTS);
+  const base = Math.max(0, options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS);
+  const cap = Math.max(base, options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS);
+  const shouldRetry = options.shouldRetry ?? defaultShouldRetry;
+  const sleep = options.sleep ?? defaultSleep;
+  let lastError;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const isLast = attempt === attempts - 1;
+      if (isLast || !shouldRetry(err)) throw err;
+      const delay = Math.min(cap, base * 2 ** attempt);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+// plugins/cursor/scripts/lib/user-config.mts
+import path from "node:path";
+var USER_CONFIG_ENV_MODEL = "CURSOR_MODEL";
+function getUserConfigPath(opts = {}) {
+  return path.join(resolveStateRoot(opts), "config.json");
+}
+function readUserConfig(opts = {}) {
+  const data = readJson(getUserConfigPath(opts));
+  if (!data || typeof data !== "object") return { version: 1 };
+  const out = { version: 1 };
+  if (data.defaultModel && typeof data.defaultModel === "object" && data.defaultModel.id) {
+    out.defaultModel = data.defaultModel;
+  }
+  return out;
+}
+function writeUserConfig(config, opts = {}) {
+  writeJsonAtomic(getUserConfigPath(opts), { ...config, version: 1 });
+}
+function setDefaultModel(model, opts = {}) {
+  const next = { ...readUserConfig(opts), defaultModel: model };
+  writeUserConfig(next, opts);
+  return next;
+}
+function clearDefaultModel(opts = {}) {
+  const { defaultModel: _drop, ...rest } = readUserConfig(opts);
+  writeUserConfig(rest, opts);
+  return rest;
+}
+function resolveDefaultModel(fallback, opts = {}) {
+  const envId = process.env[USER_CONFIG_ENV_MODEL]?.trim();
+  if (envId) return { model: { id: envId }, source: "env" };
+  const cfg = readUserConfig(opts);
+  if (cfg.defaultModel) return { model: cfg.defaultModel, source: "config" };
+  return { model: fallback, source: "fallback" };
+}
+
+// plugins/cursor/scripts/lib/cursor-agent.mts
+var DEFAULT_MODEL = { id: "composer-2" };
+function resolveApiKey(apiKey) {
+  const resolved = apiKey ?? process.env.CURSOR_API_KEY;
+  if (!resolved || resolved.trim() === "") {
+    throw new ConfigurationError(
+      "CURSOR_API_KEY is not set. Export your Cursor API key or pass apiKey explicitly."
+    );
+  }
+  return resolved;
+}
+var DEFAULT_AGENT_INSTRUCTIONS = [
+  "You are a coding agent invoked by Claude Code via the cursor-plugin-cc plugin.",
+  "Operate in the configured workspace.",
+  "Make focused, well-scoped changes; preserve unrelated user work.",
+  "Before changing files, understand the surrounding code.",
+  "Keep progress updates concise and summarize the result clearly at the end."
+].join("\n");
+var WRITE_POLICY = "You may modify files in the workspace.";
+var READ_ONLY_POLICY = "Do NOT modify files. Read and analyze only \u2014 produce diffs/suggestions in your response, but do not write to disk.";
+function writePolicyText(write) {
+  return write ? WRITE_POLICY : READ_ONLY_POLICY;
+}
+function buildPrompt(prompt, instructions) {
+  const sys = instructions ?? DEFAULT_AGENT_INSTRUCTIONS;
+  return `${sys}
+
+User task:
+${prompt}`;
+}
+function buildAgentOptionsFromFlags(workspaceRoot, flags) {
+  const opts = { cwd: workspaceRoot };
+  if (flags.model) opts.model = flags.model;
+  if (flags.cloud) {
+    opts.mode = "cloud";
+    opts.cloudRepo = detectCloudRepository(workspaceRoot);
+  }
+  return opts;
+}
+function buildAgentOptions(opts) {
+  const apiKey = resolveApiKey(opts.apiKey);
+  const model = opts.model ?? resolveDefaultModel(DEFAULT_MODEL).model;
+  const mode = opts.mode ?? "local";
+  const base = {
+    apiKey,
+    model,
+    ...opts.name ? { name: opts.name } : {},
+    ...opts.mcpServers ? { mcpServers: opts.mcpServers } : {}
+  };
+  if (mode === "cloud") {
+    if (!opts.cloudRepo) {
+      throw new ConfigurationError(
+        "Cloud mode requires a cloudRepo (url, optional startingRef). Use detectCloudRepository() from lib/git.mts."
+      );
+    }
+    const repo = { url: opts.cloudRepo.url };
+    if (opts.cloudRepo.startingRef) repo.startingRef = opts.cloudRepo.startingRef;
+    return { ...base, cloud: { repos: [repo] } };
+  }
+  return {
+    ...base,
+    local: {
+      cwd: opts.cwd,
+      ...opts.settingSources ? { settingSources: opts.settingSources } : {}
+    }
+  };
+}
+async function createAgent(opts) {
+  return Agent.create(buildAgentOptions(opts));
+}
+async function resumeAgent(agentId, opts) {
+  return Agent.resume(agentId, buildAgentOptions(opts));
+}
+async function disposeAgent(agent) {
+  await agent[Symbol.asyncDispose]();
+}
+async function sendTask(agent, prompt, options = {}) {
+  const run = options.force ? await agent.send(prompt, { local: { force: true } }) : await agent.send(prompt);
+  options.onRunStart?.(run);
+  return collectRunResult(run, options);
+}
+async function oneShot(prompt, opts) {
+  const { timeoutMs, onEvent, onRunStart, force, ...agentOpts } = opts;
+  const agent = await createAgent(agentOpts);
+  try {
+    const sendOpts = {};
+    if (timeoutMs !== void 0) sendOpts.timeoutMs = timeoutMs;
+    if (onEvent !== void 0) sendOpts.onEvent = onEvent;
+    if (onRunStart !== void 0) sendOpts.onRunStart = onRunStart;
+    if (force !== void 0) sendOpts.force = force;
+    return await sendTask(agent, prompt, sendOpts);
+  } finally {
+    await disposeAgent(agent).catch(() => {
+    });
+  }
+}
+async function cancelRun(run) {
+  if (!run.supports("cancel")) {
+    const reason = run.unsupportedReason("cancel") ?? "This run cannot be cancelled.";
+    return { cancelled: false, reason };
+  }
+  await run.cancel();
+  return { cancelled: true };
+}
+async function listRemoteAgents(options) {
+  const limit = options.limit ?? 25;
+  const listOpts = options.runtime === "cloud" ? { runtime: "cloud", limit } : { runtime: "local", cwd: options.cwd, limit };
+  const { items } = await Agent.list(listOpts);
+  return items.map((info) => ({
+    agentId: info.agentId,
+    name: info.name,
+    summary: info.summary,
+    lastModified: info.lastModified,
+    ...info.status ? { status: info.status } : {},
+    ...info.archived !== void 0 ? { archived: info.archived } : {},
+    ...info.runtime ? { runtime: info.runtime } : {}
+  }));
+}
+async function whoami(opts = {}) {
+  const apiKey = resolveApiKey(opts.apiKey);
+  return withRetry(() => Cursor.me({ apiKey }), opts.retry);
+}
+async function listModels(opts = {}) {
+  const apiKey = resolveApiKey(opts.apiKey);
+  return withRetry(() => Cursor.models.list({ apiKey }), opts.retry);
+}
+async function validateModel(model, opts = {}) {
+  const models = opts.catalog ?? await listModels(opts);
+  const match = models.find((m) => m.id === model.id);
+  if (!match) {
+    const known = models.map((m) => m.id).join(", ") || "(none)";
+    throw new ConfigurationError(
+      `Model '${model.id}' is not available for this API key. Known models: ${known}`
+    );
+  }
+  return match;
+}
+function normalizeStreamStatus(status) {
+  return status.toLowerCase();
+}
+function toAgentEvents(message) {
+  switch (message.type) {
+    case "assistant": {
+      const events = [];
+      for (const block of message.message.content) {
+        if (block.type === "text") {
+          events.push({ type: "assistant_text", text: block.text });
+        } else {
+          events.push({
+            type: "tool",
+            callId: block.id,
+            name: block.name,
+            status: "requested",
+            args: block.input
+          });
+        }
+      }
+      return events;
+    }
+    case "thinking":
+      return [{ type: "thinking", text: message.text }];
+    case "tool_call":
+      return [
+        {
+          type: "tool",
+          callId: message.call_id,
+          name: message.name,
+          status: message.status,
+          args: message.args
+        }
+      ];
+    case "status":
+      return [
+        {
+          type: "status",
+          status: normalizeStreamStatus(message.status),
+          ...message.message ? { message: message.message } : {}
+        }
+      ];
+    case "task":
+      return [
+        {
+          type: "task",
+          ...message.status ? { status: message.status } : {},
+          ...message.text ? { text: message.text } : {}
+        }
+      ];
+    case "system":
+      return [
+        {
+          type: "system",
+          ...message.model ? { model: message.model } : {},
+          ...message.tools ? { tools: message.tools } : {}
+        }
+      ];
+    default:
+      return [];
+  }
+}
+async function collectRunResult(run, options) {
+  const toolCalls = /* @__PURE__ */ new Map();
+  const textParts = [];
+  let observedTerminalStatus;
+  let timedOut = false;
+  const timeout = options.timeoutMs !== void 0 && options.timeoutMs > 0 ? setTimeout(() => {
+    timedOut = true;
+    if (run.supports("cancel")) {
+      run.cancel().catch(() => {
+      });
+    }
+  }, options.timeoutMs) : void 0;
+  try {
+    for await (const event of run.stream()) {
+      options.onEvent?.(event);
+      ingestEvent(event, textParts, toolCalls);
+      if (event.type === "status") {
+        const normalized = normalizeStreamStatus(event.status);
+        if (normalized === "finished" || normalized === "error" || normalized === "cancelled" || normalized === "expired") {
+          observedTerminalStatus = normalized;
+        }
+      }
+    }
+    if (timeout) clearTimeout(timeout);
+    const result = await run.wait();
+    const status = timedOut ? "cancelled" : observedTerminalStatus ?? result.status;
+    return {
+      status,
+      output: result.result ?? textParts.join(""),
+      toolCalls: [...toolCalls.values()],
+      agentId: run.agentId,
+      runId: run.id,
+      durationMs: result.durationMs,
+      ...timedOut ? { timedOut: true } : {}
+    };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+function ingestEvent(event, textParts, toolCalls) {
+  if (event.type === "assistant") {
+    for (const block of event.message.content) {
+      if (block.type === "text") textParts.push(block.text);
+    }
+    return;
+  }
+  if (event.type === "tool_call") {
+    toolCalls.set(event.call_id, {
+      callId: event.call_id,
+      name: event.name,
+      status: event.status,
+      args: event.args,
+      result: event.result
+    });
+  }
+}
+
+// plugins/cursor/scripts/lib/redact.mts
+var PLACEHOLDER = "[REDACTED]";
+var MIN_KEY_LENGTH = 8;
+function redactSecret(text, secret) {
+  if (!secret || secret.length < MIN_KEY_LENGTH) return text;
+  return text.split(secret).join(PLACEHOLDER);
+}
+function redactApiKey(text) {
+  return redactSecret(text, process.env.CURSOR_API_KEY);
+}
+function redactError(error) {
+  if (error instanceof Error) {
+    const parts = [error.message];
+    const cause = error.cause;
+    if (cause instanceof Error && cause.message && cause.message !== error.message) {
+      parts.push(`(cause: ${cause.message})`);
+    }
+    return redactApiKey(parts.join(" "));
+  }
+  return redactApiKey(String(error));
+}
+
+// plugins/cursor/scripts/lib/render.mts
+function compactText(text) {
+  return text.replace(/\s+/g, " ").trim();
+}
+var TOOL_SUMMARY_KEYS = {
+  read: [["path", "filePath", "target_file", "absolutePath"], ["offset"], ["limit"]],
+  glob: [
+    ["pattern", "glob", "glob_pattern"],
+    ["path", "cwd", "target_directory"]
+  ],
+  grep: [["pattern", "query"], ["path"], ["glob"], ["type"]],
+  search: [["pattern", "query"], ["path"], ["glob"], ["type"]],
+  shell: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"]
+  ],
+  terminal: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"]
+  ],
+  command: [
+    ["command", "cmd"],
+    ["cwd", "working_directory"]
+  ],
+  edit: [["path", "target_file", "file"], ["instruction"]],
+  write: [["path", "target_file", "file"], ["instruction"]],
+  patch: [["path", "target_file", "file"], ["instruction"]]
+};
+var TOOL_SUMMARY_FALLBACK = [
+  ["path", "file", "target_file"],
+  ["pattern", "query", "command"]
+];
+function getToolSummaryKeys(toolName) {
+  const lower = toolName.toLowerCase();
+  for (const [needle, keys] of Object.entries(TOOL_SUMMARY_KEYS)) {
+    if (lower.includes(needle)) return keys;
+  }
+  return TOOL_SUMMARY_FALLBACK;
+}
+function shortenValue(value, maxLength = 80) {
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+function formatArgValue(value) {
+  if (typeof value === "string") return shortenValue(value.replace(/\s+/g, " ").trim());
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) {
+    const items = value.slice(0, 3).map(formatArgValue).filter(Boolean);
+    return items.length > 0 ? `[${items.join(",")}]` : void 0;
+  }
+  return void 0;
+}
+function summarizeToolArgs(toolName, args) {
+  if (!args || typeof args !== "object") return void 0;
+  const record = args;
+  const groups = getToolSummaryKeys(toolName);
+  const parts = [];
+  for (const keys of groups) {
+    for (const key of keys) {
+      const value = record[key];
+      const formatted = formatArgValue(value);
+      if (formatted) {
+        parts.push(`${key}=${formatted}`);
+        break;
+      }
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : void 0;
+}
+function renderStreamEvent(event, options = {}) {
+  switch (event.type) {
+    case "assistant_text":
+      return { stdout: event.text };
+    case "thinking": {
+      const t = compactText(event.text);
+      return t ? { stderr: `[thinking] ${t}
+` } : {};
+    }
+    case "tool": {
+      const summary = summarizeToolArgs(event.name, event.args);
+      const tail = summary ? ` ${summary}` : "";
+      return { stderr: `[tool] ${event.status} ${event.name}${tail}
+` };
+    }
+    case "status": {
+      if (options.quietStatus && event.status === "finished") return {};
+      const msg = event.message ? ` ${compactText(event.message)}` : "";
+      return { stderr: `[status] ${event.status}${msg}
+` };
+    }
+    case "task": {
+      const head = [event.status, event.text].filter((s) => Boolean(s));
+      if (head.length === 0) return {};
+      return { stderr: `[task] ${compactText(head.join(" "))}
+` };
+    }
+    case "system":
+      return {};
+  }
+}
+var TABLE_HEADERS = ["id", "type", "status", "age", "summary"];
+function rowsFromJobs(jobs, now) {
+  return jobs.map((job) => {
+    const created = Date.parse(job.createdAt);
+    const ageMs = Number.isFinite(created) ? now - created : 0;
+    return {
+      id: job.id,
+      type: job.type,
+      status: job.status,
+      age: formatAge(ageMs),
+      summary: job.summary ? compactText(job.summary).slice(0, 60) : ""
+    };
+  });
+}
+function formatAge(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "?";
+  const sec = Math.floor(ms / 1e3);
+  if (sec < 60) return `${sec}s`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h`;
+  return `${Math.floor(hr / 24)}d`;
+}
+function ageFromIso(iso, now = Date.now()) {
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? formatAge(now - t) : "?";
+}
+function renderJobTable(jobs, now = Date.now()) {
+  if (jobs.length === 0) return "(no jobs)\n";
+  const rows = rowsFromJobs(jobs, now);
+  const widths = {
+    id: "id".length,
+    type: "type".length,
+    status: "status".length,
+    age: "age".length,
+    summary: "summary".length
+  };
+  for (const r of rows) {
+    for (const key of TABLE_HEADERS) {
+      widths[key] = Math.max(widths[key], r[key].length);
+    }
+  }
+  const header = TABLE_HEADERS.map((k) => k.toUpperCase().padEnd(widths[k])).join("  ");
+  const separator = TABLE_HEADERS.map((k) => "-".repeat(widths[k])).join("  ");
+  const body = rows.map((r) => TABLE_HEADERS.map((k) => r[k].padEnd(widths[k])).join("  ")).join("\n");
+  return `${header}
+${separator}
+${body}
+`;
+}
+var SEVERITY_ORDER = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3
+};
+function renderReviewResult(review) {
+  const lines = [];
+  lines.push(`verdict: ${review.verdict}`);
+  if (review.summary) lines.push("", review.summary);
+  const findings = [...review.findings].sort((a, b) => {
+    const sev = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (sev !== 0) return sev;
+    return a.file.localeCompare(b.file);
+  });
+  if (findings.length === 0) {
+    lines.push("", "findings: (none)");
+  } else {
+    lines.push("", `findings: ${findings.length}`);
+    for (const f of findings) {
+      const loc = f.line_start === f.line_end ? `${f.file}:${f.line_start}` : `${f.file}:${f.line_start}-${f.line_end}`;
+      const conf = Number.isFinite(f.confidence) ? `(confidence ${f.confidence.toFixed(2)})` : "";
+      lines.push("", `[${f.severity.toUpperCase()}] ${f.title} \u2014 ${loc} ${conf}`.trim(), f.body);
+      if (f.recommendation) {
+        lines.push(`  \u2192 ${f.recommendation}`);
+      }
+    }
+  }
+  if (review.next_steps.length > 0) {
+    lines.push("", "next steps:");
+    for (const step of review.next_steps) {
+      lines.push(`  - ${step}`);
+    }
+  }
+  return `${lines.join("\n")}
+`;
+}
+function renderError(error) {
+  return `error: ${redactError(error)}
+`;
+}
+
+// plugins/cursor/scripts/lib/job-control.mts
+import crypto from "node:crypto";
+var JOB_ID_BYTES = 6;
+function newJobId(type) {
+  const prefix = type === "adversarial-review" ? "adv" : type;
+  return `${prefix}-${crypto.randomBytes(JOB_ID_BYTES).toString("hex")}`;
+}
+function nowIso() {
+  return (/* @__PURE__ */ new Date()).toISOString();
+}
+function summarize(prompt, max = 80) {
+  const compact = prompt.replace(/\s+/g, " ").trim();
+  return compact.length <= max ? compact : `${compact.slice(0, max - 3)}...`;
+}
+function indexEntry(record) {
+  const entry = {
+    id: record.id,
+    type: record.type,
+    status: record.status,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt
+  };
+  const summary = record.metadata && typeof record.metadata.summary === "string" ? record.metadata.summary : summarize(record.prompt);
+  if (summary) entry.summary = summary;
+  return entry;
+}
+function upsertIndex(stateDir, record) {
+  const idx = readStateIndex(stateDir);
+  const entry = indexEntry(record);
+  const i = idx.jobs.findIndex((j) => j.id === record.id);
+  if (i === -1) {
+    idx.jobs.unshift(entry);
+  } else {
+    idx.jobs[i] = entry;
+  }
+  writeStateIndex(stateDir, idx);
+}
+function createJob(stateDir, input) {
+  const id = newJobId(input.type);
+  const created = nowIso();
+  const metadata = input.metadata || input.summary ? { ...input.metadata ?? {}, ...input.summary ? { summary: input.summary } : {} } : void 0;
+  const record = {
+    id,
+    type: input.type,
+    status: "pending",
+    prompt: input.prompt,
+    createdAt: created,
+    updatedAt: created,
+    ...metadata ? { metadata } : {}
+  };
+  writeJob(stateDir, record);
+  upsertIndex(stateDir, record);
+  return record;
+}
+function getJob(stateDir, jobId) {
+  return readJob(stateDir, jobId);
+}
+function listJobs(stateDir, filter = {}) {
+  const idx = readStateIndex(stateDir);
+  let entries = [...idx.jobs].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  if (filter.type) entries = entries.filter((j) => j.type === filter.type);
+  if (filter.status) entries = entries.filter((j) => j.status === filter.status);
+  if (typeof filter.limit === "number" && filter.limit >= 0) {
+    entries = entries.slice(0, Math.floor(filter.limit));
+  }
+  return entries;
+}
+function findRecentTaskAgents(stateDir, limit = 10, lookahead = Math.max(limit * 2, 20)) {
+  const recent = listJobs(stateDir, { type: "task", limit: lookahead });
+  const out = [];
+  for (const entry of recent) {
+    if (out.length >= limit) break;
+    const job = readJob(stateDir, entry.id);
+    if (!job?.agentId) continue;
+    const ref = {
+      jobId: job.id,
+      agentId: job.agentId,
+      createdAt: job.createdAt
+    };
+    if (entry.summary) ref.summary = entry.summary;
+    out.push(ref);
+  }
+  return out;
+}
+function update(stateDir, jobId, input) {
+  const existing = readJob(stateDir, jobId);
+  if (!existing) {
+    throw new Error(`job not found: ${jobId}`);
+  }
+  const next = {
+    ...existing,
+    ...input,
+    metadata: input.metadata ? { ...existing.metadata ?? {}, ...input.metadata } : existing.metadata,
+    updatedAt: nowIso()
+  };
+  writeJob(stateDir, next);
+  upsertIndex(stateDir, next);
+  return next;
+}
+function markRunning(stateDir, jobId, refs) {
+  return update(stateDir, jobId, {
+    status: "running",
+    startedAt: nowIso(),
+    agentId: refs.agentId,
+    runId: refs.runId
+  });
+}
+function markFinished(stateDir, jobId, result) {
+  let status;
+  let extraMetadata;
+  switch (result.status) {
+    case "finished":
+      status = "completed";
+      break;
+    case "error":
+      status = "failed";
+      break;
+    case "cancelled":
+      status = "cancelled";
+      break;
+    case "expired":
+      status = "cancelled";
+      extraMetadata = { expired: true };
+      break;
+  }
+  const updates = {
+    status,
+    finishedAt: nowIso(),
+    agentId: result.agentId,
+    runId: result.runId,
+    result: result.output
+  };
+  if (typeof result.durationMs === "number") updates.durationMs = result.durationMs;
+  if (result.timedOut || extraMetadata) {
+    updates.metadata = { ...result.timedOut ? { timedOut: true } : {}, ...extraMetadata };
+  }
+  return update(stateDir, jobId, updates);
+}
+function markFailed(stateDir, jobId, error) {
+  return update(stateDir, jobId, {
+    status: "failed",
+    finishedAt: nowIso(),
+    error: redactApiKey(error)
+  });
+}
+function markCancelled(stateDir, jobId, reason) {
+  const updates = {
+    status: "cancelled",
+    finishedAt: nowIso()
+  };
+  if (reason) updates.metadata = { cancelReason: reason };
+  return update(stateDir, jobId, updates);
+}
+var activeRuns = /* @__PURE__ */ new Map();
+function registerActiveRun(jobId, run) {
+  activeRuns.set(jobId, run);
+}
+function unregisterActiveRun(jobId) {
+  activeRuns.delete(jobId);
+}
+async function cancelJob(stateDir, jobId) {
+  const job = readJob(stateDir, jobId);
+  if (!job) {
+    return { cancelled: false, reason: `job not found: ${jobId}` };
+  }
+  if (job.status !== "pending" && job.status !== "running") {
+    return { cancelled: false, reason: `job is ${job.status}`, job };
+  }
+  const run = activeRuns.get(jobId);
+  if (!run) {
+    const updated2 = markCancelled(stateDir, jobId, "run-not-active");
+    return { cancelled: true, reason: "run-not-active", job: updated2 };
+  }
+  const result = await cancelRun(run);
+  if (!result.cancelled) {
+    return { cancelled: false, reason: result.reason, job };
+  }
+  const updated = markCancelled(stateDir, jobId, result.reason);
+  activeRuns.delete(jobId);
+  return { cancelled: true, ...result.reason ? { reason: result.reason } : {}, job: updated };
+}
+function logJobLine(stateDir, jobId, line) {
+  const scrubbed = redactApiKey(line);
+  const text = scrubbed.endsWith("\n") ? scrubbed : `${scrubbed}
+`;
+  appendJobLog(stateDir, jobId, text);
+}
+
+// plugins/cursor/scripts/commands/review.mts
+var HELP = `cursor-companion review [flags]
+cursor-companion adversarial-review [flags] [focus text...]
+
+Review a git diff. Returns a structured ReviewOutput JSON: verdict, summary,
+findings[], next_steps[]. Adversarial-review additionally accepts free-form
+focus text as positional arguments \u2014 those are passed to the reviewer as the
+priority axis.
+
+flags:
+  --staged             Review staged changes only (git diff --cached)
+  --scope <auto|working-tree|branch>
+                       Review scope. 'auto' (default) picks working-tree when
+                       the tree is dirty, otherwise branch-vs-default-branch.
+                       Mutually exclusive with --staged.
+  --base <ref>         Diff against this ref. Implies branch scope.
+  --model <id>         Override the default model
+  --timeout <ms>       Cancel the review if it exceeds this duration
+  --json               Print the raw structured review JSON
+  --help, -h
+`;
+var VALID_SCOPES = /* @__PURE__ */ new Set(["auto", "working-tree", "branch"]);
+var REVIEW_INSTRUCTIONS = [
+  "You are a senior code reviewer doing a focused review of a small change.",
+  "Be precise and concrete. Cite the exact file:line that triggers each finding.",
+  "Distinguish severity: critical (likely to break prod), high (clear bug or security issue),",
+  "  medium (correctness/design concern), low (style/nit).",
+  "Confidence is 0.0\u20131.0; be honest, do not bluff at 1.0.",
+  "Output ONLY a single JSON object matching the schema below \u2014 no prose, no markdown fences."
+].join("\n");
+var ADVERSARIAL_INSTRUCTIONS = [
+  "You are an adversarial reviewer. Your job is to challenge design choices,",
+  "  not just hunt for defects. Push back on premature abstractions, hidden coupling,",
+  "  unnecessary state, brittle assumptions, and missing edge cases.",
+  "Be precise: cite file:line for each finding. Don't manufacture issues \u2014 if the",
+  "  change is genuinely simple and correct, say so and approve.",
+  "Output ONLY a single JSON object matching the schema below \u2014 no prose, no markdown fences."
+].join("\n");
+var SCHEMA = `{
+  "verdict": "approve" | "needs-attention",
+  "summary": string,
+  "findings": [{
+    "severity": "critical" | "high" | "medium" | "low",
+    "title": string,
+    "body": string,
+    "file": string,
+    "line_start": number,
+    "line_end": number,
+    "confidence": number,
+    "recommendation": string
+  }],
+  "next_steps": string[]
+}`;
+var HelpRequested = class extends Error {
+};
+function parseFlags(args) {
+  const parsed = parseArgs(args, {
+    long: {
+      staged: "boolean",
+      scope: "string",
+      base: "string",
+      model: "string",
+      timeout: "string",
+      json: "boolean",
+      help: "boolean"
+    },
+    short: { h: "help", m: "model" }
+  });
+  if (bool(parsed, "help")) throw new HelpRequested();
+  const staged = bool(parsed, "staged");
+  const scopeRaw = optionalString(parsed, "scope");
+  if (scopeRaw && !VALID_SCOPES.has(scopeRaw)) {
+    throw new UsageError(
+      `invalid --scope: ${scopeRaw} (expected one of ${[...VALID_SCOPES].join(", ")})`
+    );
+  }
+  if (staged && scopeRaw && scopeRaw !== "working-tree") {
+    throw new UsageError("--staged is only compatible with --scope working-tree");
+  }
+  const flags = {
+    staged,
+    scope: scopeRaw ?? "auto",
+    json: bool(parsed, "json"),
+    focus: parsed.positionals.join(" ").trim()
+  };
+  const base = optionalString(parsed, "base");
+  if (base) flags.baseRef = base;
+  const modelId = optionalString(parsed, "model");
+  if (modelId) flags.model = { id: modelId };
+  const timeout = optionalString(parsed, "timeout");
+  if (timeout) {
+    const ms = Number(timeout);
+    if (!Number.isFinite(ms) || ms <= 0) throw new UsageError(`invalid --timeout: ${timeout}`);
+    flags.timeoutMs = ms;
+  }
+  return flags;
+}
+function buildReviewPrompt(input) {
+  const sections = [
+    input.instructions,
+    "",
+    "Output schema:",
+    SCHEMA,
+    "",
+    `Review target: ${input.targetLabel}`,
+    ""
+  ];
+  if (input.focus) {
+    sections.push("Reviewer focus (priority axis):", input.focus, "");
+  }
+  sections.push("Working-tree status:", input.status || "(clean)", "");
+  sections.push("Diff to review:", input.diff);
+  return sections.join("\n");
+}
+function extractJson(raw) {
+  const trimmed = raw.trim();
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/);
+  if (fenced) return fenced[1] ?? trimmed;
+  return trimmed;
+}
+function parseReview(raw) {
+  const text = extractJson(raw);
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `review output was not valid JSON: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!parsed || typeof parsed !== "object") throw new Error("review output is not an object");
+  const obj = parsed;
+  if (obj.verdict !== "approve" && obj.verdict !== "needs-attention") {
+    throw new Error(`review verdict is invalid: ${JSON.stringify(obj.verdict)}`);
+  }
+  if (typeof obj.summary !== "string") throw new Error("review summary missing");
+  if (!Array.isArray(obj.findings)) throw new Error("review findings must be an array");
+  if (!Array.isArray(obj.next_steps)) throw new Error("review next_steps must be an array");
+  return parsed;
+}
+async function runReview(args, io, options) {
+  let flags;
+  try {
+    flags = parseFlags(args);
+  } catch (err) {
+    if (err instanceof HelpRequested) {
+      io.stdout.write(HELP);
+      return 0;
+    }
+    throw err;
+  }
+  if (flags.focus && !options.adversarial) {
+    throw new UsageError(
+      "free-form focus text is only accepted for adversarial-review (got positional args)"
+    );
+  }
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+  const diffOpts = {};
+  let targetLabel;
+  if (flags.staged) {
+    diffOpts.staged = true;
+    targetLabel = "staged diff";
+  } else {
+    const target = resolveReviewTarget(workspaceRoot, {
+      scope: flags.scope,
+      ...flags.baseRef ? { baseRef: flags.baseRef } : {}
+    });
+    if (target.baseRef) diffOpts.baseRef = target.baseRef;
+    targetLabel = target.label;
+  }
+  const diff = getDiff(workspaceRoot, diffOpts);
+  if (!diff) {
+    io.stderr.write("nothing to review (empty diff)\n");
+    return 0;
+  }
+  const instructions = options.adversarial ? ADVERSARIAL_INSTRUCTIONS : REVIEW_INSTRUCTIONS;
+  const prompt = buildReviewPrompt({
+    diff,
+    status: getStatus(workspaceRoot),
+    instructions,
+    targetLabel,
+    focus: flags.focus
+  });
+  const job = createJob(stateDir, {
+    type: options.adversarial ? "adversarial-review" : "review",
+    prompt: `${options.adversarial ? "adversarial-" : ""}review (${targetLabel})`
+  });
+  const oneShotOpts = {
+    cwd: workspaceRoot,
+    onRunStart: (run) => {
+      markRunning(stateDir, job.id, { agentId: run.agentId, runId: run.id });
+    }
+  };
+  if (flags.model) oneShotOpts.model = flags.model;
+  if (flags.timeoutMs) oneShotOpts.timeoutMs = flags.timeoutMs;
+  let result;
+  try {
+    result = await oneShot(prompt, oneShotOpts);
+  } catch (err) {
+    markFailed(stateDir, job.id, err instanceof Error ? err.message : String(err));
+    throw err;
+  }
+  markFinished(stateDir, job.id, result);
+  if (result.status !== "finished") {
+    io.stderr.write(`review run did not finish: ${result.status}
+`);
+    return 1;
+  }
+  let review;
+  try {
+    review = parseReview(result.output);
+  } catch (err) {
+    io.stderr.write(
+      `failed to parse review output: ${err instanceof Error ? err.message : String(err)}
+`
+    );
+    io.stderr.write("raw output:\n");
+    io.stderr.write(result.output);
+    if (!result.output.endsWith("\n")) io.stderr.write("\n");
+    return 1;
+  }
+  if (flags.json) {
+    io.stdout.write(`${JSON.stringify(review, null, 2)}
+`);
+  } else {
+    io.stdout.write(renderReviewResult(review));
+  }
+  return review.verdict === "approve" ? 0 : 1;
+}
+
+// plugins/cursor/scripts/lib/gate.mts
+import path2 from "node:path";
+var DEFAULT_GATE_CONFIG = { version: 1, enabled: false };
+var DEFAULT_GATE_TIMEOUT_MS = 6e5;
+function getGatePath(stateDir) {
+  return path2.join(stateDir, "gate.json");
+}
+function readGateConfig(stateDir) {
+  const cfg = readJson(getGatePath(stateDir));
+  if (!cfg || typeof cfg !== "object") return { ...DEFAULT_GATE_CONFIG };
+  return {
+    version: 1,
+    enabled: cfg.enabled === true,
+    ...cfg.model ? { model: cfg.model } : {},
+    ...typeof cfg.timeoutMs === "number" && cfg.timeoutMs > 0 ? { timeoutMs: cfg.timeoutMs } : {}
+  };
+}
+function writeGateConfig(stateDir, config) {
+  writeJsonAtomic(getGatePath(stateDir), { ...config, version: 1 });
+}
+function setGateEnabled(stateDir, enabled) {
+  const current = readGateConfig(stateDir);
+  const next = { ...current, version: 1, enabled };
+  writeGateConfig(stateDir, next);
+  return next;
+}
+
+export {
+  UsageError,
+  parseArgs,
+  optionalString,
+  bool,
+  getDiff,
+  getStatus,
+  getRecentCommits,
+  getBranch,
+  setDefaultModel,
+  clearDefaultModel,
+  resolveDefaultModel,
+  DEFAULT_MODEL,
+  resolveApiKey,
+  writePolicyText,
+  buildPrompt,
+  buildAgentOptionsFromFlags,
+  createAgent,
+  resumeAgent,
+  disposeAgent,
+  sendTask,
+  oneShot,
+  listRemoteAgents,
+  whoami,
+  listModels,
+  validateModel,
+  toAgentEvents,
+  createJob,
+  getJob,
+  listJobs,
+  findRecentTaskAgents,
+  markRunning,
+  markFinished,
+  markFailed,
+  registerActiveRun,
+  unregisterActiveRun,
+  cancelJob,
+  logJobLine,
+  compactText,
+  renderStreamEvent,
+  ageFromIso,
+  renderJobTable,
+  renderReviewResult,
+  renderError,
+  parseReview,
+  runReview,
+  DEFAULT_GATE_TIMEOUT_MS,
+  readGateConfig,
+  setGateEnabled
+};

--- a/plugins/cursor/scripts/bundle/chunk-P7QODZNJ.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-P7QODZNJ.mjs
@@ -1,0 +1,146 @@
+// plugins/cursor/scripts/lib/state.mts
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+var STATE_ROOT_ENV = "CURSOR_PLUGIN_STATE_ROOT";
+var SLUG_HASH_LENGTH = 16;
+var SLUG_NAME_MAX = 32;
+var FILE_MODE = 384;
+var DIR_MODE = 448;
+function computeWorkspaceSlug(workspaceRoot) {
+  const canonical = path.resolve(workspaceRoot);
+  const hash = crypto.createHash("sha256").update(canonical).digest("hex").slice(0, SLUG_HASH_LENGTH);
+  const base = path.basename(canonical);
+  const sanitized = base.toLowerCase().replace(/[^a-z0-9._-]+/g, "-").replace(/^[-.]+|[-.]+$/g, "").slice(0, SLUG_NAME_MAX) || "workspace";
+  return `${sanitized}-${hash}`;
+}
+function resolveStateRoot(opts = {}) {
+  if (opts.root && opts.root.trim().length > 0) return path.resolve(opts.root);
+  const env = process.env[STATE_ROOT_ENV];
+  if (env && env.trim().length > 0) return path.resolve(env);
+  return path.join(os.homedir(), ".claude", "cursor-plugin");
+}
+function resolveStateDir(workspaceRoot, opts = {}) {
+  return path.join(resolveStateRoot(opts), computeWorkspaceSlug(workspaceRoot));
+}
+function ensureStateDir(stateDir) {
+  fs.mkdirSync(stateDir, { recursive: true, mode: DIR_MODE });
+  return stateDir;
+}
+function getStateIndexPath(stateDir) {
+  return path.join(stateDir, "state.json");
+}
+function assertSafeJobId(jobId) {
+  if (jobId.length === 0 || jobId.includes("/") || jobId.includes("\\") || jobId.includes("\0") || jobId === "." || jobId === "..") {
+    throw new Error(`invalid jobId: ${JSON.stringify(jobId)}`);
+  }
+}
+function getJobJsonPath(stateDir, jobId) {
+  assertSafeJobId(jobId);
+  return path.join(stateDir, `${jobId}.json`);
+}
+function getJobLogPath(stateDir, jobId) {
+  assertSafeJobId(jobId);
+  return path.join(stateDir, `${jobId}.log`);
+}
+function getSessionPath(stateDir) {
+  return path.join(stateDir, "session.json");
+}
+function writeJsonAtomic(filePath, data) {
+  ensureStateDir(path.dirname(filePath));
+  const tmp = `${filePath}.${process.pid}.${crypto.randomBytes(4).toString("hex")}.tmp`;
+  fs.writeFileSync(tmp, `${JSON.stringify(data, null, 2)}
+`, { mode: FILE_MODE });
+  try {
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    fs.rmSync(tmp, { force: true });
+    throw err;
+  }
+}
+function readJson(filePath) {
+  let raw;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return void 0;
+    throw err;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return void 0;
+  }
+}
+function readStateIndex(stateDir) {
+  const data = readJson(getStateIndexPath(stateDir));
+  if (!data || !Array.isArray(data.jobs)) return { version: 1, jobs: [] };
+  return data;
+}
+function writeStateIndex(stateDir, index) {
+  writeJsonAtomic(getStateIndexPath(stateDir), index);
+}
+function readJob(stateDir, jobId) {
+  return readJson(getJobJsonPath(stateDir, jobId));
+}
+function writeJob(stateDir, record) {
+  writeJsonAtomic(getJobJsonPath(stateDir, record.id), record);
+}
+function appendJobLog(stateDir, jobId, text) {
+  ensureStateDir(stateDir);
+  fs.appendFileSync(getJobLogPath(stateDir, jobId), text, { mode: FILE_MODE });
+}
+function readJobLog(stateDir, jobId) {
+  try {
+    return fs.readFileSync(getJobLogPath(stateDir, jobId), "utf8");
+  } catch (err) {
+    if (err.code === "ENOENT") return void 0;
+    throw err;
+  }
+}
+function readSession(stateDir) {
+  return readJson(getSessionPath(stateDir));
+}
+function writeSession(stateDir, session) {
+  writeJsonAtomic(getSessionPath(stateDir), session);
+}
+function clearSession(stateDir) {
+  fs.rmSync(getSessionPath(stateDir), { force: true });
+}
+
+// plugins/cursor/scripts/lib/workspace.mts
+import { execFileSync } from "node:child_process";
+import path2 from "node:path";
+function resolveWorkspaceRoot(cwd) {
+  try {
+    const out = execFileSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    const root = out.trim();
+    if (root.length > 0) {
+      return path2.resolve(root);
+    }
+  } catch {
+  }
+  return path2.resolve(cwd);
+}
+
+export {
+  resolveStateRoot,
+  resolveStateDir,
+  ensureStateDir,
+  writeJsonAtomic,
+  readJson,
+  readStateIndex,
+  writeStateIndex,
+  readJob,
+  writeJob,
+  appendJobLog,
+  readJobLog,
+  readSession,
+  writeSession,
+  clearSession,
+  resolveWorkspaceRoot
+};

--- a/plugins/cursor/scripts/bundle/chunk-TKO2YPM2.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-TKO2YPM2.mjs
@@ -1,0 +1,24 @@
+// plugins/cursor/scripts/lib/hook-payload.mts
+import { readFileSync } from "node:fs";
+function readHookStdinSync() {
+  if (process.stdin.isTTY) return "";
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+function parseHookPayload(raw) {
+  if (!raw.trim()) return {};
+  try {
+    const data = JSON.parse(raw);
+    if (data && typeof data === "object") return data;
+  } catch {
+  }
+  return {};
+}
+
+export {
+  readHookStdinSync,
+  parseHookPayload
+};

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -1,0 +1,997 @@
+import {
+  DEFAULT_MODEL,
+  UsageError,
+  ageFromIso,
+  bool,
+  buildAgentOptionsFromFlags,
+  buildPrompt,
+  cancelJob,
+  clearDefaultModel,
+  compactText,
+  createAgent,
+  createJob,
+  disposeAgent,
+  findRecentTaskAgents,
+  getBranch,
+  getJob,
+  getRecentCommits,
+  listJobs,
+  listModels,
+  listRemoteAgents,
+  logJobLine,
+  markFailed,
+  markFinished,
+  markRunning,
+  optionalString,
+  parseArgs,
+  readGateConfig,
+  registerActiveRun,
+  renderError,
+  renderJobTable,
+  renderStreamEvent,
+  resolveApiKey,
+  resolveDefaultModel,
+  resumeAgent,
+  runReview,
+  sendTask,
+  setDefaultModel,
+  setGateEnabled,
+  toAgentEvents,
+  unregisterActiveRun,
+  validateModel,
+  whoami,
+  writePolicyText
+} from "./chunk-AUSOW76U.mjs";
+import {
+  ensureStateDir,
+  readJobLog,
+  resolveStateDir,
+  resolveWorkspaceRoot
+} from "./chunk-P7QODZNJ.mjs";
+
+// plugins/cursor/scripts/commands/cancel.mts
+var HELP = `cursor-companion cancel <job-id> [--json] [--help]
+
+Cancel an active job. If the run is in-process, calls run.cancel() (when
+supported). Otherwise marks the persisted job as cancelled with reason
+"run-not-active" \u2014 the underlying SDK run may still complete.
+`;
+async function runCancel(args, io) {
+  const parsed = parseArgs(args, {
+    long: { json: "boolean", help: "boolean" },
+    short: { h: "help" }
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP);
+    return 0;
+  }
+  const jobId = parsed.positionals[0];
+  if (!jobId) throw new UsageError("cancel requires a job id");
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const result = await cancelJob(stateDir, jobId);
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(result, null, 2)}
+`);
+    return result.cancelled ? 0 : 1;
+  }
+  if (result.cancelled) {
+    io.stdout.write(`cancelled: ${jobId}${result.reason ? ` (${result.reason})` : ""}
+`);
+    return 0;
+  }
+  io.stderr.write(`could not cancel ${jobId}: ${result.reason ?? "unknown"}
+`);
+  return 1;
+}
+
+// plugins/cursor/scripts/commands/result.mts
+var HELP2 = `cursor-companion result <job-id> [--log] [--json] [--help]
+
+Print a completed job's result text. With --log, print the streaming log
+captured while the run was alive. With --json, emit the full JobRecord.
+`;
+async function runResult(args, io) {
+  const parsed = parseArgs(args, {
+    long: { log: "boolean", json: "boolean", help: "boolean" },
+    short: { h: "help" }
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP2);
+    return 0;
+  }
+  const jobId = parsed.positionals[0];
+  if (!jobId) throw new UsageError("result requires a job id");
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const job = getJob(stateDir, jobId);
+  if (!job) {
+    io.stderr.write(`job not found: ${jobId}
+`);
+    return 1;
+  }
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(job, null, 2)}
+`);
+    return 0;
+  }
+  if (bool(parsed, "log")) {
+    const log = readJobLog(stateDir, jobId);
+    if (!log) {
+      io.stderr.write(`no log for job ${jobId}
+`);
+      return 1;
+    }
+    io.stdout.write(log);
+    if (!log.endsWith("\n")) io.stdout.write("\n");
+    return 0;
+  }
+  if (!job.result) {
+    if (job.error) io.stderr.write(`job failed: ${job.error}
+`);
+    else io.stderr.write(`no result for job ${jobId} (status: ${job.status})
+`);
+    return 1;
+  }
+  io.stdout.write(job.result);
+  if (!job.result.endsWith("\n")) io.stdout.write("\n");
+  return 0;
+}
+
+// plugins/cursor/scripts/lib/run-agent-task.mts
+async function runAgentTaskForeground(opts) {
+  const { agent, prompt, flags, io, stateDir, jobId } = opts;
+  try {
+    const result = await sendTask(agent, prompt, {
+      ...flags.timeoutMs !== void 0 ? { timeoutMs: flags.timeoutMs } : {},
+      ...flags.force ? { force: true } : {},
+      onRunStart: (run) => {
+        markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
+        registerActiveRun(jobId, run);
+      },
+      onEvent: (event) => {
+        for (const ae of toAgentEvents(event)) {
+          const rendered = renderStreamEvent(ae, { quietStatus: true });
+          if (rendered.stdout) io.stdout.write(rendered.stdout);
+          if (rendered.stderr) {
+            io.stderr.write(rendered.stderr);
+            logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
+          }
+        }
+      }
+    });
+    markFinished(stateDir, jobId, result);
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify({ jobId, ...result })}
+`);
+    } else if (!result.output.endsWith("\n")) {
+      io.stdout.write("\n");
+    }
+    return result.status === "finished" ? 0 : 1;
+  } catch (err) {
+    markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
+    throw err;
+  } finally {
+    unregisterActiveRun(jobId);
+    await disposeAgent(agent).catch(() => void 0);
+  }
+}
+function runAgentTaskBackground(opts) {
+  const { agent, prompt, flags, stateDir, jobId } = opts;
+  void (async () => {
+    try {
+      const result = await sendTask(agent, prompt, {
+        ...flags.timeoutMs ? { timeoutMs: flags.timeoutMs } : {},
+        ...flags.force ? { force: true } : {},
+        onRunStart: (run) => {
+          markRunning(stateDir, jobId, { agentId: run.agentId, runId: run.id });
+          registerActiveRun(jobId, run);
+        },
+        onEvent: (event) => {
+          for (const ae of toAgentEvents(event)) {
+            const rendered = renderStreamEvent(ae);
+            if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
+            if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));
+          }
+        }
+      });
+      markFinished(stateDir, jobId, result);
+    } catch (err) {
+      markFailed(stateDir, jobId, err instanceof Error ? err.message : String(err));
+    } finally {
+      unregisterActiveRun(jobId);
+      await disposeAgent(agent).catch(() => void 0);
+    }
+  })();
+}
+
+// plugins/cursor/scripts/commands/resume.mts
+var HELP3 = `cursor-companion resume <agent-id> <prompt> [flags]
+cursor-companion resume --last <prompt> [flags]
+cursor-companion resume --list [--limit <n>] [--json]
+
+Reattach to an existing Cursor agent and continue the conversation. The agent
+keeps its prior context, so follow-up prompts are cheaper than starting fresh.
+
+flags:
+  --last               Resume the most recent task agent (no agent-id needed)
+  --list               Print known agent ids from this workspace, then exit
+  --remote             With --list: query the SDK for durable agents instead
+                       of the local job index. Combine with --cloud to list
+                       cloud-runtime agents (requires CURSOR_API_KEY).
+  --limit <n>          With --list: cap the number of rows (default 10)
+  --write              Allow file modifications (default: read-only)
+  --background         Start the run and exit, returning the job id
+  --force              Expire any wedged active local run before sending
+  --cloud              Use Cursor cloud against the detected GitHub origin
+  --model <id>, -m
+  --timeout <ms>       Cancel the run if it exceeds this duration
+  --json               Print the final result as JSON (single line)
+  --help, -h
+`;
+var DEFAULT_LIST_LIMIT = 10;
+var HelpRequested = class extends Error {
+};
+function parseFlags(args) {
+  const parsed = parseArgs(args, {
+    long: {
+      last: "boolean",
+      list: "boolean",
+      remote: "boolean",
+      limit: "string",
+      write: "boolean",
+      background: "boolean",
+      force: "boolean",
+      cloud: "boolean",
+      model: "string",
+      timeout: "string",
+      json: "boolean",
+      help: "boolean"
+    },
+    short: { h: "help", m: "model" }
+  });
+  if (bool(parsed, "help")) throw new HelpRequested();
+  const last = bool(parsed, "last");
+  const list = bool(parsed, "list");
+  const json = bool(parsed, "json");
+  const remote = bool(parsed, "remote");
+  const cloud = bool(parsed, "cloud");
+  if (list) {
+    if (last) throw new UsageError("--list and --last are mutually exclusive");
+    let limit = DEFAULT_LIST_LIMIT;
+    const limitArg = optionalString(parsed, "limit");
+    if (limitArg !== void 0) {
+      const n = Number(limitArg);
+      if (!Number.isFinite(n) || n < 0) throw new UsageError(`invalid --limit: ${limitArg}`);
+      limit = Math.floor(n);
+    }
+    if (cloud && !remote) {
+      throw new UsageError("--list --cloud requires --remote (cloud listing goes through the SDK)");
+    }
+    return { kind: "list", limit, json, remote, cloud };
+  }
+  if (remote) throw new UsageError("--remote requires --list");
+  if (optionalString(parsed, "limit") !== void 0) {
+    throw new UsageError("--limit requires --list");
+  }
+  const positionals = [...parsed.positionals];
+  let target;
+  if (last) {
+    target = { kind: "last" };
+  } else {
+    const agentId = positionals.shift();
+    if (!agentId) {
+      throw new UsageError(
+        "resume requires <agent-id> (or --last to pick the most recent, or --list to discover ids)"
+      );
+    }
+    target = { kind: "id", agentId };
+  }
+  const prompt = positionals.join(" ").trim();
+  if (!prompt) throw new UsageError("resume requires a prompt to send to the agent");
+  const flags = {
+    kind: "run",
+    prompt,
+    target,
+    write: bool(parsed, "write"),
+    background: bool(parsed, "background"),
+    force: bool(parsed, "force"),
+    cloud,
+    json
+  };
+  const modelId = optionalString(parsed, "model");
+  if (modelId) flags.model = { id: modelId };
+  const timeout = optionalString(parsed, "timeout");
+  if (timeout) {
+    const ms = Number(timeout);
+    if (!Number.isFinite(ms) || ms <= 0) throw new UsageError(`invalid --timeout: ${timeout}`);
+    flags.timeoutMs = ms;
+  }
+  return flags;
+}
+function renderListText(rows, now = Date.now()) {
+  if (rows.length === 0) return "(no resumable agents)\n";
+  const formatted = rows.map((r) => ({
+    agentId: r.agentId,
+    jobId: r.jobId,
+    age: ageFromIso(r.createdAt, now),
+    summary: r.summary ? compactText(r.summary).slice(0, 60) : ""
+  }));
+  const widths = {
+    agentId: Math.max("agent-id".length, ...formatted.map((r) => r.agentId.length)),
+    jobId: Math.max("job-id".length, ...formatted.map((r) => r.jobId.length)),
+    age: Math.max("age".length, ...formatted.map((r) => r.age.length))
+  };
+  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"JOB-ID".padEnd(widths.jobId)}  ${"AGE".padEnd(widths.age)}  SUMMARY`;
+  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.jobId)}  ${"-".repeat(widths.age)}  -------`;
+  const body = formatted.map(
+    (r) => `${r.agentId.padEnd(widths.agentId)}  ${r.jobId.padEnd(widths.jobId)}  ${r.age.padEnd(widths.age)}  ${r.summary}`.trimEnd()
+  ).join("\n");
+  return `${header}
+${separator}
+${body}
+`;
+}
+function renderRemoteListText(rows, now = Date.now()) {
+  if (rows.length === 0) return "(no durable agents reported by the SDK)\n";
+  const formatted = rows.map((r) => ({
+    agentId: r.agentId,
+    age: ageFromIso(new Date(r.lastModified).toISOString(), now),
+    status: r.status ?? "\u2014",
+    summary: r.summary ? compactText(r.summary).slice(0, 60) : compactText(r.name).slice(0, 60)
+  }));
+  const widths = {
+    agentId: Math.max("agent-id".length, ...formatted.map((r) => r.agentId.length)),
+    age: Math.max("age".length, ...formatted.map((r) => r.age.length)),
+    status: Math.max("status".length, ...formatted.map((r) => r.status.length))
+  };
+  const header = `${"AGENT-ID".padEnd(widths.agentId)}  ${"AGE".padEnd(widths.age)}  ${"STATUS".padEnd(widths.status)}  SUMMARY`;
+  const separator = `${"-".repeat(widths.agentId)}  ${"-".repeat(widths.age)}  ${"-".repeat(widths.status)}  -------`;
+  const body = formatted.map(
+    (r) => `${r.agentId.padEnd(widths.agentId)}  ${r.age.padEnd(widths.age)}  ${r.status.padEnd(widths.status)}  ${r.summary}`.trimEnd()
+  ).join("\n");
+  return `${header}
+${separator}
+${body}
+`;
+}
+async function runResume(args, io) {
+  let flags;
+  try {
+    flags = parseFlags(args);
+  } catch (err) {
+    if (err instanceof HelpRequested) {
+      io.stdout.write(HELP3);
+      return 0;
+    }
+    throw err;
+  }
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  if (flags.kind === "list") {
+    if (flags.remote) {
+      const rows2 = await listRemoteAgents(
+        flags.cloud ? { runtime: "cloud", limit: flags.limit } : { cwd: workspaceRoot, limit: flags.limit }
+      );
+      if (flags.json) {
+        io.stdout.write(`${JSON.stringify(rows2, null, 2)}
+`);
+      } else {
+        io.stdout.write(renderRemoteListText(rows2));
+      }
+      return 0;
+    }
+    const stateDir2 = resolveStateDir(workspaceRoot);
+    const rows = findRecentTaskAgents(stateDir2, flags.limit);
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(rows, null, 2)}
+`);
+    } else {
+      io.stdout.write(renderListText(rows));
+    }
+    return 0;
+  }
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+  let agentId;
+  if (flags.target.kind === "last") {
+    const top = findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+    if (!top) {
+      io.stderr.write("no previous task agent to resume\n");
+      return 1;
+    }
+    agentId = top;
+  } else {
+    agentId = flags.target.agentId;
+  }
+  const fullPrompt = buildPrompt(`${writePolicyText(flags.write)}
+
+${flags.prompt}`);
+  const job = createJob(stateDir, {
+    type: "task",
+    prompt: flags.prompt,
+    metadata: { resumedAgentId: agentId }
+  });
+  let agent;
+  try {
+    agent = await resumeAgent(agentId, buildAgentOptionsFromFlags(workspaceRoot, flags));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    markFailed(stateDir, job.id, `resume failed for ${agentId}: ${message}`);
+    throw err;
+  }
+  const runFlags = { timeoutMs: flags.timeoutMs, force: flags.force, json: flags.json };
+  if (flags.background) {
+    runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });
+    io.stdout.write(`${job.id}
+`);
+    return 0;
+  }
+  return runAgentTaskForeground({
+    agent,
+    prompt: fullPrompt,
+    flags: runFlags,
+    io,
+    stateDir,
+    jobId: job.id
+  });
+}
+
+// plugins/cursor/scripts/commands/setup.mts
+var NODE_MIN_MAJOR = 18;
+var HELP4 = `cursor-companion setup [flags]
+
+Validates the plugin runtime:
+  - Node.js >= ${NODE_MIN_MAJOR}
+  - CURSOR_API_KEY is set
+  - Cursor.me() succeeds (key is valid)
+  - Cursor.models.list() returns at least one model
+
+Stop review gate (per workspace, opt-in):
+  --enable-gate        Turn on the Stop review gate for this workspace
+  --disable-gate       Turn off the Stop review gate for this workspace
+
+Default model (user-wide, used when --model is not passed):
+  --set-model <id>     Persist <id> as the default for new agent runs.
+                       Validated against Cursor.models.list().
+  --clear-model        Remove the persisted default (revert to ${DEFAULT_MODEL.id}).
+                       Resolution order: --model flag > CURSOR_MODEL env >
+                       persisted default > ${DEFAULT_MODEL.id} fallback.
+
+flags:
+  --json               Machine-readable output
+  --help, -h
+`;
+function nodeMajor() {
+  const m = process.versions.node.match(/^(\d+)\./);
+  return m ? Number(m[1]) : 0;
+}
+function modelChoices(models) {
+  const choices = [];
+  const seen = /* @__PURE__ */ new Set();
+  for (const model of models) {
+    const baseLabel = model.displayName || model.id;
+    const variants = model.variants ?? [];
+    if (variants.length === 0) {
+      const key = model.id;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const choice = { label: baseLabel, selection: { id: model.id } };
+      if (model.description) choice.description = model.description;
+      choices.push(choice);
+      continue;
+    }
+    for (const variant of variants) {
+      const selection = { id: model.id, params: variant.params };
+      const key = JSON.stringify({
+        id: selection.id,
+        params: [...selection.params ?? []].sort((a, b) => a.id.localeCompare(b.id)).map((p) => `${p.id}=${p.value}`)
+      });
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const variantLabel = variant.displayName.trim();
+      const label = !variantLabel || variantLabel.toLowerCase() === baseLabel.toLowerCase() ? baseLabel : `${baseLabel} - ${variantLabel}`;
+      const choice = { label, selection };
+      const description = variant.description ?? model.description;
+      if (description) choice.description = description;
+      choices.push(choice);
+    }
+  }
+  return choices;
+}
+function errorMessage(reason) {
+  return reason instanceof Error ? reason.message : String(reason);
+}
+async function buildReport(input) {
+  const resolved = resolveDefaultModel(DEFAULT_MODEL);
+  const report = {
+    node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
+    apiKey: { ok: false },
+    account: { ok: false },
+    models: { ok: false, choices: [] },
+    defaultModel: { id: resolved.model.id, source: resolved.source },
+    gate: { enabled: input.gateEnabled, workspaceRoot: input.workspaceRoot }
+  };
+  try {
+    resolveApiKey();
+    report.apiKey.ok = true;
+  } catch (err) {
+    report.apiKey.error = errorMessage(err);
+    return report;
+  }
+  const modelsPromise = input.prefetchedCatalog ? Promise.resolve(input.prefetchedCatalog) : listModels();
+  const [accountResult, modelsResult] = await Promise.allSettled([whoami(), modelsPromise]);
+  if (accountResult.status === "fulfilled") {
+    report.account.ok = true;
+    report.account.apiKeyName = accountResult.value.apiKeyName;
+  } else {
+    report.account.error = errorMessage(accountResult.reason);
+  }
+  if (modelsResult.status === "fulfilled") {
+    report.models.choices = modelChoices(modelsResult.value);
+    report.models.ok = report.models.choices.length > 0;
+  } else {
+    report.models.error = errorMessage(modelsResult.reason);
+  }
+  return report;
+}
+function renderReport(report) {
+  const lines = [];
+  const yes = (ok) => ok ? "ok" : "fail";
+  lines.push(`Node.js     ${yes(report.node.ok)}  (${report.node.version})`);
+  lines.push(
+    `API key     ${yes(report.apiKey.ok)}` + (report.apiKey.error ? `  ${report.apiKey.error}` : "")
+  );
+  if (report.account.ok) {
+    lines.push(`Account     ok    (key: ${report.account.apiKeyName ?? "?"})`);
+  } else if (report.account.error) {
+    lines.push(`Account     fail  ${report.account.error}`);
+  }
+  if (report.models.ok) {
+    lines.push(`Models      ok    (${report.models.choices.length} available)`);
+    for (const choice of report.models.choices) {
+      lines.push(`  - ${choice.label}  [${choice.selection.id}]`);
+    }
+  } else if (report.models.error) {
+    lines.push(`Models      fail  ${report.models.error}`);
+  }
+  lines.push(
+    `Default     ${report.defaultModel.id}  (${describeSource(report.defaultModel.source)})`
+  );
+  lines.push(
+    `Stop gate   ${report.gate.enabled ? "on" : "off"}   (workspace: ${report.gate.workspaceRoot})`
+  );
+  return `${lines.join("\n")}
+`;
+}
+function describeSource(source) {
+  switch (source) {
+    case "env":
+      return "from CURSOR_MODEL env";
+    case "config":
+      return "from persisted default";
+    case "fallback":
+      return "built-in fallback";
+  }
+}
+async function runSetup(args, io) {
+  const parsed = parseArgs(args, {
+    long: {
+      json: "boolean",
+      help: "boolean",
+      "enable-gate": "boolean",
+      "disable-gate": "boolean",
+      "set-model": "string",
+      "clear-model": "boolean"
+    },
+    short: { h: "help" }
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP4);
+    return 0;
+  }
+  const enableGate = bool(parsed, "enable-gate");
+  const disableGate = bool(parsed, "disable-gate");
+  if (enableGate && disableGate) {
+    throw new UsageError("--enable-gate and --disable-gate are mutually exclusive");
+  }
+  const setModelId = optionalString(parsed, "set-model");
+  const clearModel = bool(parsed, "clear-model");
+  if (setModelId && clearModel) {
+    throw new UsageError("--set-model and --clear-model are mutually exclusive");
+  }
+  if (setModelId !== void 0 && setModelId.trim() === "") {
+    throw new UsageError("--set-model requires a non-empty model id");
+  }
+  let prefetchedCatalog;
+  if (setModelId) {
+    prefetchedCatalog = await listModels();
+    await validateModel({ id: setModelId }, { catalog: prefetchedCatalog });
+    setDefaultModel({ id: setModelId });
+  } else if (clearModel) {
+    clearDefaultModel();
+  }
+  const workspaceRoot = resolveWorkspaceRoot(io.cwd());
+  const stateDir = resolveStateDir(workspaceRoot);
+  const togglingGate = enableGate || disableGate;
+  const gateEnabled = togglingGate ? setGateEnabled(stateDir, enableGate).enabled : readGateConfig(stateDir).enabled;
+  const report = await buildReport({
+    workspaceRoot,
+    gateEnabled,
+    ...prefetchedCatalog ? { prefetchedCatalog } : {}
+  });
+  if (bool(parsed, "json")) {
+    io.stdout.write(`${JSON.stringify(report, null, 2)}
+`);
+  } else {
+    io.stdout.write(renderReport(report));
+  }
+  const allOk = report.node.ok && report.apiKey.ok && report.account.ok && report.models.ok;
+  return allOk ? 0 : 1;
+}
+
+// plugins/cursor/scripts/commands/status.mts
+import { setTimeout as sleep } from "node:timers/promises";
+var VALID_TYPES = /* @__PURE__ */ new Set(["task", "review", "adversarial-review"]);
+var VALID_STATUSES = /* @__PURE__ */ new Set(["pending", "running", "completed", "failed", "cancelled"]);
+var TERMINAL_STATUSES = /* @__PURE__ */ new Set(["completed", "failed", "cancelled"]);
+var DEFAULT_WAIT_TIMEOUT_MS = 24e4;
+var DEFAULT_WAIT_POLL_MS = 1e3;
+var HELP5 = `cursor-companion status [<job-id>] [flags]
+
+Show the job table for the current workspace, or detail for one job. With
+a job id, --wait polls until the job reaches a terminal state.
+
+flags:
+  --type <task|review|adversarial-review>  Filter by type
+  --status <pending|running|completed|failed|cancelled>
+  --limit <n>                              Cap number of rows
+  --wait                                   With <job-id>: block until terminal
+  --timeout-ms <ms>                        Max time to wait (default 240000)
+  --poll-ms <ms>                           Poll interval (default 1000)
+  --json                                   Print as JSON
+  --help, -h
+`;
+function parsePositiveMs(parsed, key) {
+  const raw = optionalString(parsed, key);
+  if (!raw) return void 0;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) throw new UsageError(`invalid --${key}: ${raw}`);
+  return Math.floor(n);
+}
+async function runStatus(args, io) {
+  const parsed = parseArgs(args, {
+    long: {
+      type: "string",
+      status: "string",
+      limit: "string",
+      wait: "boolean",
+      "timeout-ms": "string",
+      "poll-ms": "string",
+      json: "boolean",
+      help: "boolean"
+    },
+    short: { h: "help" }
+  });
+  if (bool(parsed, "help")) {
+    io.stdout.write(HELP5);
+    return 0;
+  }
+  const cwd = io.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const json = bool(parsed, "json");
+  const wait = bool(parsed, "wait");
+  const timeoutMs = parsePositiveMs(parsed, "timeout-ms");
+  const pollMs = parsePositiveMs(parsed, "poll-ms");
+  const jobId = parsed.positionals[0];
+  if (jobId) {
+    let job = getJob(stateDir, jobId);
+    if (!job) {
+      io.stderr.write(`job not found: ${jobId}
+`);
+      return 1;
+    }
+    if (wait && !TERMINAL_STATUSES.has(job.status)) {
+      const deadline = Date.now() + (timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+      const interval = pollMs ?? DEFAULT_WAIT_POLL_MS;
+      while (Date.now() < deadline) {
+        await sleep(interval);
+        const fresh = getJob(stateDir, jobId);
+        if (fresh) job = fresh;
+        if (TERMINAL_STATUSES.has(job.status)) break;
+      }
+      if (!TERMINAL_STATUSES.has(job.status)) {
+        io.stderr.write(`status --wait timed out (job still ${job.status})
+`);
+        if (json) {
+          io.stdout.write(`${JSON.stringify(job, null, 2)}
+`);
+        } else {
+          io.stdout.write(renderJobDetail(job));
+        }
+        return 1;
+      }
+    }
+    if (json) {
+      io.stdout.write(`${JSON.stringify(job, null, 2)}
+`);
+    } else {
+      io.stdout.write(renderJobDetail(job));
+    }
+    return 0;
+  }
+  if (wait || timeoutMs || pollMs) {
+    throw new UsageError("--wait/--timeout-ms/--poll-ms require a positional <job-id>");
+  }
+  const filter = {};
+  const type = optionalString(parsed, "type");
+  if (type) {
+    if (!VALID_TYPES.has(type)) {
+      throw new UsageError(
+        `invalid --type: ${type} (expected one of ${[...VALID_TYPES].join(", ")})`
+      );
+    }
+    filter.type = type;
+  }
+  const status = optionalString(parsed, "status");
+  if (status) {
+    if (!VALID_STATUSES.has(status)) {
+      throw new UsageError(
+        `invalid --status: ${status} (expected one of ${[...VALID_STATUSES].join(", ")})`
+      );
+    }
+    filter.status = status;
+  }
+  const limit = optionalString(parsed, "limit");
+  if (limit) {
+    const n = Number(limit);
+    if (!Number.isFinite(n) || n < 0) throw new UsageError(`invalid --limit: ${limit}`);
+    filter.limit = Math.floor(n);
+  }
+  const jobs = listJobs(stateDir, filter);
+  if (json) {
+    io.stdout.write(`${JSON.stringify(jobs, null, 2)}
+`);
+  } else {
+    io.stdout.write(renderJobTable(jobs));
+  }
+  return 0;
+}
+function renderJobDetail(job) {
+  if (!job) return "";
+  const lines = [];
+  lines.push(`id:         ${job.id}`);
+  lines.push(`type:       ${job.type}`);
+  lines.push(`status:     ${job.status}`);
+  lines.push(`createdAt:  ${job.createdAt}`);
+  lines.push(`updatedAt:  ${job.updatedAt}`);
+  if (job.startedAt) lines.push(`startedAt:  ${job.startedAt}`);
+  if (job.finishedAt) lines.push(`finishedAt: ${job.finishedAt}`);
+  if (typeof job.durationMs === "number") lines.push(`durationMs: ${job.durationMs}`);
+  if (job.agentId) lines.push(`agentId:    ${job.agentId}`);
+  if (job.runId) lines.push(`runId:      ${job.runId}`);
+  if (job.metadata && Object.keys(job.metadata).length > 0) {
+    lines.push(`metadata:   ${JSON.stringify(job.metadata)}`);
+  }
+  if (job.error) {
+    lines.push("", "error:", job.error);
+  }
+  if (job.prompt) {
+    lines.push("", "prompt:", job.prompt);
+  }
+  return `${lines.join("\n")}
+`;
+}
+
+// plugins/cursor/scripts/commands/task.mts
+import { readFileSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+var HELP6 = `cursor-companion task <prompt> [flags]
+
+Delegate an implementation task to a Cursor agent. Streams events to stdout
+(assistant text) and stderr (annotations).
+
+flags:
+  --write              Allow file modifications (default: read-only)
+  --resume-last        Resume the most-recent task agent for this workspace
+  --background         Start the run and exit, returning the job id
+  --force              Expire any wedged active local run before sending
+  --cloud              Use Cursor cloud against the detected GitHub origin
+  --prompt-file <path> Read the prompt from a file. Concatenated with any
+                       positional prompt text (positional first, file body
+                       second, separated by a blank line).
+  --model <id>         Override the default model
+  -m <id>
+  --timeout <ms>       Cancel the run if it exceeds this duration
+  --json               Print the final result as JSON (single line)
+  --help, -h
+`;
+var HelpRequested2 = class extends Error {
+};
+function readPromptFile(cwd, path) {
+  const abs = resolvePath(cwd, path);
+  try {
+    return readFileSync(abs, "utf8").trim();
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new UsageError(`failed to read --prompt-file ${path}: ${detail}`);
+  }
+}
+function parseFlags2(args, cwd) {
+  const parsed = parseArgs(args, {
+    long: {
+      write: "boolean",
+      "resume-last": "boolean",
+      background: "boolean",
+      force: "boolean",
+      cloud: "boolean",
+      "prompt-file": "string",
+      model: "string",
+      timeout: "string",
+      json: "boolean",
+      help: "boolean"
+    },
+    short: { h: "help", m: "model" }
+  });
+  if (bool(parsed, "help")) throw new HelpRequested2();
+  const positionalPrompt = parsed.positionals.join(" ").trim();
+  const promptFilePath = optionalString(parsed, "prompt-file");
+  const filePrompt = promptFilePath ? readPromptFile(cwd, promptFilePath) : "";
+  const prompt = [positionalPrompt, filePrompt].filter((s) => s.length > 0).join("\n\n");
+  if (!prompt) throw new UsageError("task requires a prompt argument or --prompt-file");
+  const flags = {
+    prompt,
+    write: bool(parsed, "write"),
+    resumeLast: bool(parsed, "resume-last"),
+    background: bool(parsed, "background"),
+    force: bool(parsed, "force"),
+    cloud: bool(parsed, "cloud"),
+    json: bool(parsed, "json")
+  };
+  const modelId = optionalString(parsed, "model");
+  if (modelId) flags.model = { id: modelId };
+  const timeout = optionalString(parsed, "timeout");
+  if (timeout) {
+    const ms = Number(timeout);
+    if (!Number.isFinite(ms) || ms <= 0) throw new UsageError(`invalid --timeout: ${timeout}`);
+    flags.timeoutMs = ms;
+  }
+  return flags;
+}
+function buildContextHeader(workspaceRoot) {
+  const lines = [];
+  const branch = getBranch(workspaceRoot);
+  if (branch) lines.push(`Current branch: ${branch}`);
+  const commits = getRecentCommits(workspaceRoot, 5);
+  if (commits.length > 0) {
+    lines.push("Recent commits:");
+    for (const c of commits) {
+      lines.push(`  ${c.hash.slice(0, 8)} ${c.subject}`);
+    }
+  }
+  return lines.join("\n");
+}
+async function resolveTaskAgent(flags, stateDir, agentOpts, io) {
+  if (!flags.resumeLast) return createAgent(agentOpts);
+  const agentId = findRecentTaskAgents(stateDir, 1)[0]?.agentId;
+  if (!agentId) {
+    io.stderr.write("no previous task agent to resume \u2014 starting fresh\n");
+    return createAgent(agentOpts);
+  }
+  try {
+    return await resumeAgent(agentId, agentOpts);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    io.stderr.write(`resume failed (${message}); starting fresh
+`);
+    return createAgent(agentOpts);
+  }
+}
+async function runTask(args, io) {
+  const cwd = io.cwd();
+  let flags;
+  try {
+    flags = parseFlags2(args, cwd);
+  } catch (err) {
+    if (err instanceof HelpRequested2) {
+      io.stdout.write(HELP6);
+      return 0;
+    }
+    throw err;
+  }
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+  const contextHeader = flags.cloud ? "" : buildContextHeader(workspaceRoot);
+  const sections = [contextHeader, writePolicyText(flags.write), flags.prompt].filter(
+    (s) => s.length > 0
+  );
+  const fullPrompt = buildPrompt(sections.join("\n\n"));
+  const job = createJob(stateDir, { type: "task", prompt: flags.prompt });
+  const agentOpts = buildAgentOptionsFromFlags(workspaceRoot, flags);
+  const agent = await resolveTaskAgent(flags, stateDir, agentOpts, io);
+  const runFlags = { timeoutMs: flags.timeoutMs, force: flags.force, json: flags.json };
+  if (flags.background) {
+    runAgentTaskBackground({ agent, prompt: fullPrompt, flags: runFlags, stateDir, jobId: job.id });
+    io.stdout.write(`${job.id}
+`);
+    return 0;
+  }
+  return runAgentTaskForeground({
+    agent,
+    prompt: fullPrompt,
+    flags: runFlags,
+    io,
+    stateDir,
+    jobId: job.id
+  });
+}
+
+// plugins/cursor/scripts/cursor-companion.mts
+var HELP7 = `cursor-companion <command> [args]
+
+commands:
+  task <prompt>          Delegate an implementation task to Cursor
+  resume <agent-id|--last|--list> [prompt]
+                         Reattach to an existing Cursor agent and continue
+  review                 Review the current diff
+  adversarial-review     Challenge design choices, not just defects
+  status [<job-id>]      Show job table or single job detail
+  result <job-id>        Retrieve a completed job's output
+  cancel <job-id>        Cancel an active job
+  setup                  Validate API key, list available models
+
+global flags:
+  --json                 Machine-readable output where supported
+  --help, -h             Show this help
+
+run '<command> --help' for command-specific options.
+`;
+async function main(argv, io) {
+  const [, , command, ...rest] = argv;
+  if (command === void 0 || command === "--help" || command === "-h") {
+    io.stdout.write(HELP7);
+    return 0;
+  }
+  try {
+    switch (command) {
+      case "task":
+        return await runTask(rest, io);
+      case "resume":
+        return await runResume(rest, io);
+      case "review":
+        return await runReview(rest, io, { adversarial: false });
+      case "adversarial-review":
+        return await runReview(rest, io, { adversarial: true });
+      case "status":
+        return await runStatus(rest, io);
+      case "result":
+        return await runResult(rest, io);
+      case "cancel":
+        return await runCancel(rest, io);
+      case "setup":
+        return await runSetup(rest, io);
+      default:
+        io.stderr.write(`cursor-companion: unknown command '${command}'
+`);
+        io.stderr.write(HELP7);
+        return 2;
+    }
+  } catch (err) {
+    io.stderr.write(renderError(err));
+    return err instanceof UsageError ? 2 : 1;
+  }
+}
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const code = await main(process.argv, {
+    stdout: process.stdout,
+    stderr: process.stderr,
+    cwd: () => process.cwd(),
+    env: process.env
+  });
+  process.exit(code);
+}
+export {
+  main
+};

--- a/plugins/cursor/scripts/bundle/session-lifecycle-hook.mjs
+++ b/plugins/cursor/scripts/bundle/session-lifecycle-hook.mjs
@@ -1,0 +1,59 @@
+import {
+  parseHookPayload,
+  readHookStdinSync
+} from "./chunk-TKO2YPM2.mjs";
+import {
+  clearSession,
+  ensureStateDir,
+  readSession,
+  resolveStateDir,
+  resolveWorkspaceRoot,
+  writeSession
+} from "./chunk-P7QODZNJ.mjs";
+
+// plugins/cursor/scripts/session-lifecycle-hook.mts
+var EVENTS = ["SessionStart", "SessionEnd"];
+function handleSessionStart() {
+  const payload = parseHookPayload(readHookStdinSync());
+  const cwd = process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
+  const sessionId = payload.session_id ?? `local-${Date.now()}`;
+  const session = {
+    version: 1,
+    sessionId,
+    startedAt: (/* @__PURE__ */ new Date()).toISOString(),
+    agentIds: [],
+    pluginRoot: process.env.CLAUDE_PLUGIN_ROOT
+  };
+  writeSession(stateDir, session);
+  return 0;
+}
+function handleSessionEnd() {
+  readHookStdinSync();
+  const cwd = process.cwd();
+  const workspaceRoot = resolveWorkspaceRoot(cwd);
+  const stateDir = resolveStateDir(workspaceRoot);
+  const session = readSession(stateDir);
+  if (!session) return 0;
+  clearSession(stateDir);
+  return 0;
+}
+function main(argv) {
+  const event = argv[2];
+  if (event === void 0 || !EVENTS.includes(event)) {
+    console.error(`session-lifecycle-hook: expected one of ${EVENTS.join(", ")}`);
+    return 2;
+  }
+  try {
+    return event === "SessionStart" ? handleSessionStart() : handleSessionEnd();
+  } catch {
+    return 0;
+  }
+}
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv));
+}
+export {
+  main
+};

--- a/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
+++ b/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
@@ -1,0 +1,135 @@
+import {
+  DEFAULT_GATE_TIMEOUT_MS,
+  getDiff,
+  getStatus,
+  oneShot,
+  parseReview,
+  readGateConfig,
+  renderReviewResult
+} from "./chunk-AUSOW76U.mjs";
+import {
+  parseHookPayload,
+  readHookStdinSync
+} from "./chunk-TKO2YPM2.mjs";
+import {
+  resolveStateDir,
+  resolveWorkspaceRoot
+} from "./chunk-P7QODZNJ.mjs";
+
+// plugins/cursor/scripts/stop-review-gate-hook.mts
+var GATE_INSTRUCTIONS = [
+  "You are an automated review gate. Claude Code is about to stop and return",
+  "  control to the user. Independently review the working-tree diff for",
+  "  issues that would be unsafe to merge as-is.",
+  "Be conservative: do NOT flag style nits, refactors, or speculative concerns.",
+  "Set verdict='needs-attention' ONLY when there is at least one finding with",
+  "  severity 'critical' or 'high'. Otherwise set verdict='approve'.",
+  "Cite file:line for each finding so Claude can locate it.",
+  "Output ONLY a single JSON object matching the schema below \u2014 no prose,",
+  "  no markdown fences."
+].join("\n");
+var SCHEMA = `{
+  "verdict": "approve" | "needs-attention",
+  "summary": string,
+  "findings": [{
+    "severity": "critical" | "high" | "medium" | "low",
+    "title": string,
+    "body": string,
+    "file": string,
+    "line_start": number,
+    "line_end": number,
+    "confidence": number,
+    "recommendation": string
+  }],
+  "next_steps": string[]
+}`;
+function buildPrompt(diff, status) {
+  return [
+    GATE_INSTRUCTIONS,
+    "",
+    "Output schema:",
+    SCHEMA,
+    "",
+    "Working-tree status:",
+    status || "(clean)",
+    "",
+    "Diff to review:",
+    diff
+  ].join("\n");
+}
+function formatBlockReason(review) {
+  const header = "cursor-plugin-cc Stop review gate found issues that should be addressed before stopping. Review the findings, fix them (or explain why they are not blocking), then stop again.\n\n";
+  return header + renderReviewResult(review);
+}
+async function main(io) {
+  const payload = parseHookPayload(io.readStdin());
+  if (payload.stop_hook_active === true) return 0;
+  const cwd = payload.cwd ?? io.cwd();
+  let workspaceRoot;
+  try {
+    workspaceRoot = resolveWorkspaceRoot(cwd);
+  } catch {
+    return 0;
+  }
+  const stateDir = resolveStateDir(workspaceRoot);
+  const config = readGateConfig(stateDir);
+  if (!config.enabled) return 0;
+  let diff;
+  try {
+    diff = getDiff(workspaceRoot);
+  } catch {
+    return 0;
+  }
+  if (!diff) return 0;
+  const prompt = buildPrompt(diff, getStatus(workspaceRoot));
+  const oneShotOpts = {
+    cwd: workspaceRoot,
+    timeoutMs: config.timeoutMs ?? DEFAULT_GATE_TIMEOUT_MS
+  };
+  if (config.model) oneShotOpts.model = config.model;
+  let result;
+  try {
+    result = await oneShot(prompt, oneShotOpts);
+  } catch (err) {
+    io.stderr.write(
+      `cursor-plugin-cc gate: review failed (${err instanceof Error ? err.message : String(err)}); allowing.
+`
+    );
+    return 0;
+  }
+  if (result.status !== "finished") {
+    io.stderr.write(`cursor-plugin-cc gate: review did not finish (${result.status}); allowing.
+`);
+    return 0;
+  }
+  let review;
+  try {
+    review = parseReview(result.output);
+  } catch (err) {
+    io.stderr.write(
+      `cursor-plugin-cc gate: could not parse review output (${err instanceof Error ? err.message : String(err)}); allowing.
+`
+    );
+    return 0;
+  }
+  if (review.verdict === "approve") return 0;
+  const decision = {
+    decision: "block",
+    reason: formatBlockReason(review)
+  };
+  io.stdout.write(JSON.stringify(decision));
+  return 0;
+}
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const code = await main({
+    readStdin: readHookStdinSync,
+    stdout: process.stdout,
+    stderr: process.stderr,
+    cwd: () => process.cwd()
+  });
+  process.exit(code);
+}
+export {
+  formatBlockReason,
+  main
+};

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { build } from "esbuild";
+
+const outdir = "plugins/cursor/scripts/bundle";
+
+await build({
+  entryPoints: [
+    "plugins/cursor/scripts/cursor-companion.mts",
+    "plugins/cursor/scripts/session-lifecycle-hook.mts",
+    "plugins/cursor/scripts/stop-review-gate-hook.mts",
+  ],
+  bundle: true,
+  splitting: true,
+  platform: "node",
+  format: "esm",
+  target: "node18",
+  outdir,
+  outExtension: { ".js": ".mjs" },
+  external: ["@cursor/sdk"],
+});
+
+for (const f of await readdir(outdir)) {
+  if (!f.endsWith(".mjs")) continue;
+  const p = join(outdir, f);
+  const src = await readFile(p, "utf8");
+  if (src.startsWith("#!")) {
+    await writeFile(p, src.replace(/^#![^\n]*\n/, ""));
+  }
+}


### PR DESCRIPTION
## Summary
- Bundle plugin scripts with esbuild (`@cursor/sdk` external) and commit the output so Claude Code can load the plugin without a build step
- Add a lightweight `bootstrap.mjs` hook that runs `npm install --omit=dev` on first `SessionStart` to fetch `@cursor/sdk` at runtime
- Both `SessionStart` and `Stop` hooks run bootstrap before executing, fixing the case where `Stop` fires before deps are installed

## Test plan
- [x] `npm run build` produces both tsc output and esbuild bundle
- [x] Bundled `cursor-companion.mjs setup` works with live API key
- [x] Bootstrap installs `@cursor/sdk` from scratch in a temp directory
- [x] Session lifecycle hook runs successfully from bundle
- [x] Codex review passed (P1 build gap + P2 stop hook gap both fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)