### PR TITLE
fix: close codex-plugin-cc parity gaps in plugin UX layer

### DIFF
--- a/plugins/cursor/.claude-plugin/plugin.json
+++ b/plugins/cursor/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "cursor",
   "version": "0.1.0",
   "description": "Use Cursor from Claude Code to review code or delegate tasks.",
-  "author": { "name": "cursor-plugin-cc" }
+  "author": { "name": "N3RDMJ" }
 }

--- a/plugins/cursor/agents/cursor-rescue.md
+++ b/plugins/cursor/agents/cursor-rescue.md
@@ -1,27 +1,40 @@
 ---
 name: cursor-rescue
-description: Delegate a hard problem to a Cursor agent. Use when stuck, when an independent implementation pass would help, or when a deeper root-cause analysis is needed. Returns Cursor's output unchanged.
+description: Proactively use when Claude Code is stuck, wants a second implementation or diagnosis pass, needs a deeper root-cause investigation, or should hand a substantial coding task to Cursor through the shared runtime
 tools: Bash
 model: inherit
+skills:
+  - cursor-prompting
 ---
 
-You are a thin forwarder. Your job is to:
+You are a thin forwarding wrapper around the Cursor companion task runtime.
 
-1. Take the prompt the parent passed in (`$ARGUMENTS`).
-2. Build exactly one shell command:
-   ```bash
-   node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs task "<prompt>" --write
-   ```
-   Quote-escape the prompt; preserve any extra flags the caller passed
-   (`--cloud`, `--force`, `--model`, `--background`, `--timeout`).
-3. Run it via the Bash tool and return the **complete stdout unchanged**.
+Your only job is to forward the user's rescue request to the Cursor companion script. Do not do anything else.
 
-Do **not**:
-- Inspect files yourself.
-- Edit, plan, or summarize the result.
-- Add prose around the output.
-- Re-run the command on a non-zero exit; surface the exit context to the
-  caller and stop.
+Selection guidance:
 
-If the command fails before producing any output (e.g. `CURSOR_API_KEY`
-unset), say so in one line and stop.
+- Do not wait for the user to explicitly ask for Cursor. Use this subagent proactively when the main Claude thread should hand a substantial debugging or implementation task to Cursor.
+- Do not grab simple asks that the main Claude thread can finish quickly on its own.
+
+Forwarding rules:
+
+- Use exactly one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" task ...`.
+- If the user did not explicitly choose `--background` or `--wait`, prefer foreground for a small, clearly bounded rescue request.
+- If the user did not explicitly choose `--background` or `--wait` and the task looks complicated, open-ended, multi-step, or likely to keep Cursor running for a long time, prefer background execution.
+- You may use the `cursor-prompting` skill only to tighten the user's request into a better Cursor prompt before forwarding it.
+- Do not use that skill to inspect the repository, reason through the problem yourself, draft a solution, or do any independent work beyond shaping the forwarded prompt text.
+- Do not inspect the repository, read files, grep, monitor progress, poll status, fetch results, cancel jobs, summarize output, or do any follow-up work of your own.
+- Do not call `review`, `adversarial-review`, `status`, `result`, or `cancel`. This subagent only forwards to `task`.
+- Leave model unset by default. Only add `--model` when the user explicitly asks for a specific model.
+- Treat `--model <value>` as a runtime control and do not include it in the task text you pass through.
+- Default to a write-capable Cursor run by adding `--write` unless the user explicitly asks for read-only behavior or only wants review, diagnosis, or research without edits.
+- Treat `--resume-last` and `--fresh` as routing controls and do not include them in the task text you pass through.
+- If the user is clearly asking to continue prior Cursor work in this repository, such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", add `--resume-last`.
+- Otherwise forward the task as a fresh `task` run.
+- Preserve the user's task text as-is apart from stripping routing flags.
+- Return the stdout of the `cursor-companion` command exactly as-is.
+- If the Bash call fails or Cursor cannot be invoked, return nothing.
+
+Response style:
+
+- Do not add commentary before or after the forwarded `cursor-companion` output.

--- a/plugins/cursor/commands/adversarial-review.md
+++ b/plugins/cursor/commands/adversarial-review.md
@@ -1,24 +1,62 @@
 ---
-description: Adversarial review — challenge design choices in the current diff.
-allowed-tools: Bash(node:*)
-disable-model-invocation: true
+description: Run a Cursor review that challenges the implementation approach and design choices
+argument-hint: '[--wait|--background] [--base <ref>] [--staged] [--scope auto|working-tree|branch] [focus ...]'
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 
-# /cursor:adversarial-review
+Run an adversarial Cursor review through the shared plugin runtime.
+Position it as a challenge review that questions the chosen implementation, design choices, tradeoffs, and assumptions.
+It is not just a stricter pass over implementation defects.
 
-Run a deliberately challenging review. Where `/cursor:review` hunts for
-defects, this prompt pushes back on premature abstractions, hidden coupling,
-unnecessary state, and brittle assumptions.
+Raw slash-command arguments:
+`$ARGUMENTS`
 
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return Cursor's output verbatim to the user.
+- Keep the framing focused on whether the current approach is the right one, what assumptions it depends on, and where the design could fail under real-world conditions.
+
+Execution mode rules:
+- If the raw arguments include `--wait`, do not ask. Run in the foreground.
+- If the raw arguments include `--background`, do not ask. Run in a Claude background task.
+- Otherwise, estimate the review size before asking:
+  - For working-tree review, start with `git status --short --untracked-files=all`.
+  - For working-tree review, also inspect both `git diff --shortstat --cached` and `git diff --shortstat`.
+  - For base-branch review, use `git diff --shortstat <base>...HEAD`.
+  - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
+  - Only conclude there is nothing to review when the relevant scope is actually empty.
+  - Recommend waiting only when the scoped review is clearly tiny, roughly 1-2 files total and no sign of a broader directory-sized change.
+  - In every other case, including unclear size, recommend background.
+  - When in doubt, run the review instead of declaring that there is nothing to review.
+- Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:
+  - `Wait for results`
+  - `Run in background`
+
+Argument handling:
+- Preserve the user's arguments exactly.
+- Do not strip `--wait` or `--background` yourself.
+- Do not weaken the adversarial framing or rewrite the user's focus text.
+- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- Unlike `/cursor:review`, it can take extra focus text after the flags.
+
+Foreground flow:
+- Run:
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs adversarial-review $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review $ARGUMENTS
 ```
+- Return the command stdout verbatim, exactly as-is.
+- Do not paraphrase, summarize, or add commentary before or after it.
+- Do not fix any issues mentioned in the review output.
 
-Same output shape and flags as `/cursor:review`, plus free-form positional
-**focus text** that becomes the priority axis for the reviewer (e.g.
-`/cursor:adversarial-review concurrency and atomicity` or
-`--scope branch -- security`).
-
-If the change is genuinely simple and correct, the review will say so —
-adversarial framing is not "always find fault." Surface the output verbatim
-to the user.
+Background flow:
+- Launch the review with `Bash` in the background:
+```typescript
+Bash({
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review $ARGUMENTS`,
+  description: "Cursor adversarial review",
+  run_in_background: true
+})
+```
+- Do not call `BashOutput` or wait for completion in this turn.
+- After launching the command, tell the user: "Cursor adversarial review started in the background. Check `/cursor:status` for progress."

--- a/plugins/cursor/commands/adversarial-review.md
+++ b/plugins/cursor/commands/adversarial-review.md
@@ -34,16 +34,15 @@ Execution mode rules:
   - `Run in background`
 
 Argument handling:
-- Preserve the user's arguments exactly.
-- Do not strip `--wait` or `--background` yourself.
+- `--wait` and `--background` are execution-mode flags for Claude Code, not for the companion script. Strip them from the arguments before invoking the companion. The companion does not accept these flags.
+- Preserve all other user arguments exactly (`--staged`, `--scope`, `--base`, `--model`, `--timeout`, `--json`, and any focus text).
 - Do not weaken the adversarial framing or rewrite the user's focus text.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
 - Unlike `/cursor:review`, it can take extra focus text after the flags.
 
 Foreground flow:
-- Run:
+- Strip `--wait` and `--background` from `$ARGUMENTS`, then run:
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review <remaining-args>
 ```
 - Return the command stdout verbatim, exactly as-is.
 - Do not paraphrase, summarize, or add commentary before or after it.
@@ -53,7 +52,7 @@ Background flow:
 - Launch the review with `Bash` in the background:
 ```typescript
 Bash({
-  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review $ARGUMENTS`,
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" adversarial-review <remaining-args>`,
   description: "Cursor adversarial review",
   run_in_background: true
 })

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -1,5 +1,6 @@
 ---
 description: Reattach to an existing Cursor agent and continue the conversation.
+argument-hint: '<agent-id|--last|--list> [prompt] [--write] [--background] [--model <id>]'
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
@@ -7,7 +8,7 @@ disable-model-invocation: true
 # /cursor:resume
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs resume $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume $ARGUMENTS
 ```
 
 Resume a durable Cursor agent. The agent keeps the context from prior runs,
@@ -31,5 +32,11 @@ Model resolution: `--model` flag > `CURSOR_MODEL` env > persisted default
 
 Default policy is read-only — pass `--write` to allow file modifications.
 
-Surface the output verbatim. If `--list` returns `(no resumable agents)`, the
-workspace has no recorded agentIds yet — start with `/cursor:task` first.
+Return the command stdout verbatim, exactly as-is. Do not paraphrase,
+summarize, or add commentary.
+
+If the command fails with an authentication error or missing API key, tell
+the user to run `/cursor:setup`.
+
+If `--list` returns `(no resumable agents)`, the workspace has no recorded
+agentIds yet — tell the user to start with `/cursor:task` first.

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -1,28 +1,59 @@
 ---
-description: Independent code review of the working-tree diff via Cursor.
-allowed-tools: Bash(node:*)
-disable-model-invocation: true
+description: Run a Cursor code review against local git state
+argument-hint: '[--wait|--background] [--base <ref>] [--staged] [--scope auto|working-tree|branch]'
+allowed-tools: Read, Glob, Grep, Bash(node:*), Bash(git:*), AskUserQuestion
 ---
 
-# /cursor:review
+Run a Cursor review through the shared plugin runtime.
 
-Run a Cursor-driven structured review of the current diff.
+Raw slash-command arguments:
+`$ARGUMENTS`
 
+Core constraint:
+- This command is review-only.
+- Do not fix issues, apply patches, or suggest that you are about to make changes.
+- Your only job is to run the review and return Cursor's output verbatim to the user.
+
+Execution mode rules:
+- If the raw arguments include `--wait`, do not ask. Run the review in the foreground.
+- If the raw arguments include `--background`, do not ask. Run the review in a Claude background task.
+- Otherwise, estimate the review size before asking:
+  - For working-tree review, start with `git status --short --untracked-files=all`.
+  - For working-tree review, also inspect both `git diff --shortstat --cached` and `git diff --shortstat`.
+  - For base-branch review, use `git diff --shortstat <base>...HEAD`.
+  - Treat untracked files or directories as reviewable work even when `git diff --shortstat` is empty.
+  - Only conclude there is nothing to review when the relevant working-tree status is empty or the explicit branch diff is empty.
+  - Recommend waiting only when the review is clearly tiny, roughly 1-2 files total and no sign of a broader directory-sized change.
+  - In every other case, including unclear size, recommend background.
+  - When in doubt, run the review instead of declaring that there is nothing to review.
+- Then use `AskUserQuestion` exactly once with two options, putting the recommended option first and suffixing its label with `(Recommended)`:
+  - `Wait for results`
+  - `Run in background`
+
+Argument handling:
+- Preserve the user's arguments exactly.
+- Do not strip `--wait` or `--background` yourself.
+- Do not add extra review instructions or rewrite the user's intent.
+- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
+- If the user needs custom review instructions or more adversarial framing, they should use `/cursor:adversarial-review`.
+
+Foreground flow:
+- Run:
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs review $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review $ARGUMENTS
 ```
+- Return the command stdout verbatim, exactly as-is.
+- Do not paraphrase, summarize, or add commentary before or after it.
+- Do not fix any issues mentioned in the review output.
 
-Useful flags:
-- `--staged` — review staged changes only
-- `--scope <auto|working-tree|branch>` — review scope. `auto` (default) picks
-  working-tree when the tree is dirty, otherwise diffs against the detected
-  default branch (`main`/`master`/`trunk`).
-- `--base <ref>` — diff against a specific ref. Implies branch scope.
-- `--json` — emit the structured ReviewOutput JSON unchanged
-
-The CLI prints a verdict (`approve` / `needs-attention`), a summary, and
-per-finding entries with severity, file:line, and a recommendation. Exit code
-is 0 on `approve`, 1 on `needs-attention` or any failure.
-
-Pass the output through to the user. Do not summarize away severity or file
-locations — they are the high-signal bits.
+Background flow:
+- Launch the review with `Bash` in the background:
+```typescript
+Bash({
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review $ARGUMENTS`,
+  description: "Cursor review",
+  run_in_background: true
+})
+```
+- Do not call `BashOutput` or wait for completion in this turn.
+- After launching the command, tell the user: "Cursor review started in the background. Check `/cursor:status` for progress."

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -31,16 +31,15 @@ Execution mode rules:
   - `Run in background`
 
 Argument handling:
-- Preserve the user's arguments exactly.
-- Do not strip `--wait` or `--background` yourself.
+- `--wait` and `--background` are execution-mode flags for Claude Code, not for the companion script. Strip them from the arguments before invoking the companion. The companion does not accept these flags.
+- Preserve all other user arguments exactly (`--staged`, `--scope`, `--base`, `--model`, `--timeout`, `--json`).
 - Do not add extra review instructions or rewrite the user's intent.
-- The companion script parses `--wait` and `--background`, but Claude Code's `Bash(..., run_in_background: true)` is what actually detaches the run.
 - If the user needs custom review instructions or more adversarial framing, they should use `/cursor:adversarial-review`.
 
 Foreground flow:
-- Run:
+- Strip `--wait` and `--background` from `$ARGUMENTS`, then run:
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review <remaining-args>
 ```
 - Return the command stdout verbatim, exactly as-is.
 - Do not paraphrase, summarize, or add commentary before or after it.
@@ -50,7 +49,7 @@ Background flow:
 - Launch the review with `Bash` in the background:
 ```typescript
 Bash({
-  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review $ARGUMENTS`,
+  command: `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" review <remaining-args>`,
   description: "Cursor review",
   run_in_background: true
 })

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,5 +1,6 @@
 ---
 description: Validate the cursor-plugin-cc runtime — Node, API key, account, models. Toggle the Stop review gate.
+argument-hint: '[--enable-gate|--disable-gate] [--set-model <id>|--clear-model] [--json]'
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
@@ -9,7 +10,7 @@ disable-model-invocation: true
 Run the plugin's self-check.
 
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs setup $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" setup $ARGUMENTS
 ```
 
 Pass `--json` for machine-readable output. If anything fails (API key missing,

--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -1,17 +1,22 @@
 ---
-description: Show cursor-plugin-cc job table for the current workspace.
+description: Show active and recent Cursor jobs for this workspace, including review-gate status
+argument-hint: '[job-id] [--wait] [--timeout-ms <ms>] [--json]'
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
 
-# /cursor:status
-
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs status $ARGUMENTS
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" status $ARGUMENTS
 ```
 
-With no arguments: prints a table of recent jobs (id, type, status, age,
-summary). With a job id positional: prints the full job detail.
+If the user did not pass a job ID:
+- Render the command output as a single Markdown table for the current and past runs in this session.
+- Keep it compact. Do not include progress blocks or extra prose outside the table.
+- Preserve the actionable fields from the command output, including job ID, kind, status, elapsed or duration, summary, and follow-up commands.
+
+If the user did pass a job ID:
+- Present the full command output to the user.
+- Do not summarize or condense it.
 
 Filters available: `--type <task|review|adversarial-review>`,
 `--status <pending|running|completed|failed|cancelled>`, `--limit <n>`.
@@ -21,5 +26,3 @@ When passing a `<job-id>`, `--wait` blocks until the job reaches a terminal
 state (`completed`/`failed`/`cancelled`). Tune with `--timeout-ms <ms>`
 (default 240000) and `--poll-ms <ms>` (default 1000). On timeout, exit code
 is 1 and the last-known job state is still printed.
-
-Surface the output verbatim.

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -1,30 +1,50 @@
 ---
-description: Delegate a coding task to a Cursor agent.
-argument-hint: <prompt>
+description: Delegate investigation, an explicit fix request, or follow-up task to a Cursor agent
+argument-hint: "[--background|--wait] [--resume-last|--fresh] [--model <id>] [--write] [what Cursor should investigate, solve, or continue]"
+allowed-tools: Bash(node:*), AskUserQuestion, Agent
 ---
 
-# /cursor:task
+Invoke the `cursor:cursor-rescue` subagent via the `Agent` tool (`subagent_type: "cursor:cursor-rescue"`), forwarding the raw user request as the prompt.
+`cursor:cursor-rescue` is a subagent, not a skill — do not call `Skill(cursor:cursor-rescue)` or `Skill(cursor:rescue)`. The command runs inline so the `Agent` tool stays in scope.
+The final user-visible response must be Cursor's output verbatim.
 
-Hand off a coding task to a Cursor agent. Use this when the work is
-well-scoped and you want a second pair of hands rather than driving the
-implementation yourself.
+Raw user request:
+$ARGUMENTS
 
-Invoke the `cursor-rescue` subagent with the task description. The subagent
-forwards the prompt to `cursor-companion.mjs task` and returns whatever
-Cursor produces, unchanged.
+Execution mode:
 
-Default invocation:
+- If the request includes `--background`, run the `cursor:cursor-rescue` subagent in the background.
+- If the request includes `--wait`, run the `cursor:cursor-rescue` subagent in the foreground.
+- If neither flag is present, default to foreground.
+- `--background` and `--wait` are execution flags for Claude Code. Do not forward them to `task`, and do not treat them as part of the natural-language task text.
+- `--model` is a runtime-selection flag. Preserve it for the forwarded `task` call, but do not treat it as part of the natural-language task text.
+- If the request includes `--resume-last`, do not ask whether to continue. The user already chose.
+- If the request includes `--fresh`, do not ask whether to continue. The user already chose.
+- Otherwise, before starting Cursor, check for a resumable agent from this workspace by running:
 
-> Use the cursor-rescue subagent with: `$ARGUMENTS`
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --last --dry-run --json 2>/dev/null
+```
 
-If the user passed `--write`, `--cloud`, `--background`, `--force`,
-`--model`, or `--prompt-file <path>`, include them verbatim in the prompt
-to the subagent. `--prompt-file` is useful when the task description is
-long enough to be cumbersome inline.
+- If that helper reports an available agent, use `AskUserQuestion` exactly once to ask whether to continue the current Cursor thread or start a new one.
+- The two choices must be:
+  - `Continue current Cursor thread`
+  - `Start a new Cursor thread`
+- If the user is clearly giving a follow-up instruction such as "continue", "keep going", "resume", "apply the top fix", or "dig deeper", put `Continue current Cursor thread (Recommended)` first.
+- Otherwise put `Start a new Cursor thread (Recommended)` first.
+- If the user chooses continue, add `--resume-last` before routing to the subagent.
+- If the user chooses a new thread, do not add `--resume-last`.
+- If the helper reports no available agent, do not ask. Route normally.
 
-Model resolution: `--model` flag > `CURSOR_MODEL` env > persisted default
-(set via `/cursor:setup --set-model <id>`) > built-in fallback.
+Operating rules:
 
-When the result comes back, follow `cursor-result-handling/SKILL.md` —
-present the deliverables and any caveats clearly, do not silently accept
-the output.
+- The subagent is a thin forwarder only. It should use one `Bash` call to invoke `node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" task ...` and return that command's stdout as-is.
+- Return the Cursor companion stdout verbatim to the user.
+- Do not paraphrase, summarize, rewrite, or add commentary before or after it.
+- Do not ask the subagent to inspect files, monitor progress, poll `/cursor:status`, fetch `/cursor:result`, call `/cursor:cancel`, summarize output, or do follow-up work of its own.
+- Leave model unset unless the user explicitly asks for one.
+- Leave `--resume-last` and `--fresh` in the forwarded request. The subagent handles that routing when it builds the `task` command.
+- If the helper reports that Cursor is not configured or `CURSOR_API_KEY` is missing, stop and tell the user to run `/cursor:setup`.
+- If the user did not supply a request, ask what Cursor should investigate or fix.
+
+Model resolution: `--model` flag > `CURSOR_MODEL` env > persisted default (set via `/cursor:setup --set-model <id>`) > built-in fallback.

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -23,10 +23,10 @@ Execution mode:
 - Otherwise, before starting Cursor, check for a resumable agent from this workspace by running:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --last --dry-run --json 2>/dev/null
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --list --json --limit 1 2>/dev/null
 ```
 
-- If that helper reports an available agent, use `AskUserQuestion` exactly once to ask whether to continue the current Cursor thread or start a new one.
+- If that command outputs a non-empty agent list (at least one agent ID), use `AskUserQuestion` exactly once to ask whether to continue the current Cursor thread or start a new one.
 - The two choices must be:
   - `Continue current Cursor thread`
   - `Start a new Cursor thread`

--- a/plugins/cursor/hooks/hooks.json
+++ b/plugins/cursor/hooks/hooks.json
@@ -1,4 +1,5 @@
 {
+  "description": "Optional stop-time review gate for Cursor Companion.",
   "hooks": {
     "SessionStart": [
       {

--- a/plugins/cursor/skills/cursor-rescue/SKILL.md
+++ b/plugins/cursor/skills/cursor-rescue/SKILL.md
@@ -12,11 +12,29 @@ description: Delegate a hard problem or second-opinion investigation to a Cursor
 - The work is well-scoped (one feature, one bug, one refactor target). For
   unscoped exploration, drive the work yourself.
 
+Proactive delegation: forward complex debugging, multi-step implementations,
+or root-cause investigations to Cursor without waiting for explicit user
+request. But avoid grabbing quick tasks the main thread can complete
+independently.
+
 # How to use
 
 Invoke the `cursor-rescue` subagent (`subagent_type: "cursor:cursor-rescue"`)
 with a single prompt. The subagent runs `cursor-companion.mjs task` and
 returns Cursor's stdout unchanged.
+
+# Execution mode
+
+- Prefer foreground for small, bounded rescue requests.
+- Use `--background` for complicated, multi-step, or long-running tasks.
+- If running in background, tell the user to check `/cursor:status` for
+  progress.
+
+# Resume detection
+
+- If the user says "continue", "keep going", "resume", "apply the top fix",
+  or "dig deeper", add `--resume-last` to continue the most recent agent.
+- Otherwise start a fresh task.
 
 # What to include in the prompt
 

--- a/plugins/cursor/skills/cursor-result-handling/SKILL.md
+++ b/plugins/cursor/skills/cursor-result-handling/SKILL.md
@@ -15,6 +15,12 @@ When a Cursor task finishes (via `cursor-rescue` or `/cursor:task`):
    workspace. Run `git status` and show what was modified — don't claim
    "Cursor edited X" without verifying.
 
+CRITICAL: After presenting review or task findings, STOP. Do not make any
+code changes. Do not fix any issues. You MUST explicitly ask the user which
+issues, if any, they want fixed before touching a single file. Auto-applying
+fixes from a review or task output is strictly forbidden, even if the fix
+is obvious.
+
 # Reviews
 
 For `/cursor:review` and `/cursor:adversarial-review`:
@@ -23,6 +29,21 @@ For `/cursor:review` and `/cursor:adversarial-review`:
 2. Quote findings ordered by severity (critical → high → medium → low).
 3. Include `file:line` for each finding — it's the high-signal bit.
 4. Don't filter out low-severity items unless the user asked to.
+
+# Failure handling
+
+- For `cursor:cursor-rescue`, do not turn a failed or incomplete Cursor run
+  into a Claude-side implementation attempt. Report the failure and stop.
+- If Cursor was never successfully invoked, do not generate a substitute
+  answer at all.
+- If the helper reports that setup or authentication is required, direct the
+  user to `/cursor:setup` and do not improvise alternate auth flows.
+
+# Evidence boundaries
+
+- Preserve evidence boundaries. If Cursor marked something as an inference,
+  uncertainty, or follow-up question, keep that distinction.
+- Do not promote Cursor's tentative suggestions into definitive statements.
 
 # Caveats to flag
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,9 +6,8 @@ const here = (rel: string) => fileURLToPath(new URL(rel, import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
-      // Force a single copy of @cursor/sdk so vi.mock intercepts all usages
-      // (the plugin sub-package installs its own copy under plugins/cursor/node_modules).
-      "@cursor/sdk": here("./plugins/cursor/node_modules/@cursor/sdk/dist/esm/index.js"),
+      // Force a single copy of @cursor/sdk so vi.mock intercepts all usages.
+      "@cursor/sdk": here("./node_modules/@cursor/sdk/dist/esm/index.js"),
       "@plugin": here("./plugins/cursor/scripts"),
       "@test": here("./tests"),
     },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,6 +6,9 @@ const here = (rel: string) => fileURLToPath(new URL(rel, import.meta.url));
 export default defineConfig({
   resolve: {
     alias: {
+      // Force a single copy of @cursor/sdk so vi.mock intercepts all usages
+      // (the plugin sub-package installs its own copy under plugins/cursor/node_modules).
+      "@cursor/sdk": here("./plugins/cursor/node_modules/@cursor/sdk/dist/esm/index.js"),
       "@plugin": here("./plugins/cursor/scripts"),
       "@test": here("./tests"),
     },


### PR DESCRIPTION
## Summary

Closes all identified gaps between codex-plugin-cc and cursor-plugin-cc in the plugin UX layer (command markdown, agent definitions, skills, hooks, manifest). No TypeScript runtime changes.

### Critical (behavioral safety)
- **"Do not auto-fix after review"** — added to `cursor-result-handling` skill. Claude must ask the user before touching files after a review or task output.
- **"Do not substitute Claude's answer for failed Cursor"** — if Cursor fails, Claude reports the failure and stops instead of silently doing the work itself.

### High (UX patterns)
- **Interactive execution-mode selection** — review and adversarial-review commands now estimate diff size via `git status`/`git diff --shortstat` and use `AskUserQuestion` to let the user pick foreground vs background (matching codex behavior).
- **Resume-candidate probing** — `/cursor:task` now checks for resumable agents before starting fresh, asks "Continue current thread" vs "Start new thread".
- **Explicit "do not fix" prohibition** — review commands now state this clearly.
- **Expanded allowed-tools** — review commands now include `Read`, `Glob`, `Grep`, `Bash(git:*)`, `AskUserQuestion`.

### Medium (guidance)
- **Subagent proactive delegation** — cursor-rescue agent now has selection guidance, foreground/background heuristics, and resume detection for continuation-flavored requests.
- **Status table rendering** — guidance for compact markdown table when no job-id is passed.
- **Setup redirects** — auth failures now redirect to `/cursor:setup` across commands and skills.
- **Evidence-boundary preservation** — result handling skill preserves Cursor's uncertainty markers.

### Low (polish)
- **`argument-hint`** frontmatter added to review, adversarial-review, task, resume, setup, status commands.
- **`description`** field added to hooks.json.
- **Author field** in plugin.json changed from "cursor-plugin-cc" to "N3RDMJ".
- **Verbatim directives** strengthened across all command files.

## Test plan

- [x] `/cursor:review` estimates diff size and asks foreground vs background
- [x] `/cursor:review --background` skips the question and runs in background
- [x] `/cursor:review --wait` skips the question and runs in foreground
- [x] `/cursor:task "investigate X"` checks for resumable agents before starting
- [x] `/cursor:task` with no arguments asks what to investigate
- [x] Auth failure redirects to `/cursor:setup`
- [x] Review output is presented verbatim without auto-fixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)