### PR TITLE
fix(security): harden bootstrap install and bump @cursor/sdk

### DIFF
--- a/plugins/cursor/package-lock.json
+++ b/plugins/cursor/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@cursor-plugin-cc/cursor",
       "version": "0.1.0",
       "dependencies": {
-        "@cursor/sdk": "^1.0.9"
+        "@cursor/sdk": "^1.0.11"
       }
     },
     "node_modules/@bufbuild/protobuf": {

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -6,6 +6,6 @@
   "type": "module",
   "main": "scripts/bundle/cursor-companion.mjs",
   "dependencies": {
-    "@cursor/sdk": "^1.0.9"
+    "@cursor/sdk": "^1.0.11"
   }
 }

--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -11,7 +11,7 @@ const marker = join(pluginRoot, "node_modules", "@cursor", "sdk");
 
 if (!existsSync(marker)) {
   try {
-    execSync("npm install --omit=dev --ignore-scripts=false", {
+    execSync("npm install --omit=dev --ignore-scripts", {
       cwd: pluginRoot,
       stdio: "pipe",
       timeout: 60_000,


### PR DESCRIPTION
## Summary

Addresses findings from the security review of cursor-plugin-cc.

### VULN-001: Dependency chain vulnerabilities (High)

- **Bootstrap hardened**: Changed `--ignore-scripts=false` to `--ignore-scripts` in `bootstrap.mjs`. This prevents transitive deps (`sqlite3`, `node-gyp`, `tar`) from running arbitrary build scripts during plugin auto-install.
- **SDK bumped**: `@cursor/sdk` updated from `^1.0.9` to `^1.0.11` (latest). Plugin lockfile regenerated.
- **Accepted risk**: 10 transitive vulnerabilities remain upstream in `@cursor/sdk` (via `undici`, `tar`, `sqlite3`, `node-gyp`). These cannot be resolved without a patched SDK release. The esbuild bundle only includes the ESM surface — the vulnerable native deps are not exercised at runtime.

### VERIFY-001: $ARGUMENTS expansion safety

- **No code change needed**: `$ARGUMENTS` is a Claude Code plugin variable interpolated before tool dispatch. The `allowed-tools: Bash(node:*)` constraint prevents shell injection. The runtime parses `process.argv` directly, never shell-expanding user input.

## Test plan

- [x] `npm test` — 284 passed, 3 skipped
- [x] `npm run build` — clean
- [x] `npm audit --omit=dev` — 10 vulnerabilities (all upstream in @cursor/sdk, unchanged)
- [x] Bootstrap uses `--ignore-scripts` (no native build scripts run during auto-install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)