### PR TITLE
feat: OS keychain credential storage for Cursor API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.log
 .env
 CLAUDE.local.md
+.worktrees/
 .claude/settings.local.json
 
 # Plugin bundle is committed (needed at install time)

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,6 +1,6 @@
 ---
-description: Validate the cursor-plugin-cc runtime — Node, API key, account, models. Toggle the Stop review gate.
-argument-hint: '[--enable-gate|--disable-gate] [--set-model <id>|--clear-model] [--json]'
+description: Validate the cursor-plugin-cc runtime — Node, API key, account, models. Manage credentials and the Stop review gate.
+argument-hint: '[--login|--logout] [--enable-gate|--disable-gate] [--set-model <id>|--clear-model] [--json]'
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
@@ -17,6 +17,24 @@ Pass `--json` for machine-readable output. If anything fails (API key missing,
 network error, model catalog empty), the exit code is non-zero and the failure
 rows print on stdout. No further action needed — surface the output verbatim
 to the user.
+
+## Credential management
+
+The plugin resolves the Cursor API key in this order:
+
+1. `process.env.CURSOR_API_KEY`
+2. OS keychain (macOS Keychain, Linux Secret Service via `secret-tool`)
+3. Error with setup instructions
+
+Manage the keychain credential via:
+
+- `--login` — read a key from stdin (hidden input when interactive), validate
+  it via `Cursor.me()`, and store it in the OS keychain. Does **not** accept
+  the key as a CLI flag to avoid shell history exposure.
+- `--logout` — remove the stored key from the OS keychain.
+
+The setup output's "API key" row reports the active key source (`env`,
+`keychain`, or an error message). The `--json` output includes `apiKey.source`.
 
 ## Stop review gate
 

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -2,6 +2,7 @@ import type { ModelSelection, SDKModel } from "@cursor/sdk";
 
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
+import { deleteApiKey, detectBackend, type KeySource, storeApiKey } from "../lib/credentials.mjs";
 import {
   DEFAULT_MODEL,
   listModels,
@@ -31,9 +32,15 @@ const HELP = `cursor-companion setup [flags]
 
 Validates the plugin runtime:
   - Node.js >= ${NODE_MIN_MAJOR}
-  - CURSOR_API_KEY is set
+  - API key is available (env or keychain)
   - Cursor.me() succeeds (key is valid)
   - Cursor.models.list() returns at least one model
+
+Credential management:
+  --login              Store a Cursor API key in the OS keychain.
+                       Reads from stdin (pipe or interactive hidden input).
+                       Validates via Cursor.me() before storing.
+  --logout             Remove the stored key from the OS keychain.
 
 Stop review gate (per workspace, opt-in):
   --enable-gate        Turn on the Stop review gate for this workspace
@@ -56,10 +63,6 @@ function nodeMajor(): number {
   return m ? Number(m[1]) : 0;
 }
 
-/**
- * Flatten the SDK model catalog into selectable variants. Mirrors the cookbook
- * `modelToChoices` shape (one row per concrete `ModelSelection`).
- */
 export function modelChoices(models: Awaited<ReturnType<typeof listModels>>): ModelChoice[] {
   const choices: ModelChoice[] = [];
   const seen = new Set<string>();
@@ -101,7 +104,7 @@ export function modelChoices(models: Awaited<ReturnType<typeof listModels>>): Mo
 
 interface SetupReport {
   node: { ok: boolean; version: string };
-  apiKey: { ok: boolean; error?: string };
+  apiKey: { ok: boolean; source?: KeySource; error?: string };
   account: { ok: boolean; apiKeyName?: string; error?: string };
   models: { ok: boolean; choices: ModelChoice[]; error?: string };
   defaultModel: { id: string; source: DefaultModelSource };
@@ -111,7 +114,6 @@ interface SetupReport {
 interface BuildReportInput {
   workspaceRoot: string;
   gateEnabled: boolean;
-  /** Catalog already fetched by the caller — skips the duplicate list call. */
   prefetchedCatalog?: SDKModel[];
 }
 
@@ -131,8 +133,9 @@ async function buildReport(input: BuildReportInput): Promise<SetupReport> {
   };
 
   try {
-    resolveApiKey();
+    const { source } = await resolveApiKey();
     report.apiKey.ok = true;
+    report.apiKey.source = source;
   } catch (err) {
     report.apiKey.error = errorMessage(err);
     return report;
@@ -164,10 +167,12 @@ function renderReport(report: SetupReport): string {
   const lines: string[] = [];
   const yes = (ok: boolean): string => (ok ? "ok" : "fail");
   lines.push(`Node.js     ${yes(report.node.ok)}  (${report.node.version})`);
-  lines.push(
-    `API key     ${yes(report.apiKey.ok)}` +
-      (report.apiKey.error ? `  ${report.apiKey.error}` : ""),
-  );
+  const keyDetail = report.apiKey.ok
+    ? `  (source: ${report.apiKey.source})`
+    : report.apiKey.error
+      ? `  ${report.apiKey.error}`
+      : "";
+  lines.push(`API key     ${yes(report.apiKey.ok)}${keyDetail}`);
   if (report.account.ok) {
     lines.push(`Account     ok    (key: ${report.account.apiKeyName ?? "?"})`);
   } else if (report.account.error) {
@@ -201,11 +206,126 @@ function describeSource(source: DefaultModelSource): string {
   }
 }
 
+async function readHiddenInput(io: CommandIO): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const stdin = process.stdin;
+    if (!stdin.isTTY) {
+      let data = "";
+      stdin.setEncoding("utf8");
+      stdin.on("data", (chunk: string) => {
+        data += chunk;
+      });
+      stdin.on("end", () => resolve(data.trim()));
+      stdin.on("error", reject);
+      stdin.resume();
+      return;
+    }
+    io.stderr.write("Enter Cursor API key: ");
+    const prev = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.setEncoding("utf8");
+    stdin.resume();
+    let buf = "";
+    const onData = (ch: string) => {
+      if (ch === "\n" || ch === "\r" || ch === "") {
+        stdin.setRawMode(prev);
+        stdin.pause();
+        stdin.removeListener("data", onData);
+        io.stderr.write("\n");
+        resolve(buf.trim());
+      } else if (ch === "") {
+        stdin.setRawMode(prev);
+        stdin.pause();
+        stdin.removeListener("data", onData);
+        reject(new Error("Aborted"));
+      } else if (ch === "" || ch === "\b") {
+        buf = buf.slice(0, -1);
+      } else {
+        buf += ch;
+      }
+    };
+    stdin.on("data", onData);
+  });
+}
+
+async function runLogin(io: CommandIO, json: boolean): Promise<ExitCode> {
+  const backend = detectBackend();
+  if (!backend) {
+    const msg = "No supported keychain backend on this platform. Use CURSOR_API_KEY env instead.";
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+    } else {
+      io.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
+
+  const key = await readHiddenInput(io);
+  if (!key) {
+    const msg = "No key provided.";
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+    } else {
+      io.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
+
+  let apiKeyName: string | undefined;
+  try {
+    const user = await whoami({ apiKey: key, retry: { attempts: 1 } });
+    apiKeyName = user.apiKeyName;
+  } catch (err) {
+    const msg = `Validation failed: ${errorMessage(err)}`;
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+    } else {
+      io.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
+
+  await storeApiKey(key);
+
+  if (json) {
+    io.stdout.write(
+      `${JSON.stringify({ ok: true, source: "keychain", backend: backend.name, apiKeyName })}\n`,
+    );
+  } else {
+    io.stdout.write(`Key stored in ${backend.name}${apiKeyName ? ` (${apiKeyName})` : ""}\n`);
+  }
+  return 0;
+}
+
+async function runLogout(io: CommandIO, json: boolean): Promise<ExitCode> {
+  const backend = detectBackend();
+  if (!backend) {
+    const msg = "No supported keychain backend on this platform.";
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+    } else {
+      io.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
+
+  await deleteApiKey();
+
+  if (json) {
+    io.stdout.write(`${JSON.stringify({ ok: true, backend: backend.name })}\n`);
+  } else {
+    io.stdout.write(`Key removed from ${backend.name}\n`);
+  }
+  return 0;
+}
+
 export async function runSetup(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   const parsed = parseArgs(args, {
     long: {
       json: "boolean",
       help: "boolean",
+      login: "boolean",
+      logout: "boolean",
       "enable-gate": "boolean",
       "disable-gate": "boolean",
       "set-model": "string",
@@ -217,6 +337,14 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     io.stdout.write(HELP);
     return 0;
   }
+
+  const jsonFlag = bool(parsed, "json");
+
+  if (bool(parsed, "login") && bool(parsed, "logout")) {
+    throw new UsageError("--login and --logout are mutually exclusive");
+  }
+  if (bool(parsed, "login")) return runLogin(io, jsonFlag);
+  if (bool(parsed, "logout")) return runLogout(io, jsonFlag);
 
   const enableGate = bool(parsed, "enable-gate");
   const disableGate = bool(parsed, "disable-gate");
@@ -233,8 +361,6 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     throw new UsageError("--set-model requires a non-empty model id");
   }
 
-  // Pre-fetch the catalog when validating --set-model so buildReport can
-  // reuse it instead of listing models a second time.
   let prefetchedCatalog: SDKModel[] | undefined;
   if (setModelId) {
     prefetchedCatalog = await listModels();
@@ -257,7 +383,7 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     ...(prefetchedCatalog ? { prefetchedCatalog } : {}),
   });
 
-  if (bool(parsed, "json")) {
+  if (jsonFlag) {
     io.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
   } else {
     io.stdout.write(renderReport(report));

--- a/plugins/cursor/scripts/lib/credentials.mts
+++ b/plugins/cursor/scripts/lib/credentials.mts
@@ -1,0 +1,183 @@
+import { execFile as execFileCb, spawn } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+function spawnWithStdin(
+  command: string,
+  args: string[],
+  input: string,
+  timeoutMs: number,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { timeout: timeoutMs, stdio: ["pipe", "ignore", "pipe"] });
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with code ${code}: ${stderr.trim()}`));
+    });
+    child.stdin.end(input);
+  });
+}
+
+const SERVICE = "cursor-plugin-cc";
+const ACCOUNT = "default";
+const EXEC_TIMEOUT_MS = 5_000;
+
+export type KeySource = "explicit" | "env" | "keychain" | "none";
+
+export interface ResolvedKey {
+  apiKey: string;
+  source: Exclude<KeySource, "none">;
+}
+
+export interface KeychainBackend {
+  get(): Promise<string | undefined>;
+  set(secret: string): Promise<void>;
+  delete(): Promise<void>;
+  readonly name: string;
+}
+
+class LinuxSecretTool implements KeychainBackend {
+  readonly name = "secret-tool (Secret Service)";
+
+  async get(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFile(
+        "secret-tool",
+        ["lookup", "service", SERVICE, "account", ACCOUNT],
+        { timeout: EXEC_TIMEOUT_MS },
+      );
+      const val = stdout.trimEnd();
+      return val.length > 0 ? val : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set(secret: string): Promise<void> {
+    await spawnWithStdin(
+      "secret-tool",
+      ["store", "--label", `${SERVICE} API key`, "service", SERVICE, "account", ACCOUNT],
+      secret,
+      EXEC_TIMEOUT_MS,
+    );
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await execFile("secret-tool", ["clear", "service", SERVICE, "account", ACCOUNT], {
+        timeout: EXEC_TIMEOUT_MS,
+      });
+    } catch {
+      /* already absent */
+    }
+  }
+}
+
+class MacOSSecurity implements KeychainBackend {
+  readonly name = "macOS Keychain";
+
+  async get(): Promise<string | undefined> {
+    try {
+      const { stdout } = await execFile(
+        "security",
+        ["find-generic-password", "-s", SERVICE, "-a", ACCOUNT, "-w"],
+        { timeout: EXEC_TIMEOUT_MS },
+      );
+      const val = stdout.trimEnd();
+      return val.length > 0 ? val : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set(secret: string): Promise<void> {
+    try {
+      await this.delete();
+    } catch {
+      /* may not exist yet */
+    }
+    // Omit -w to keep the secret out of argv (visible via ps).
+    // security reads the password from stdin when -w has no argument.
+    await spawnWithStdin(
+      "security",
+      ["add-generic-password", "-s", SERVICE, "-a", ACCOUNT, "-U"],
+      `${secret}\n`,
+      EXEC_TIMEOUT_MS,
+    );
+  }
+
+  async delete(): Promise<void> {
+    try {
+      await execFile("security", ["delete-generic-password", "-s", SERVICE, "-a", ACCOUNT], {
+        timeout: EXEC_TIMEOUT_MS,
+      });
+    } catch {
+      /* already absent */
+    }
+  }
+}
+
+let cachedBackend: KeychainBackend | null | undefined;
+
+export function detectBackend(): KeychainBackend | null {
+  if (cachedBackend !== undefined) return cachedBackend;
+  const p = process.platform;
+  if (p === "darwin") {
+    cachedBackend = new MacOSSecurity();
+  } else if (p === "linux") {
+    cachedBackend = new LinuxSecretTool();
+  } else {
+    cachedBackend = null;
+  }
+  return cachedBackend;
+}
+
+export function resetBackendCache(): void {
+  cachedBackend = undefined;
+}
+
+export function setBackendForTesting(backend: KeychainBackend | null): void {
+  cachedBackend = backend;
+}
+
+export async function resolveApiKeyFromKeychain(): Promise<ResolvedKey | undefined> {
+  const backend = detectBackend();
+  if (!backend) return undefined;
+  const secret = await backend.get();
+  if (!secret || secret.trim() === "") return undefined;
+  return { apiKey: secret, source: "keychain" };
+}
+
+export async function storeApiKey(secret: string): Promise<void> {
+  const backend = detectBackend();
+  if (!backend) {
+    throw new Error(
+      "No supported keychain backend found. Use CURSOR_API_KEY environment variable instead.",
+    );
+  }
+  await backend.set(secret);
+}
+
+export async function deleteApiKey(): Promise<void> {
+  const backend = detectBackend();
+  if (!backend) {
+    throw new Error("No supported keychain backend found.");
+  }
+  await backend.delete();
+}
+
+let activeKeychainSecret: string | undefined;
+
+export function getActiveKeychainSecret(): string | undefined {
+  return activeKeychainSecret;
+}
+
+export function setActiveKeychainSecret(secret: string | undefined): void {
+  activeKeychainSecret = secret;
+}

--- a/plugins/cursor/scripts/lib/cursor-agent.mts
+++ b/plugins/cursor/scripts/lib/cursor-agent.mts
@@ -16,6 +16,12 @@ import {
   type SettingSource,
 } from "@cursor/sdk";
 
+import {
+  type KeySource,
+  type ResolvedKey,
+  resolveApiKeyFromKeychain,
+  setActiveKeychainSecret,
+} from "./credentials.mjs";
 import { detectCloudRepository } from "./git.mjs";
 import { type RetryOptions, withRetry } from "./retry.mjs";
 import { resolveDefaultModel } from "./user-config.mjs";
@@ -99,18 +105,47 @@ export interface RequestOptions {
 }
 
 /**
- * Resolve a Cursor API key from the supplied option or `CURSOR_API_KEY`.
- * Throws a ConfigurationError when neither is set so callers fail fast with
- * a clear message instead of a generic 401 from the SDK.
+ * Synchronous fast-path: resolve from explicit value or env var. Does not
+ * check the keychain — use `resolveApiKeyAsync` when the full chain is needed.
  */
-export function resolveApiKey(apiKey?: string): string {
+export function resolveApiKeySync(apiKey?: string): string | undefined {
   const resolved = apiKey ?? process.env.CURSOR_API_KEY;
-  if (!resolved || resolved.trim() === "") {
-    throw new ConfigurationError(
-      "CURSOR_API_KEY is not set. Export your Cursor API key or pass apiKey explicitly.",
-    );
+  if (resolved && resolved.trim() !== "") return resolved;
+  return undefined;
+}
+
+export interface ResolvedApiKey {
+  apiKey: string;
+  source: KeySource;
+}
+
+/**
+ * Resolve a Cursor API key: explicit → env → OS keychain → error.
+ * The keychain lookup is async (shells out to secret-tool / security).
+ * Stamps the keychain secret into the redaction registry when used.
+ */
+export async function resolveApiKey(apiKey?: string): Promise<ResolvedApiKey> {
+  if (apiKey && apiKey.trim() !== "") {
+    return { apiKey, source: "explicit" };
   }
-  return resolved;
+  const env = process.env.CURSOR_API_KEY;
+  if (env && env.trim() !== "") {
+    return { apiKey: env, source: "env" };
+  }
+  let keychainResult: ResolvedKey | undefined;
+  try {
+    keychainResult = await resolveApiKeyFromKeychain();
+  } catch {
+    /* keychain unavailable — fall through to error */
+  }
+  if (keychainResult) {
+    setActiveKeychainSecret(keychainResult.apiKey);
+    return { apiKey: keychainResult.apiKey, source: "keychain" };
+  }
+  throw new ConfigurationError(
+    "No API key found. Run /cursor:setup --login to store one in the OS keychain, " +
+      "or export CURSOR_API_KEY.",
+  );
 }
 
 /**
@@ -137,8 +172,8 @@ export function buildAgentOptionsFromFlags(
   return opts;
 }
 
-function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
-  const apiKey = resolveApiKey(opts.apiKey);
+async function buildAgentOptions(opts: CursorAgentOptions): Promise<AgentOptions> {
+  const { apiKey } = await resolveApiKey(opts.apiKey);
   const model = opts.model ?? resolveDefaultModel(DEFAULT_MODEL).model;
   const mode: AgentMode = opts.mode ?? "local";
 
@@ -171,11 +206,11 @@ function buildAgentOptions(opts: CursorAgentOptions): AgentOptions {
 }
 
 export async function createAgent(opts: CursorAgentOptions): Promise<SDKAgent> {
-  return Agent.create(buildAgentOptions(opts));
+  return Agent.create(await buildAgentOptions(opts));
 }
 
 export async function resumeAgent(agentId: string, opts: CursorAgentOptions): Promise<SDKAgent> {
-  return Agent.resume(agentId, buildAgentOptions(opts));
+  return Agent.resume(agentId, await buildAgentOptions(opts));
 }
 
 export async function disposeAgent(agent: SDKAgent): Promise<void> {
@@ -288,12 +323,12 @@ export async function downloadArtifact(agent: SDKAgent, path: string): Promise<B
  * unchanged because the SDK marks them non-retryable.
  */
 export async function whoami(opts: RequestOptions = {}): Promise<SDKUser> {
-  const apiKey = resolveApiKey(opts.apiKey);
+  const { apiKey } = await resolveApiKey(opts.apiKey);
   return withRetry(() => Cursor.me({ apiKey }), opts.retry);
 }
 
 export async function listModels(opts: RequestOptions = {}): Promise<SDKModel[]> {
-  const apiKey = resolveApiKey(opts.apiKey);
+  const { apiKey } = await resolveApiKey(opts.apiKey);
   return withRetry(() => Cursor.models.list({ apiKey }), opts.retry);
 }
 

--- a/plugins/cursor/scripts/lib/redact.mts
+++ b/plugins/cursor/scripts/lib/redact.mts
@@ -6,6 +6,8 @@
  * surfacing in `~/.claude/cursor-plugin/<workspace>/<job>.log`.
  */
 
+import { getActiveKeychainSecret } from "./credentials.mjs";
+
 const PLACEHOLDER = "[REDACTED]";
 const MIN_KEY_LENGTH = 8;
 
@@ -24,7 +26,9 @@ export function redactSecret(text: string, secret: string | undefined): string {
  * call when the env var is unset — returns the input unchanged.
  */
 export function redactApiKey(text: string): string {
-  return redactSecret(text, process.env.CURSOR_API_KEY);
+  let result = redactSecret(text, process.env.CURSOR_API_KEY);
+  result = redactSecret(result, getActiveKeychainSecret());
+  return result;
 }
 
 /**

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -21,6 +21,7 @@ vi.mock("@cursor/sdk", async () => {
 });
 
 import { main as companionMain } from "@plugin/cursor-companion.mjs";
+import { setBackendForTesting } from "@plugin/lib/credentials.mjs";
 import { readGateConfig } from "@plugin/lib/gate.mjs";
 import { resolveStateDir } from "@plugin/lib/state.mjs";
 import { readUserConfig, USER_CONFIG_ENV_MODEL } from "@plugin/lib/user-config.mjs";
@@ -37,6 +38,7 @@ beforeEach(() => {
   process.env.CURSOR_API_KEY = "test-key";
   savedModelEnv = process.env[USER_CONFIG_ENV_MODEL];
   delete process.env[USER_CONFIG_ENV_MODEL];
+  setBackendForTesting(null);
   vi.clearAllMocks();
   sdkMocks.cursorMe.mockResolvedValue({ apiKeyName: "test-key", userId: "u" });
   sdkMocks.modelsList.mockResolvedValue([
@@ -52,6 +54,7 @@ afterEach(() => {
   delete process.env.CURSOR_API_KEY;
   if (savedModelEnv === undefined) delete process.env[USER_CONFIG_ENV_MODEL];
   else process.env[USER_CONFIG_ENV_MODEL] = savedModelEnv;
+  setBackendForTesting(null);
 });
 
 describe("CLI: setup", () => {
@@ -143,5 +146,39 @@ describe("CLI: setup", () => {
     const out = io.captured.stdout.join("");
     expect(out).toContain("Default     composer-2");
     expect(out).toContain("from CURSOR_MODEL env");
+  });
+
+  it("reports apiKey source as 'env' when using CURSOR_API_KEY", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("(source: env)");
+  });
+
+  it("--json report includes apiKey.source", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--json"), io)).toBe(0);
+    const report = JSON.parse(io.captured.stdout.join(""));
+    expect(report.apiKey.source).toBe("env");
+  });
+
+  it("rejects --login together with --logout", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--login", "--logout"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
+  });
+
+  it("--logout fails gracefully when no backend", async () => {
+    setBackendForTesting(null);
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--logout"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("No supported keychain backend");
+  });
+
+  it("--logout --json returns structured error when no backend", async () => {
+    setBackendForTesting(null);
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--logout", "--json"), io)).toBe(1);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(parsed.ok).toBe(false);
   });
 });

--- a/tests/unit/lib/credentials.test.mts
+++ b/tests/unit/lib/credentials.test.mts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  deleteApiKey,
+  detectBackend,
+  getActiveKeychainSecret,
+  type KeychainBackend,
+  resetBackendCache,
+  resolveApiKeyFromKeychain,
+  setActiveKeychainSecret,
+  setBackendForTesting,
+  storeApiKey,
+} from "../../../plugins/cursor/scripts/lib/credentials.mjs";
+
+beforeEach(() => {
+  resetBackendCache();
+});
+
+afterEach(() => {
+  resetBackendCache();
+  setActiveKeychainSecret(undefined);
+});
+
+function fakeBackend(stored?: string): KeychainBackend & { stored: string | undefined } {
+  const state = { stored };
+  return {
+    name: "fake",
+    get stored() {
+      return state.stored;
+    },
+    async get() {
+      return state.stored;
+    },
+    async set(secret: string) {
+      state.stored = secret;
+    },
+    async delete() {
+      state.stored = undefined;
+    },
+  };
+}
+
+describe("detectBackend", () => {
+  it("returns null when overridden with null", () => {
+    setBackendForTesting(null);
+    expect(detectBackend()).toBeNull();
+  });
+
+  it("returns the injected backend when set", () => {
+    const backend = fakeBackend();
+    setBackendForTesting(backend);
+    expect(detectBackend()).toBe(backend);
+  });
+});
+
+describe("resolveApiKeyFromKeychain", () => {
+  it("returns the stored key with source 'keychain'", async () => {
+    setBackendForTesting(fakeBackend("key_stored"));
+    const result = await resolveApiKeyFromKeychain();
+    expect(result).toEqual({ apiKey: "key_stored", source: "keychain" });
+  });
+
+  it("returns undefined when the keychain is empty", async () => {
+    setBackendForTesting(fakeBackend(undefined));
+    expect(await resolveApiKeyFromKeychain()).toBeUndefined();
+  });
+
+  it("returns undefined when no backend is available", async () => {
+    setBackendForTesting(null);
+    expect(await resolveApiKeyFromKeychain()).toBeUndefined();
+  });
+});
+
+describe("storeApiKey", () => {
+  it("stores a key via the backend", async () => {
+    const backend = fakeBackend();
+    setBackendForTesting(backend);
+    await storeApiKey("key_new");
+    expect(backend.stored).toBe("key_new");
+  });
+
+  it("throws when no backend is available", async () => {
+    setBackendForTesting(null);
+    await expect(storeApiKey("key")).rejects.toThrow(/No supported keychain backend/);
+  });
+});
+
+describe("deleteApiKey", () => {
+  it("removes a stored key via the backend", async () => {
+    const backend = fakeBackend("key_existing");
+    setBackendForTesting(backend);
+    await deleteApiKey();
+    expect(backend.stored).toBeUndefined();
+  });
+
+  it("throws when no backend is available", async () => {
+    setBackendForTesting(null);
+    await expect(deleteApiKey()).rejects.toThrow(/No supported keychain backend/);
+  });
+});
+
+describe("activeKeychainSecret", () => {
+  it("starts as undefined", () => {
+    expect(getActiveKeychainSecret()).toBeUndefined();
+  });
+
+  it("round-trips a value", () => {
+    setActiveKeychainSecret("secret123");
+    expect(getActiveKeychainSecret()).toBe("secret123");
+    setActiveKeychainSecret(undefined);
+    expect(getActiveKeychainSecret()).toBeUndefined();
+  });
+});

--- a/tests/unit/lib/cursor-agent.test.mts
+++ b/tests/unit/lib/cursor-agent.test.mts
@@ -35,6 +35,7 @@ vi.mock("@cursor/sdk", async () => {
   };
 });
 
+import { setBackendForTesting } from "../../../plugins/cursor/scripts/lib/credentials.mjs";
 import {
   cancelRun,
   createAgent,
@@ -44,6 +45,7 @@ import {
   normalizeStreamStatus,
   oneShot,
   resolveApiKey,
+  resolveApiKeySync,
   resumeAgent,
   sendTask,
   toAgentEvents,
@@ -125,6 +127,7 @@ beforeEach(() => {
   savedModelEnv = process.env[USER_CONFIG_ENV_MODEL];
   process.env[STATE_ROOT_ENV] = stateRoot;
   delete process.env[USER_CONFIG_ENV_MODEL];
+  setBackendForTesting(null);
 });
 
 afterEach(() => {
@@ -135,25 +138,81 @@ afterEach(() => {
   else process.env[STATE_ROOT_ENV] = savedStateRoot;
   if (savedModelEnv === undefined) delete process.env[USER_CONFIG_ENV_MODEL];
   else process.env[USER_CONFIG_ENV_MODEL] = savedModelEnv;
+  setBackendForTesting(null);
 });
 
 describe("resolveApiKey", () => {
-  it("returns the explicit value when provided", () => {
-    expect(resolveApiKey("explicit")).toBe("explicit");
+  it("returns explicit value with source 'explicit'", async () => {
+    const result = await resolveApiKey("explicit-key");
+    expect(result).toEqual({ apiKey: "explicit-key", source: "explicit" });
   });
 
-  it("falls back to CURSOR_API_KEY", () => {
+  it("falls back to CURSOR_API_KEY with source 'env'", async () => {
     process.env.CURSOR_API_KEY = "from-env";
-    expect(resolveApiKey()).toBe("from-env");
+    const result = await resolveApiKey();
+    expect(result).toEqual({ apiKey: "from-env", source: "env" });
   });
 
-  it("throws ConfigurationError when neither is set", () => {
+  it("falls back to keychain when env is unset", async () => {
     delete process.env.CURSOR_API_KEY;
-    expect(() => resolveApiKey()).toThrow(/CURSOR_API_KEY/);
+    setBackendForTesting({
+      name: "test-keychain",
+      get: async () => "from-keychain",
+      set: async () => undefined,
+      delete: async () => undefined,
+    });
+    const result = await resolveApiKey();
+    expect(result).toEqual({ apiKey: "from-keychain", source: "keychain" });
   });
 
-  it("treats whitespace-only keys as missing", () => {
-    expect(() => resolveApiKey("   ")).toThrow(/CURSOR_API_KEY/);
+  it("throws when no source is available", async () => {
+    delete process.env.CURSOR_API_KEY;
+    await expect(resolveApiKey()).rejects.toThrow(/No API key found/);
+  });
+
+  it("treats whitespace-only explicit values as missing", async () => {
+    delete process.env.CURSOR_API_KEY;
+    await expect(resolveApiKey("   ")).rejects.toThrow(/No API key found/);
+  });
+
+  it("prefers env over keychain", async () => {
+    process.env.CURSOR_API_KEY = "from-env";
+    setBackendForTesting({
+      name: "test-keychain",
+      get: async () => "from-keychain",
+      set: async () => undefined,
+      delete: async () => undefined,
+    });
+    const result = await resolveApiKey();
+    expect(result.source).toBe("env");
+  });
+
+  it("prefers explicit over env and keychain", async () => {
+    process.env.CURSOR_API_KEY = "from-env";
+    setBackendForTesting({
+      name: "test-keychain",
+      get: async () => "from-keychain",
+      set: async () => undefined,
+      delete: async () => undefined,
+    });
+    const result = await resolveApiKey("explicit");
+    expect(result.source).toBe("explicit");
+  });
+});
+
+describe("resolveApiKeySync", () => {
+  it("returns explicit value", () => {
+    expect(resolveApiKeySync("explicit")).toBe("explicit");
+  });
+
+  it("falls back to env", () => {
+    process.env.CURSOR_API_KEY = "from-env";
+    expect(resolveApiKeySync()).toBe("from-env");
+  });
+
+  it("returns undefined when neither is set", () => {
+    delete process.env.CURSOR_API_KEY;
+    expect(resolveApiKeySync()).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `lib/credentials.mts` — credential store abstraction with OS keychain backends (macOS Keychain via `security`, Linux Secret Service via `secret-tool`). Both pipe secrets through stdin, never argv.
- `resolveApiKey` is now async with resolution chain: explicit → `CURSOR_API_KEY` env → OS keychain → error with setup instructions.
- `/cursor:setup --login` reads the key from hidden stdin input, validates via `Cursor.me()`, and stores in the OS keychain. `--logout` removes it. No plaintext fallback when keychain is unavailable.
- `redactApiKey` now covers keychain-loaded secrets in addition to the env var.
- Setup report shows `apiKey.source` (env/keychain) in both text and `--json` output.

## Test plan

- [x] `npm run typecheck` — no errors
- [x] `npx biome check .` — no errors
- [x] `npm test` — 314 passed, 0 failures (22 new tests)
- [x] New unit tests cover: credential backend detection, store/delete/resolve, active secret tracking, async resolveApiKey chain with all source priorities, sync variant, setup source reporting, `--login`/`--logout` mutual exclusion, no-backend error paths
- [x] Codex review passed — P2 macOS argv leak fixed (stdin piping)