### PR TITLE
fix: inject source file map into agent context to prevent bundle reads

### DIFF
--- a/plugins/cursor/prompts/investigation.md
+++ b/plugins/cursor/prompts/investigation.md
@@ -14,6 +14,8 @@ If you want to suggest changes, describe them in prose — do not produce diffs,
 </write_policy>
 
 <constraints>
+Read TypeScript source files (.mts/.ts), not compiled bundles (.mjs/.js). If the workspace context lists compiled output, ignore those files entirely.
+Start by listing files to understand the project structure before reading code.
 Focus your investigation on the files and modules directly relevant to the question.
 Do not read SDK internals, type definitions, or unrelated modules unless the question specifically requires it.
 Complete your analysis efficiently: aim for the fewest tool calls that produce a thorough answer.

--- a/plugins/cursor/prompts/task.md
+++ b/plugins/cursor/prompts/task.md
@@ -12,6 +12,8 @@ You operate in the configured workspace.
 </write_policy>
 
 <constraints>
+Read TypeScript source files (.mts/.ts), not compiled bundles (.mjs/.js). If the workspace context lists compiled output, ignore those files entirely.
+Start by listing files to understand the project structure before reading code.
 Make focused, well-scoped changes; preserve unrelated user work.
 Before changing files, understand the surrounding code.
 Keep progress updates concise — prefer tool calls over narration.

--- a/plugins/cursor/scripts/commands/task.mts
+++ b/plugins/cursor/scripts/commands/task.mts
@@ -11,7 +11,7 @@ import {
   createAgent,
   resumeAgent,
 } from "../lib/cursor-agent.mjs";
-import { getBranch, getRecentCommits } from "../lib/git.mjs";
+import { getBranch, getRecentCommits, getSourceTree } from "../lib/git.mjs";
 import { createJob, findRecentTaskAgents, markFailed } from "../lib/job-control.mjs";
 import { interpolateTemplate, loadPromptTemplate } from "../lib/prompts.mjs";
 import { runAgentTaskBackground, runAgentTaskForeground } from "../lib/run-agent-task.mjs";
@@ -117,6 +117,11 @@ function buildContextHeader(workspaceRoot: string): string {
     for (const c of commits) {
       lines.push(`  ${c.hash.slice(0, 8)} ${c.subject}`);
     }
+  }
+  const sourceTree = getSourceTree(workspaceRoot);
+  if (sourceTree) {
+    lines.push("");
+    lines.push(sourceTree);
   }
   return lines.join("\n");
 }

--- a/plugins/cursor/scripts/lib/git.mts
+++ b/plugins/cursor/scripts/lib/git.mts
@@ -183,6 +183,70 @@ export function resolveReviewTarget(
   };
 }
 
+const SOURCE_EXTS = /\.(mts|ts|tsx)$/;
+const DECLARATION_EXTS = /\.d\.(mts|ts)$/;
+const TEST_PATTERN = /\.test\.(mts|ts|tsx)$/;
+const COMPILED_DIRS = /(?:^|\/)(?:bundle|dist|build|compiled|output)\//;
+const COMPILED_EXTS = /\.(mjs|js|cjs)$/;
+const MAX_LISTED_FILES = 50;
+
+export function getSourceTree(cwd: string): string {
+  const out = runGit(cwd, ["ls-files"]);
+  if (!out) return "";
+
+  const files = out.split("\n").filter((f) => f.length > 0);
+
+  const source: string[] = [];
+  const tests: string[] = [];
+  const compiled: string[] = [];
+
+  for (const f of files) {
+    if (SOURCE_EXTS.test(f) && !DECLARATION_EXTS.test(f)) {
+      if (TEST_PATTERN.test(f)) {
+        tests.push(f);
+      } else {
+        source.push(f);
+      }
+    } else if (COMPILED_EXTS.test(f) && COMPILED_DIRS.test(f)) {
+      compiled.push(f);
+    }
+  }
+
+  if (source.length === 0 && compiled.length === 0) return "";
+
+  const lines: string[] = [];
+
+  if (source.length > 0) {
+    lines.push("Source files (read these):");
+    appendFiles(lines, source);
+  }
+  if (tests.length > 0) {
+    lines.push("Tests:");
+    appendFiles(lines, tests);
+  }
+  if (compiled.length > 0) {
+    lines.push("Compiled output (do not read — use the source files above):");
+    appendFiles(lines, compiled);
+  }
+
+  return lines.join("\n");
+}
+
+function appendFiles(lines: string[], files: string[]): void {
+  if (files.length <= MAX_LISTED_FILES) {
+    for (const f of files) lines.push(`  ${f}`);
+    return;
+  }
+  const dirs = new Map<string, number>();
+  for (const f of files) {
+    const dir = f.includes("/") ? f.slice(0, f.lastIndexOf("/")) : ".";
+    dirs.set(dir, (dirs.get(dir) ?? 0) + 1);
+  }
+  for (const [dir, count] of [...dirs.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`  ${dir}/ (${count} files)`);
+  }
+}
+
 /** `remote.origin.url` if set; otherwise `undefined`. */
 export function getRemoteUrl(cwd: string): string | undefined {
   return runGit(cwd, ["config", "--get", "remote.origin.url"]) || undefined;

--- a/tests/unit/lib/git.test.mts
+++ b/tests/unit/lib/git.test.mts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -12,6 +12,7 @@ import {
   getDiff,
   getRecentCommits,
   getRemoteUrl,
+  getSourceTree,
   getStatus,
   isDirty,
   normalizeGitHubRemote,
@@ -218,6 +219,81 @@ describe("resolveReviewTarget", () => {
 
   it("detectDefaultBranch returns 'main' for the conventional repo", () => {
     expect(detectDefaultBranch(repo)).toBe("main");
+  });
+});
+
+describe("getSourceTree", () => {
+  let repo: string;
+
+  beforeEach(() => {
+    repo = makeRepo();
+  });
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true });
+  });
+
+  it("categorizes .mts source, tests, and bundle .mjs files", () => {
+    mkdirSync(path.join(repo, "src"), { recursive: true });
+    mkdirSync(path.join(repo, "src/bundle"), { recursive: true });
+    mkdirSync(path.join(repo, "tests"), { recursive: true });
+    writeFileSync(path.join(repo, "src/main.mts"), "export {};");
+    writeFileSync(path.join(repo, "src/util.mts"), "export {};");
+    writeFileSync(path.join(repo, "src/bundle/main.mjs"), "export {};");
+    writeFileSync(path.join(repo, "tests/main.test.mts"), "import 'vitest';");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+
+    const tree = getSourceTree(repo);
+    expect(tree).toContain("Source files (read these):");
+    expect(tree).toContain("src/main.mts");
+    expect(tree).toContain("src/util.mts");
+    expect(tree).toContain("Tests:");
+    expect(tree).toContain("tests/main.test.mts");
+    expect(tree).toContain("Compiled output (do not read");
+    expect(tree).toContain("src/bundle/main.mjs");
+  });
+
+  it("returns empty string for repos with no source or bundle files", () => {
+    writeFileSync(path.join(repo, "README.md"), "# hello");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+    expect(getSourceTree(repo)).toBe("");
+  });
+
+  it("excludes .d.ts and .d.mts declaration files from source", () => {
+    mkdirSync(path.join(repo, "src"), { recursive: true });
+    writeFileSync(path.join(repo, "src/main.mts"), "export {};");
+    writeFileSync(path.join(repo, "src/main.d.mts"), "export {};");
+    writeFileSync(path.join(repo, "src/types.d.ts"), "export {};");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+
+    const tree = getSourceTree(repo);
+    expect(tree).toContain("src/main.mts");
+    expect(tree).not.toContain("main.d.mts");
+    expect(tree).not.toContain("types.d.ts");
+  });
+
+  it("ignores .mjs files outside bundle/dist/build directories", () => {
+    mkdirSync(path.join(repo, "src"), { recursive: true });
+    writeFileSync(path.join(repo, "src/main.mts"), "export {};");
+    writeFileSync(path.join(repo, "src/bootstrap.mjs"), "import('./main.mjs');");
+    git(repo, ["add", "."]);
+    git(repo, ["commit", "-q", "-m", "init"]);
+
+    const tree = getSourceTree(repo);
+    expect(tree).not.toContain("bootstrap.mjs");
+    expect(tree).not.toContain("Compiled output");
+  });
+
+  it("returns empty string in non-git directory", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "cursor-no-git-"));
+    try {
+      expect(getSourceTree(dir)).toBe("");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `getSourceTree()` to `git.mts` — scans `git ls-files`, categorizes tracked files into source (`.mts/.ts/.tsx`), tests, and compiled bundles (`.mjs/.js/.cjs` in `bundle/`/`dist/`/`build/` dirs), and produces a labeled manifest the agent can use to orient itself
- Wires the source tree into `buildContextHeader()` so every task/investigation prompt now includes an explicit file map in `WORKSPACE_CONTEXT`
- Adds source-preference constraints to `task.md` and `investigation.md` prompt templates: "Read TypeScript source files (.mts/.ts), not compiled bundles (.mjs/.js)"
- Collapses to directory summaries when a category exceeds 50 files (large repo safety)

## Test plan

- [x] 4 new unit tests for `getSourceTree`: categorization, empty repo, declaration exclusion, non-bundle `.mjs` ignored, non-git directory
- [x] All 319 existing tests pass
- [x] Typecheck clean
- [x] Biome check clean

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)