### PR TITLE
fix: compile native deps during plugin bootstrap

### DIFF
--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -7,15 +7,25 @@ import { fileURLToPath } from "node:url";
 const pluginRoot =
   process.env.CLAUDE_PLUGIN_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
 
-const marker = join(pluginRoot, "node_modules", "@cursor", "sdk");
+const sdkDir = join(pluginRoot, "node_modules", "@cursor", "sdk");
+const sentinel = join(pluginRoot, "node_modules", ".bootstrap-ok");
 
-if (!existsSync(marker)) {
+const needsInstall = !existsSync(sdkDir) || !existsSync(sentinel);
+
+if (needsInstall) {
   try {
-    execSync("npm install --omit=dev --ignore-scripts", {
+    execSync("npm install --omit=dev", {
       cwd: pluginRoot,
       stdio: "pipe",
-      timeout: 60_000,
+      timeout: 120_000,
     });
+    execSync(`node -e "require('sqlite3')"`, {
+      cwd: pluginRoot,
+      stdio: "pipe",
+      timeout: 10_000,
+    });
+    const { writeFileSync } = await import("node:fs");
+    writeFileSync(sentinel, new Date().toISOString(), "utf8");
   } catch {
     // Best-effort — hooks must never crash Claude Code.
   }


### PR DESCRIPTION
## Summary

- **Root cause**: `@cursor/sdk@1.0.11` added `sqlite3` as a transitive native dependency. The bootstrap script ran `npm install --ignore-scripts`, which skipped compiling the native binary — breaking every plugin command on fresh installs.
- **Fix**: Remove `--ignore-scripts` and add a `.bootstrap-ok` sentinel that only gets written after verifying `sqlite3` loads successfully. Partial installs (directory exists, binary missing) now trigger a re-install instead of silently failing.
- Bump install timeout from 60s to 120s to accommodate native compilation.

## Test plan

- [x] Verified `cursor-companion --help` works after fix
- [x] Verified bootstrap skips install on subsequent runs (31ms)
- [x] Verified bootstrap re-runs when sentinel is missing