### PR TITLE
feat: track agent phase from task events in /cursor:status

### DIFF
--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -146,6 +146,7 @@ function renderJobDetail(job: ReturnType<typeof getJob>): string {
   lines.push(`id:         ${job.id}`);
   lines.push(`type:       ${job.type}`);
   lines.push(`status:     ${job.status}`);
+  if (job.phase) lines.push(`phase:      ${job.phase}`);
   lines.push(`createdAt:  ${job.createdAt}`);
   lines.push(`updatedAt:  ${job.updatedAt}`);
   if (job.startedAt) lines.push(`startedAt:  ${job.startedAt}`);

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -59,6 +59,7 @@ function indexEntry(record: JobRecord): JobIndexEntry {
       ? record.metadata.summary
       : summarize(record.prompt);
   if (summary) entry.summary = summary;
+  if (record.phase) entry.phase = record.phase;
   return entry;
 }
 
@@ -173,6 +174,7 @@ interface UpdateInput {
   result?: string;
   error?: string;
   metadata?: Record<string, unknown>;
+  phase?: string;
 }
 
 function update(stateDir: string, jobId: string, input: UpdateInput): JobRecord {
@@ -265,6 +267,29 @@ export function markFailed(stateDir: string, jobId: string, error: string): JobR
     finishedAt: nowIso(),
     error: redactApiKey(error),
   });
+}
+
+const PHASE_MAX_LENGTH = 80;
+
+function normalizePhase(raw: string): string {
+  const compact = raw.replace(/\s+/g, " ").trim();
+  if (compact.length <= PHASE_MAX_LENGTH) return compact;
+  return `${compact.slice(0, PHASE_MAX_LENGTH - 3)}...`;
+}
+
+/**
+ * Stamp the most-recent task description onto the job record. No-ops when the
+ * phase is empty, unchanged, or the job is already terminal — task events fire
+ * frequently and we don't want to thrash the on-disk state files.
+ */
+export function markPhase(stateDir: string, jobId: string, phase: string): JobRecord | undefined {
+  const normalized = normalizePhase(phase);
+  if (!normalized) return undefined;
+  const existing = readJob(stateDir, jobId);
+  if (!existing) return undefined;
+  if (TERMINAL_STATUSES.has(existing.status)) return existing;
+  if (existing.phase === normalized) return existing;
+  return update(stateDir, jobId, { phase: normalized });
 }
 
 /** Mark a job as cancelled (without an associated Run). */

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -159,11 +159,12 @@ export interface JobTableRow {
   id: string;
   type: string;
   status: string;
+  phase: string;
   age: string;
   summary: string;
 }
 
-const TABLE_HEADERS: Array<keyof JobTableRow> = ["id", "type", "status", "age", "summary"];
+const TABLE_HEADERS: Array<keyof JobTableRow> = ["id", "type", "status", "phase", "age", "summary"];
 
 function rowsFromJobs(jobs: JobIndexEntry[], now: number): JobTableRow[] {
   return jobs.map((job) => {
@@ -173,6 +174,7 @@ function rowsFromJobs(jobs: JobIndexEntry[], now: number): JobTableRow[] {
       id: job.id,
       type: job.type,
       status: job.status,
+      phase: job.phase ? compactText(job.phase).slice(0, 40) : "",
       age: formatAge(ageMs),
       summary: job.summary ? compactText(job.summary).slice(0, 60) : "",
     };
@@ -212,6 +214,7 @@ export function renderJobTable(jobs: JobIndexEntry[], now: number = Date.now()):
     id: "id".length,
     type: "type".length,
     status: "status".length,
+    phase: "phase".length,
     age: "age".length,
     summary: "summary".length,
   };

--- a/plugins/cursor/scripts/lib/run-agent-task.mts
+++ b/plugins/cursor/scripts/lib/run-agent-task.mts
@@ -1,10 +1,11 @@
 import type { SDKAgent, SDKMessage } from "@cursor/sdk";
 
-import { disposeAgent, sendTask, toAgentEvents } from "./cursor-agent.mjs";
+import { type AgentEvent, disposeAgent, sendTask, toAgentEvents } from "./cursor-agent.mjs";
 import {
   logJobLine,
   markFailed,
   markFinished,
+  markPhase,
   markRunning,
   registerActiveRun,
   unregisterActiveRun,
@@ -32,6 +33,17 @@ export interface RunAgentTaskOptions {
 }
 
 /**
+ * Pull a phase string out of a task event. Prefers the model-supplied `text`
+ * (describes the work) over the SDK `status` (e.g. "started"). Returns undefined
+ * when neither field is present.
+ */
+function phaseFromEvent(event: AgentEvent): string | undefined {
+  if (event.type !== "task") return undefined;
+  const candidate = event.text ?? event.status;
+  return candidate && candidate.trim() !== "" ? candidate : undefined;
+}
+
+/**
  * Foreground run: stream the agent's events to stdout/stderr, persist job
  * transitions, dispose the agent on exit. Ownership of the agent passes to
  * this helper — callers must not dispose it themselves.
@@ -52,6 +64,8 @@ export async function runAgentTaskForeground(opts: RunAgentTaskOptions): Promise
       },
       onEvent: (event: SDKMessage) => {
         for (const ae of toAgentEvents(event)) {
+          const phase = phaseFromEvent(ae);
+          if (phase) markPhase(stateDir, jobId, phase);
           const rendered = renderStreamEvent(ae, { quietStatus: true, quietThinking: true });
           if (rendered.stdout) io.stdout.write(rendered.stdout);
           if (rendered.stderr) {
@@ -99,6 +113,8 @@ export function runAgentTaskBackground(opts: Omit<RunAgentTaskOptions, "io">): v
         },
         onEvent: (event: SDKMessage) => {
           for (const ae of toAgentEvents(event)) {
+            const phase = phaseFromEvent(ae);
+            if (phase) markPhase(stateDir, jobId, phase);
             const rendered = renderStreamEvent(ae);
             if (rendered.stdout) logJobLine(stateDir, jobId, rendered.stdout.replace(/\n$/, ""));
             if (rendered.stderr) logJobLine(stateDir, jobId, rendered.stderr.replace(/\n$/, ""));

--- a/plugins/cursor/scripts/lib/state.mts
+++ b/plugins/cursor/scripts/lib/state.mts
@@ -21,6 +21,8 @@ export interface JobIndexEntry {
   createdAt: string;
   updatedAt: string;
   summary?: string;
+  /** Most recent task-event description ("what is it doing right now"). */
+  phase?: string;
 }
 
 export interface JobIndex {
@@ -43,6 +45,8 @@ export interface JobRecord {
   result?: string;
   error?: string;
   metadata?: Record<string, unknown>;
+  /** Most recent task-event description ("what is it doing right now"). */
+  phase?: string;
 }
 
 export interface SessionState {

--- a/tests/unit/lib/job-control.test.mts
+++ b/tests/unit/lib/job-control.test.mts
@@ -14,6 +14,7 @@ import {
   logJobLine,
   markFailed,
   markFinished,
+  markPhase,
   markRunning,
   registerActiveRun,
   unregisterActiveRun,
@@ -136,6 +137,46 @@ describe("state transitions", () => {
 
   it("update of a missing id throws", () => {
     expect(() => markFailed(stateDir, "missing-job", "x")).toThrow(/job not found/);
+  });
+});
+
+describe("markPhase", () => {
+  it("stamps the normalized phase on the job and surfaces it on the index entry", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    const after = markPhase(stateDir, job.id, "  reading\nfile  ");
+    expect(after?.phase).toBe("reading file");
+    const listed = listJobs(stateDir).find((j) => j.id === job.id);
+    expect(listed?.phase).toBe("reading file");
+  });
+
+  it("truncates very long phases", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    const after = markPhase(stateDir, job.id, "a".repeat(200));
+    expect(after?.phase?.length).toBe(80);
+    expect(after?.phase?.endsWith("...")).toBe(true);
+  });
+
+  it("no-ops when the phase is unchanged (no updatedAt bump)", async () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    const first = markPhase(stateDir, job.id, "thinking");
+    const firstUpdatedAt = first?.updatedAt;
+    await new Promise((r) => setTimeout(r, 5));
+    const second = markPhase(stateDir, job.id, "thinking");
+    expect(second?.updatedAt).toBe(firstUpdatedAt);
+  });
+
+  it("returns undefined for empty input or missing jobs", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    expect(markPhase(stateDir, job.id, "   ")).toBeUndefined();
+    expect(markPhase(stateDir, "missing-job", "anything")).toBeUndefined();
+  });
+
+  it("does not modify a terminal job", () => {
+    const job = createJob(stateDir, { type: "task", prompt: "x" });
+    markFinished(stateDir, job.id, fakeResult({ status: "finished" }));
+    const after = markPhase(stateDir, job.id, "should-not-stick");
+    expect(after?.status).toBe("completed");
+    expect(after?.phase).toBeUndefined();
   });
 });
 

--- a/tests/unit/lib/render.test.mts
+++ b/tests/unit/lib/render.test.mts
@@ -139,14 +139,17 @@ describe("renderJobTable", () => {
         status: "running",
         createdAt: new Date(now - 3_600_000).toISOString(),
         updatedAt: new Date(now - 3_600_000).toISOString(),
+        phase: "investigating auth flow",
       },
     ];
     const out = renderJobTable(jobs, now);
     expect(out).toContain("ID");
     expect(out).toContain("STATUS");
+    expect(out).toContain("PHASE");
     expect(out).toContain("abc123");
     expect(out).toContain("30s");
     expect(out).toContain("1h");
+    expect(out).toContain("investigating auth flow");
   });
 });
 


### PR DESCRIPTION
Persist the most recent task-event description on the job record so
/cursor:status can show what a long-running agent is currently doing.
Phase is added as a column in the job table and a row in the per-job
detail view; markPhase no-ops on unchanged or terminal jobs to avoid
thrashing the on-disk state.