### PR TITLE
feat: surface log tail in /cursor:status detail view

### DIFF
--- a/plugins/cursor/scripts/commands/status.mts
+++ b/plugins/cursor/scripts/commands/status.mts
@@ -4,7 +4,7 @@ import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, optionalString, parseArgs, UsageError } from "../lib/args.mjs";
 import { getJob, type ListJobsFilter, listJobs, reconcileStaleJobs } from "../lib/job-control.mjs";
 import { renderJobTable } from "../lib/render.mjs";
-import { type JobStatus, type JobType, resolveStateDir } from "../lib/state.mjs";
+import { type JobStatus, type JobType, resolveStateDir, tailJobLog } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const VALID_TYPES = new Set<string>(["task", "review", "adversarial-review"]);
@@ -13,6 +13,7 @@ const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set(["completed", "failed"
 
 const DEFAULT_WAIT_TIMEOUT_MS = 240_000;
 const DEFAULT_WAIT_POLL_MS = 1_000;
+const PROGRESS_TAIL_LINES = 15;
 
 const HELP = `cursor-companion status [<job-id>] [flags]
 
@@ -88,7 +89,7 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
         if (json) {
           io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
         } else {
-          io.stdout.write(renderJobDetail(job));
+          io.stdout.write(renderJobDetail(job, stateDir));
         }
         return 1;
       }
@@ -96,7 +97,7 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
     if (json) {
       io.stdout.write(`${JSON.stringify(job, null, 2)}\n`);
     } else {
-      io.stdout.write(renderJobDetail(job));
+      io.stdout.write(renderJobDetail(job, stateDir));
     }
     return 0;
   }
@@ -140,7 +141,7 @@ export async function runStatus(args: readonly string[], io: CommandIO): Promise
   return 0;
 }
 
-function renderJobDetail(job: ReturnType<typeof getJob>): string {
+function renderJobDetail(job: ReturnType<typeof getJob>, stateDir: string): string {
   if (!job) return "";
   const lines: string[] = [];
   lines.push(`id:         ${job.id}`);
@@ -162,6 +163,14 @@ function renderJobDetail(job: ReturnType<typeof getJob>): string {
   }
   if (job.prompt) {
     lines.push("", "prompt:", job.prompt);
+  }
+  // Surface a tail of the streaming log for non-terminal jobs so users can
+  // peek at progress without `result --log`.
+  if (!TERMINAL_STATUSES.has(job.status)) {
+    const tail = tailJobLog(stateDir, job.id, PROGRESS_TAIL_LINES);
+    if (tail) {
+      lines.push("", `progress: (last ${PROGRESS_TAIL_LINES} log lines)`, tail);
+    }
   }
   return `${lines.join("\n")}\n`;
 }

--- a/plugins/cursor/scripts/lib/state.mts
+++ b/plugins/cursor/scripts/lib/state.mts
@@ -216,6 +216,21 @@ export function readJobLog(stateDir: string, jobId: string): string | undefined 
   }
 }
 
+/**
+ * Return the last `lines` lines of the per-job log, joined by `\n` with no
+ * trailing newline. Returns undefined when the log is missing or empty so
+ * callers can omit the section entirely.
+ */
+export function tailJobLog(stateDir: string, jobId: string, lines: number): string | undefined {
+  if (lines <= 0) return undefined;
+  const log = readJobLog(stateDir, jobId);
+  if (!log) return undefined;
+  const body = log.endsWith("\n") ? log.slice(0, -1) : log;
+  if (body.length === 0) return undefined;
+  const split = body.split("\n");
+  return (split.length <= lines ? split : split.slice(-lines)).join("\n");
+}
+
 export function readSession(stateDir: string): SessionState | undefined {
   return readJson<SessionState>(getSessionPath(stateDir));
 }

--- a/tests/cli/status.test.mts
+++ b/tests/cli/status.test.mts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { main as companionMain } from "@plugin/cursor-companion.mjs";
-import { createJob, markFailed, markRunning } from "@plugin/lib/job-control.mjs";
+import { createJob, logJobLine, markFailed, markRunning } from "@plugin/lib/job-control.mjs";
 import { ensureStateDir, resolveStateDir } from "@plugin/lib/state.mjs";
 import { argv, captureIO } from "@test/helpers/io.mjs";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -68,6 +68,52 @@ describe("CLI: status --wait", () => {
     expect(code).toBe(1);
     expect(io.captured.stderr.join("")).toContain("status --wait timed out");
     expect(io.captured.stdout.join("")).toContain("status:     running");
+  });
+
+  it("includes a progress tail for a non-terminal job", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "running" });
+    markRunning(stateDir, job.id, { agentId: "agent-x", runId: "run-x" });
+    for (const line of ["fetching repo", "running tests", "thinking", "step four", "step five"]) {
+      logJobLine(stateDir, job.id, line);
+    }
+
+    const io = captureIO(workDir);
+    const code = await companionMain(argv("status", job.id), io);
+    expect(code).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("progress:");
+    expect(out).toContain("fetching repo");
+    expect(out).toContain("step five");
+  });
+
+  it("omits the progress block for terminal jobs", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "done" });
+    logJobLine(stateDir, job.id, "noisy log line");
+    markFailed(stateDir, job.id, "boom");
+
+    const io = captureIO(workDir);
+    const code = await companionMain(argv("status", job.id), io);
+    expect(code).toBe(0);
+    expect(io.captured.stdout.join("")).not.toContain("progress:");
+  });
+
+  it("includes the progress tail when --wait times out on a running job", async () => {
+    const stateDir = ensureStateDir(resolveStateDir(workDir));
+    const job = createJob(stateDir, { type: "task", prompt: "stuck" });
+    markRunning(stateDir, job.id, { agentId: "agent-y", runId: "run-y" });
+    logJobLine(stateDir, job.id, "still cooking");
+
+    const io = captureIO(workDir);
+    const code = await companionMain(
+      argv("status", job.id, "--wait", "--timeout-ms", "30", "--poll-ms", "10"),
+      io,
+    );
+    expect(code).toBe(1);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("progress:");
+    expect(out).toContain("still cooking");
   });
 
   it("--json with --wait emits the final job record on stdout", async () => {

--- a/tests/unit/lib/state.test.mts
+++ b/tests/unit/lib/state.test.mts
@@ -32,6 +32,7 @@ import {
   resolveStateDir,
   resolveStateRoot,
   STATE_ROOT_ENV,
+  tailJobLog,
   writeJob,
   writeJsonAtomic,
   writeSession,
@@ -207,6 +208,29 @@ describe("job records and logs", () => {
 
   it("readJobLog returns undefined when no log exists", () => {
     expect(readJobLog(stateDir, "ghost")).toBeUndefined();
+  });
+
+  it("tailJobLog returns the last N lines without a trailing newline", () => {
+    for (const i of [1, 2, 3, 4, 5]) appendJobLog(stateDir, "job-tail", `line${i}\n`);
+    expect(tailJobLog(stateDir, "job-tail", 3)).toBe("line3\nline4\nline5");
+  });
+
+  it("tailJobLog returns the entire log when fewer than N lines exist", () => {
+    appendJobLog(stateDir, "job-short", "only\n");
+    expect(tailJobLog(stateDir, "job-short", 10)).toBe("only");
+  });
+
+  it("tailJobLog handles a log without a trailing newline", () => {
+    appendJobLog(stateDir, "job-noeol", "a\nb\nc");
+    expect(tailJobLog(stateDir, "job-noeol", 2)).toBe("b\nc");
+  });
+
+  it("tailJobLog returns undefined for missing or empty logs and zero lines", () => {
+    expect(tailJobLog(stateDir, "ghost", 5)).toBeUndefined();
+    appendJobLog(stateDir, "job-empty", "");
+    expect(tailJobLog(stateDir, "job-empty", 5)).toBeUndefined();
+    appendJobLog(stateDir, "job-something", "x\n");
+    expect(tailJobLog(stateDir, "job-something", 0)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
Adds a "progress:" block to renderJobDetail showing the last 15 log lines
for any non-terminal job, mirroring Codex's Progress: section. Lets users
peek at a running job without running /cursor:result --log.

Introduces tailJobLog() in state.mts for the underlying read.