### PR TITLE
fix: align /cursor:status with verbatim passthrough contract

### DIFF
--- a/plugins/cursor/commands/status.md
+++ b/plugins/cursor/commands/status.md
@@ -9,14 +9,9 @@ disable-model-invocation: true
 node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" status $ARGUMENTS
 ```
 
-If the user did not pass a job ID:
-- Render the command output as a single Markdown table for the current and past runs in this session.
-- Keep it compact. Do not include progress blocks or extra prose outside the table.
-- Preserve the actionable fields from the command output, including job ID, kind, status, elapsed or duration, summary, and follow-up commands.
-
-If the user did pass a job ID:
-- Present the full command output to the user.
-- Do not summarize or condense it.
+The script renders Markdown server-side (a job table without a job id, a
+detail view with one). Surface the output verbatim — do not paraphrase,
+re-table, summarize, or condense it.
 
 Filters available: `--type <task|review|adversarial-review>`,
 `--status <pending|running|completed|failed|cancelled>`, `--limit <n>`.


### PR DESCRIPTION
The companion script already renders Markdown server-side (job table for
the list view, detail view for a single job). The previous instructions
told Claude to re-render the table for the no-id case while passing the
detail view through unchanged — a hybrid that didn't match any other
command and caused inconsistent table cell rewriting.

Replace with a uniform "surface verbatim" instruction so /cursor:status
behaves like /cursor:result, /cursor:resume, /cursor:review, etc.