### PR TITLE
feat: surface SDK install status and add /cursor:setup --install

### DIFF
--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -1,11 +1,27 @@
 ---
-description: Validate the cursor-plugin-cc runtime — Node, API key, account, models. Manage credentials and the Stop review gate.
-argument-hint: '[--login|--logout] [--enable-gate|--disable-gate] [--set-model <id>|--clear-model] [--json]'
+description: Validate the cursor-plugin-cc runtime — Node, SDK, API key, account, models. Manage credentials and the Stop review gate.
+argument-hint: '[--install] [--login|--logout] [--enable-gate|--disable-gate] [--set-model <id>|--clear-model] [--json]'
 allowed-tools: Bash(node:*), Bash(printf:*), Bash(rm:*)
 disable-model-invocation: true
 ---
 
 # /cursor:setup
+
+## When `--install` is passed
+
+Run the CLI directly:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" setup --install
+```
+
+This reruns `npm install --omit=dev` in the plugin root and persists a status
+file alongside the plugin's `node_modules/`. Use it when the SDK row in the
+default report is `fail` (typical cause: the `SessionStart` bootstrap hook
+hit a network or permissions error and silently swallowed it).
+
+Surface the output verbatim. On success the next `/cursor:setup` should show
+`SDK | ok |`.
 
 ## When `--login` is passed
 
@@ -61,8 +77,11 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" setup $ARGUMENT
 
 Pass `--json` for machine-readable output. If anything fails (API key missing,
 network error, model catalog empty), the exit code is non-zero and the failure
-rows print on stdout. No further action needed — surface the output verbatim
-to the user.
+rows print on stdout. Surface the output verbatim to the user.
+
+If the **SDK** row is `fail`, recommend `/cursor:setup --install` as the
+remediation. The default report includes a remediation hint at the bottom in
+that case.
 
 ## Credential management
 

--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -38,15 +38,13 @@ if (needsInstall) {
     error = stderr ? `${message}: ${stderr.slice(-1024)}` : message;
   }
 
-  // Persist the result so /cursor:setup can surface bootstrap failures
-  // instead of leaving the user staring at a generic SDK-load error.
+  // /cursor:setup reads this file to surface bootstrap failures.
   try {
     mkdirSync(nodeModules, { recursive: true });
     const status = {
       ok,
       attemptedAt: new Date().toISOString(),
       durationMs: Date.now() - startedAt,
-      source: "bootstrap",
       command,
       ...(error ? { error } : {}),
     };

--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -1,20 +1,26 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const pluginRoot =
   process.env.CLAUDE_PLUGIN_ROOT ?? dirname(dirname(fileURLToPath(import.meta.url)));
 
-const sdkDir = join(pluginRoot, "node_modules", "@cursor", "sdk");
-const sentinel = join(pluginRoot, "node_modules", ".bootstrap-ok");
+const nodeModules = join(pluginRoot, "node_modules");
+const sdkDir = join(nodeModules, "@cursor", "sdk");
+const sentinel = join(nodeModules, ".bootstrap-ok");
+const statusFile = join(nodeModules, ".bootstrap-status.json");
 
 const needsInstall = !existsSync(sdkDir) || !existsSync(sentinel);
 
 if (needsInstall) {
+  const command = "npm install --omit=dev";
+  const startedAt = Date.now();
+  let ok = false;
+  let error;
   try {
-    execSync("npm install --omit=dev", {
+    execSync(command, {
       cwd: pluginRoot,
       stdio: "pipe",
       timeout: 120_000,
@@ -24,8 +30,34 @@ if (needsInstall) {
       stdio: "pipe",
       timeout: 10_000,
     });
-    const { writeFileSync } = await import("node:fs");
     writeFileSync(sentinel, new Date().toISOString(), "utf8");
+    ok = true;
+  } catch (err) {
+    const stderr = err?.stderr ? err.stderr.toString("utf8").trim() : "";
+    const message = err instanceof Error ? err.message : String(err);
+    error = stderr ? `${message}: ${stderr.slice(-1024)}` : message;
+  }
+
+  // Persist the result so /cursor:setup can surface bootstrap failures
+  // instead of leaving the user staring at a generic SDK-load error.
+  try {
+    mkdirSync(nodeModules, { recursive: true });
+    const status = {
+      ok,
+      attemptedAt: new Date().toISOString(),
+      durationMs: Date.now() - startedAt,
+      source: "bootstrap",
+      command,
+      ...(error ? { error } : {}),
+    };
+    const tmp = `${statusFile}.${process.pid}.tmp`;
+    writeFileSync(tmp, `${JSON.stringify(status, null, 2)}\n`, { mode: 0o600 });
+    try {
+      renameSync(tmp, statusFile);
+    } catch (renameErr) {
+      rmSync(tmp, { force: true });
+      throw renameErr;
+    }
   } catch {
     // Best-effort — hooks must never crash Claude Code.
   }

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -552,13 +552,13 @@ function runNpmInstall(pluginRoot, options = {}) {
       });
       return;
     }
-    let stderrTail = "";
+    let outputTail = "";
     const collect = (chunk) => {
       const text = chunk.toString("utf8");
-      stderrTail = (stderrTail + text).slice(-2048);
+      outputTail = (outputTail + text).slice(-2048);
       options.onOutput?.(text);
     };
-    child.stdout?.on("data", (chunk) => options.onOutput?.(chunk.toString("utf8")));
+    child.stdout?.on("data", collect);
     child.stderr?.on("data", collect);
     const timer = setTimeout(() => {
       try {
@@ -587,7 +587,7 @@ function runNpmInstall(pluginRoot, options = {}) {
         finish({ ok: true, durationMs: Date.now() - start, command });
       } else {
         const reason = signal ? `npm install terminated by signal ${signal}` : `npm install exited with code ${code}`;
-        const detail = stderrTail.trim();
+        const detail = outputTail.trim();
         finish({
           ok: false,
           error: detail ? `${reason}: ${detail}` : reason,
@@ -605,7 +605,6 @@ async function installAndRecord(pluginRoot, options = {}) {
     attemptedAt: (/* @__PURE__ */ new Date()).toISOString(),
     durationMs: result.durationMs,
     command: result.command,
-    ...options.source ? { source: options.source } : {},
     ...result.error ? { error: result.error } : {}
   };
   try {
@@ -693,12 +692,10 @@ function modelChoices(models) {
 var INSTALL_REMEDIATION = "Run /cursor:setup --install to (re)install the SDK.";
 function buildSdkReport() {
   const pluginRoot = resolvePluginRoot();
-  const installed = isSdkInstalled(pluginRoot);
+  const ok = isSdkInstalled(pluginRoot);
   const bootstrap = readBootstrapStatus(pluginRoot);
-  const ok = installed && bootstrap?.ok !== false;
   const sdk = { ok, pluginRoot };
   if (bootstrap) sdk.bootstrap = bootstrap;
-  if (!ok) sdk.remediation = INSTALL_REMEDIATION;
   return sdk;
 }
 function errorMessage(reason) {
@@ -776,21 +773,17 @@ function renderReport(report) {
   }
   if (!report.sdk.ok) {
     lines.push("");
-    lines.push(`> ${report.sdk.remediation ?? INSTALL_REMEDIATION}`);
+    lines.push(`> ${INSTALL_REMEDIATION}`);
   }
   return `${lines.join("\n")}
 `;
 }
 function describeSdk(sdk) {
   if (sdk.ok) {
-    if (sdk.bootstrap?.ok && sdk.bootstrap.attemptedAt) {
-      return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
-    }
+    if (sdk.bootstrap?.ok) return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
     return "installed";
   }
-  if (sdk.bootstrap?.error) {
-    return `bootstrap failed: ${sdk.bootstrap.error}`;
-  }
+  if (sdk.bootstrap?.error) return `bootstrap failed: ${sdk.bootstrap.error}`;
   return "not installed";
 }
 function describeSource(source) {
@@ -903,7 +896,6 @@ async function runInstall(io, json) {
 `);
   }
   const result = await installAndRecord(pluginRoot, {
-    source: "setup",
     onOutput: json ? void 0 : (chunk) => io.stderr.write(chunk)
   });
   if (json) {

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -44,6 +44,7 @@ import {
   markPhase,
   markRunning,
   readJobLog,
+  readJson,
   reconcileStaleJobs,
   registerActiveRun,
   resolveApiKey,
@@ -58,7 +59,8 @@ import {
   toAgentEvents,
   unregisterActiveRun,
   validateModel,
-  whoami
+  whoami,
+  writeJsonAtomic
 } from "./chunk-B3GESHAJ.mjs";
 
 // plugins/cursor/scripts/commands/cancel.mts
@@ -479,15 +481,156 @@ async function runResume(args, io) {
   });
 }
 
+// plugins/cursor/scripts/lib/install.mts
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+var BOOTSTRAP_STATUS_FILENAME = ".bootstrap-status.json";
+var BOOTSTRAP_SENTINEL_FILENAME = ".bootstrap-ok";
+function resolvePluginRoot() {
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot && envRoot.trim() !== "") return path.resolve(envRoot);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "..");
+}
+function pluginNodeModules(pluginRoot) {
+  return path.join(pluginRoot, "node_modules");
+}
+function statusPath(pluginRoot) {
+  return path.join(pluginNodeModules(pluginRoot), BOOTSTRAP_STATUS_FILENAME);
+}
+function sentinelPath(pluginRoot) {
+  return path.join(pluginNodeModules(pluginRoot), BOOTSTRAP_SENTINEL_FILENAME);
+}
+function isSdkInstalled(pluginRoot) {
+  const direct = path.join(pluginNodeModules(pluginRoot), "@cursor", "sdk", "package.json");
+  if (fs.existsSync(direct)) return true;
+  try {
+    const require2 = createRequire(import.meta.url);
+    require2.resolve("@cursor/sdk");
+    return true;
+  } catch {
+    return false;
+  }
+}
+function readBootstrapStatus(pluginRoot) {
+  return readJson(statusPath(pluginRoot));
+}
+function writeBootstrapStatus(pluginRoot, status) {
+  writeJsonAtomic(statusPath(pluginRoot), status);
+}
+function writeBootstrapSentinel(pluginRoot) {
+  fs.mkdirSync(pluginNodeModules(pluginRoot), { recursive: true });
+  fs.writeFileSync(sentinelPath(pluginRoot), (/* @__PURE__ */ new Date()).toISOString(), "utf8");
+}
+function runNpmInstall(pluginRoot, options = {}) {
+  const command = "npm install --omit=dev";
+  const timeoutMs = options.timeoutMs ?? 12e4;
+  const start = Date.now();
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    let child;
+    try {
+      child = spawn("npm", ["install", "--omit=dev"], {
+        cwd: pluginRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env
+      });
+    } catch (err) {
+      finish({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+        command
+      });
+      return;
+    }
+    let stderrTail = "";
+    const collect = (chunk) => {
+      const text = chunk.toString("utf8");
+      stderrTail = (stderrTail + text).slice(-2048);
+      options.onOutput?.(text);
+    };
+    child.stdout?.on("data", (chunk) => options.onOutput?.(chunk.toString("utf8")));
+    child.stderr?.on("data", collect);
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+      }
+      finish({
+        ok: false,
+        error: `npm install timed out after ${timeoutMs}ms`,
+        durationMs: Date.now() - start,
+        command
+      });
+    }, timeoutMs);
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      finish({
+        ok: false,
+        error: err.message,
+        durationMs: Date.now() - start,
+        command
+      });
+    });
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        finish({ ok: true, durationMs: Date.now() - start, command });
+      } else {
+        const reason = signal ? `npm install terminated by signal ${signal}` : `npm install exited with code ${code}`;
+        const detail = stderrTail.trim();
+        finish({
+          ok: false,
+          error: detail ? `${reason}: ${detail}` : reason,
+          durationMs: Date.now() - start,
+          command
+        });
+      }
+    });
+  });
+}
+async function installAndRecord(pluginRoot, options = {}) {
+  const result = await runNpmInstall(pluginRoot, options);
+  const status = {
+    ok: result.ok,
+    attemptedAt: (/* @__PURE__ */ new Date()).toISOString(),
+    durationMs: result.durationMs,
+    command: result.command,
+    ...options.source ? { source: options.source } : {},
+    ...result.error ? { error: result.error } : {}
+  };
+  try {
+    writeBootstrapStatus(pluginRoot, status);
+    if (result.ok) writeBootstrapSentinel(pluginRoot);
+  } catch {
+  }
+  return result;
+}
+
 // plugins/cursor/scripts/commands/setup.mts
 var NODE_MIN_MAJOR = 18;
 var HELP4 = `cursor-companion setup [flags]
 
 Validates the plugin runtime:
   - Node.js >= ${NODE_MIN_MAJOR}
+  - @cursor/sdk is installed (bootstrap.mjs ran successfully)
   - API key is available (env or keychain)
   - Cursor.me() succeeds (key is valid)
   - Cursor.models.list() returns at least one model
+
+SDK installation:
+  --install            Run \`npm install --omit=dev\` in the plugin root.
+                       Use this when bootstrap reports a failure or the
+                       SDK row in the report is "fail".
 
 Credential management:
   --login              Store a Cursor API key in the OS keychain.
@@ -547,6 +690,17 @@ function modelChoices(models) {
   }
   return choices;
 }
+var INSTALL_REMEDIATION = "Run /cursor:setup --install to (re)install the SDK.";
+function buildSdkReport() {
+  const pluginRoot = resolvePluginRoot();
+  const installed = isSdkInstalled(pluginRoot);
+  const bootstrap = readBootstrapStatus(pluginRoot);
+  const ok = installed && bootstrap?.ok !== false;
+  const sdk = { ok, pluginRoot };
+  if (bootstrap) sdk.bootstrap = bootstrap;
+  if (!ok) sdk.remediation = INSTALL_REMEDIATION;
+  return sdk;
+}
 function errorMessage(reason) {
   return reason instanceof Error ? reason.message : String(reason);
 }
@@ -554,6 +708,7 @@ async function buildReport(input) {
   const resolved = resolveDefaultModel(DEFAULT_MODEL);
   const report = {
     node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
+    sdk: buildSdkReport(),
     apiKey: { ok: false },
     account: { ok: false },
     models: { ok: false, choices: [] },
@@ -597,6 +752,7 @@ function renderReport(report) {
     );
   };
   row("Node.js", yes(report.node.ok), report.node.version);
+  row("SDK", yes(report.sdk.ok), describeSdk(report.sdk));
   const keyDetail = report.apiKey.ok ? `source: ${report.apiKey.source}` : report.apiKey.error ?? "";
   row("API key", yes(report.apiKey.ok), keyDetail);
   if (report.account.ok) {
@@ -618,8 +774,24 @@ function renderReport(report) {
       lines.push(`- ${choice.label} \`[${choice.selection.id}]\``);
     }
   }
+  if (!report.sdk.ok) {
+    lines.push("");
+    lines.push(`> ${report.sdk.remediation ?? INSTALL_REMEDIATION}`);
+  }
   return `${lines.join("\n")}
 `;
+}
+function describeSdk(sdk) {
+  if (sdk.ok) {
+    if (sdk.bootstrap?.ok && sdk.bootstrap.attemptedAt) {
+      return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
+    }
+    return "installed";
+  }
+  if (sdk.bootstrap?.error) {
+    return `bootstrap failed: ${sdk.bootstrap.error}`;
+  }
+  return "not installed";
 }
 function describeSource(source) {
   switch (source) {
@@ -724,6 +896,40 @@ async function runLogin(io, json) {
   }
   return 0;
 }
+async function runInstall(io, json) {
+  const pluginRoot = resolvePluginRoot();
+  if (!json) {
+    io.stdout.write(`Installing @cursor/sdk in ${pluginRoot}
+`);
+  }
+  const result = await installAndRecord(pluginRoot, {
+    source: "setup",
+    onOutput: json ? void 0 : (chunk) => io.stderr.write(chunk)
+  });
+  if (json) {
+    io.stdout.write(
+      `${JSON.stringify(
+        {
+          ok: result.ok,
+          pluginRoot,
+          durationMs: result.durationMs,
+          command: result.command,
+          ...result.error ? { error: result.error } : {}
+        },
+        null,
+        2
+      )}
+`
+    );
+  } else if (result.ok) {
+    io.stdout.write(`Install succeeded in ${result.durationMs}ms.
+`);
+  } else {
+    io.stderr.write(`Install failed: ${result.error ?? "unknown error"}
+`);
+  }
+  return result.ok ? 0 : 1;
+}
 async function runLogout(io, json) {
   const backend = detectBackend();
   if (!backend) {
@@ -752,6 +958,7 @@ async function runSetup(args, io) {
     long: {
       json: "boolean",
       help: "boolean",
+      install: "boolean",
       login: "boolean",
       logout: "boolean",
       "enable-gate": "boolean",
@@ -766,9 +973,11 @@ async function runSetup(args, io) {
     return 0;
   }
   const jsonFlag = bool(parsed, "json");
-  if (bool(parsed, "login") && bool(parsed, "logout")) {
-    throw new UsageError("--login and --logout are mutually exclusive");
+  const exclusive = ["install", "login", "logout"].filter((flag) => bool(parsed, flag));
+  if (exclusive.length > 1) {
+    throw new UsageError(`${exclusive.map((f) => `--${f}`).join(" and ")} are mutually exclusive`);
   }
+  if (bool(parsed, "install")) return runInstall(io, jsonFlag);
   if (bool(parsed, "login")) return runLogin(io, jsonFlag);
   if (bool(parsed, "logout")) return runLogout(io, jsonFlag);
   const enableGate = bool(parsed, "enable-gate");
@@ -807,7 +1016,7 @@ async function runSetup(args, io) {
   } else {
     io.stdout.write(renderReport(report));
   }
-  const allOk = report.node.ok && report.apiKey.ok && report.account.ok && report.models.ok;
+  const allOk = report.node.ok && report.sdk.ok && report.apiKey.ok && report.account.ok && report.models.ok;
   return allOk ? 0 : 1;
 }
 
@@ -1016,13 +1225,13 @@ flags:
 `;
 var HelpRequested2 = class extends Error {
 };
-function readPromptFile(cwd, path) {
-  const abs = resolvePath(cwd, path);
+function readPromptFile(cwd, path2) {
+  const abs = resolvePath(cwd, path2);
   try {
     return readFileSync(abs, "utf8").trim();
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
-    throw new UsageError(`failed to read --prompt-file ${path}: ${detail}`);
+    throw new UsageError(`failed to read --prompt-file ${path2}: ${detail}`);
   }
 }
 function parseFlags2(args, cwd) {

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -11,6 +11,13 @@ import {
   whoami,
 } from "../lib/cursor-agent.mjs";
 import { readGateConfig, setGateEnabled } from "../lib/gate.mjs";
+import {
+  type BootstrapStatus,
+  installAndRecord,
+  isSdkInstalled,
+  readBootstrapStatus,
+  resolvePluginRoot,
+} from "../lib/install.mjs";
 import { escapeMarkdownCell } from "../lib/render.mjs";
 import { resolveStateDir } from "../lib/state.mjs";
 import {
@@ -33,9 +40,15 @@ const HELP = `cursor-companion setup [flags]
 
 Validates the plugin runtime:
   - Node.js >= ${NODE_MIN_MAJOR}
+  - @cursor/sdk is installed (bootstrap.mjs ran successfully)
   - API key is available (env or keychain)
   - Cursor.me() succeeds (key is valid)
   - Cursor.models.list() returns at least one model
+
+SDK installation:
+  --install            Run \`npm install --omit=dev\` in the plugin root.
+                       Use this when bootstrap reports a failure or the
+                       SDK row in the report is "fail".
 
 Credential management:
   --login              Store a Cursor API key in the OS keychain.
@@ -105,6 +118,12 @@ export function modelChoices(models: Awaited<ReturnType<typeof listModels>>): Mo
 
 interface SetupReport {
   node: { ok: boolean; version: string };
+  sdk: {
+    ok: boolean;
+    pluginRoot: string;
+    bootstrap?: BootstrapStatus;
+    remediation?: string;
+  };
   apiKey: { ok: boolean; source?: KeySource; error?: string };
   account: { ok: boolean; apiKeyName?: string; error?: string };
   models: { ok: boolean; choices: ModelChoice[]; error?: string };
@@ -118,6 +137,19 @@ interface BuildReportInput {
   prefetchedCatalog?: SDKModel[];
 }
 
+const INSTALL_REMEDIATION = "Run /cursor:setup --install to (re)install the SDK.";
+
+function buildSdkReport(): SetupReport["sdk"] {
+  const pluginRoot = resolvePluginRoot();
+  const installed = isSdkInstalled(pluginRoot);
+  const bootstrap = readBootstrapStatus(pluginRoot);
+  const ok = installed && bootstrap?.ok !== false;
+  const sdk: SetupReport["sdk"] = { ok, pluginRoot };
+  if (bootstrap) sdk.bootstrap = bootstrap;
+  if (!ok) sdk.remediation = INSTALL_REMEDIATION;
+  return sdk;
+}
+
 function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason);
 }
@@ -126,6 +158,7 @@ async function buildReport(input: BuildReportInput): Promise<SetupReport> {
   const resolved = resolveDefaultModel(DEFAULT_MODEL);
   const report: SetupReport = {
     node: { ok: nodeMajor() >= NODE_MIN_MAJOR, version: process.versions.node },
+    sdk: buildSdkReport(),
     apiKey: { ok: false },
     account: { ok: false },
     models: { ok: false, choices: [] },
@@ -177,6 +210,7 @@ function renderReport(report: SetupReport): string {
     );
   };
   row("Node.js", yes(report.node.ok), report.node.version);
+  row("SDK", yes(report.sdk.ok), describeSdk(report.sdk));
   const keyDetail = report.apiKey.ok
     ? `source: ${report.apiKey.source}`
     : (report.apiKey.error ?? "");
@@ -201,7 +235,24 @@ function renderReport(report: SetupReport): string {
       lines.push(`- ${choice.label} \`[${choice.selection.id}]\``);
     }
   }
+  if (!report.sdk.ok) {
+    lines.push("");
+    lines.push(`> ${report.sdk.remediation ?? INSTALL_REMEDIATION}`);
+  }
   return `${lines.join("\n")}\n`;
+}
+
+function describeSdk(sdk: SetupReport["sdk"]): string {
+  if (sdk.ok) {
+    if (sdk.bootstrap?.ok && sdk.bootstrap.attemptedAt) {
+      return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
+    }
+    return "installed";
+  }
+  if (sdk.bootstrap?.error) {
+    return `bootstrap failed: ${sdk.bootstrap.error}`;
+  }
+  return "not installed";
 }
 
 function describeSource(source: DefaultModelSource): string {
@@ -306,6 +357,38 @@ async function runLogin(io: CommandIO, json: boolean): Promise<ExitCode> {
   return 0;
 }
 
+async function runInstall(io: CommandIO, json: boolean): Promise<ExitCode> {
+  const pluginRoot = resolvePluginRoot();
+  if (!json) {
+    io.stdout.write(`Installing @cursor/sdk in ${pluginRoot}\n`);
+  }
+  const result = await installAndRecord(pluginRoot, {
+    source: "setup",
+    onOutput: json ? undefined : (chunk) => io.stderr.write(chunk),
+  });
+
+  if (json) {
+    io.stdout.write(
+      `${JSON.stringify(
+        {
+          ok: result.ok,
+          pluginRoot,
+          durationMs: result.durationMs,
+          command: result.command,
+          ...(result.error ? { error: result.error } : {}),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else if (result.ok) {
+    io.stdout.write(`Install succeeded in ${result.durationMs}ms.\n`);
+  } else {
+    io.stderr.write(`Install failed: ${result.error ?? "unknown error"}\n`);
+  }
+  return result.ok ? 0 : 1;
+}
+
 async function runLogout(io: CommandIO, json: boolean): Promise<ExitCode> {
   const backend = detectBackend();
   if (!backend) {
@@ -333,6 +416,7 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     long: {
       json: "boolean",
       help: "boolean",
+      install: "boolean",
       login: "boolean",
       logout: "boolean",
       "enable-gate": "boolean",
@@ -349,9 +433,11 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
 
   const jsonFlag = bool(parsed, "json");
 
-  if (bool(parsed, "login") && bool(parsed, "logout")) {
-    throw new UsageError("--login and --logout are mutually exclusive");
+  const exclusive = ["install", "login", "logout"].filter((flag) => bool(parsed, flag));
+  if (exclusive.length > 1) {
+    throw new UsageError(`${exclusive.map((f) => `--${f}`).join(" and ")} are mutually exclusive`);
   }
+  if (bool(parsed, "install")) return runInstall(io, jsonFlag);
   if (bool(parsed, "login")) return runLogin(io, jsonFlag);
   if (bool(parsed, "logout")) return runLogout(io, jsonFlag);
 
@@ -398,6 +484,7 @@ export async function runSetup(args: readonly string[], io: CommandIO): Promise<
     io.stdout.write(renderReport(report));
   }
 
-  const allOk = report.node.ok && report.apiKey.ok && report.account.ok && report.models.ok;
+  const allOk =
+    report.node.ok && report.sdk.ok && report.apiKey.ok && report.account.ok && report.models.ok;
   return allOk ? 0 : 1;
 }

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -122,7 +122,6 @@ interface SetupReport {
     ok: boolean;
     pluginRoot: string;
     bootstrap?: BootstrapStatus;
-    remediation?: string;
   };
   apiKey: { ok: boolean; source?: KeySource; error?: string };
   account: { ok: boolean; apiKeyName?: string; error?: string };
@@ -141,12 +140,12 @@ const INSTALL_REMEDIATION = "Run /cursor:setup --install to (re)install the SDK.
 
 function buildSdkReport(): SetupReport["sdk"] {
   const pluginRoot = resolvePluginRoot();
-  const installed = isSdkInstalled(pluginRoot);
+  // A loadable SDK overrides a stale `ok: false` from a prior failed bootstrap
+  // (e.g. the user fixed the install manually) — otherwise the row would lie.
+  const ok = isSdkInstalled(pluginRoot);
   const bootstrap = readBootstrapStatus(pluginRoot);
-  const ok = installed && bootstrap?.ok !== false;
   const sdk: SetupReport["sdk"] = { ok, pluginRoot };
   if (bootstrap) sdk.bootstrap = bootstrap;
-  if (!ok) sdk.remediation = INSTALL_REMEDIATION;
   return sdk;
 }
 
@@ -237,21 +236,17 @@ function renderReport(report: SetupReport): string {
   }
   if (!report.sdk.ok) {
     lines.push("");
-    lines.push(`> ${report.sdk.remediation ?? INSTALL_REMEDIATION}`);
+    lines.push(`> ${INSTALL_REMEDIATION}`);
   }
   return `${lines.join("\n")}\n`;
 }
 
 function describeSdk(sdk: SetupReport["sdk"]): string {
   if (sdk.ok) {
-    if (sdk.bootstrap?.ok && sdk.bootstrap.attemptedAt) {
-      return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
-    }
+    if (sdk.bootstrap?.ok) return `installed (last bootstrap: ${sdk.bootstrap.attemptedAt})`;
     return "installed";
   }
-  if (sdk.bootstrap?.error) {
-    return `bootstrap failed: ${sdk.bootstrap.error}`;
-  }
+  if (sdk.bootstrap?.error) return `bootstrap failed: ${sdk.bootstrap.error}`;
   return "not installed";
 }
 
@@ -363,7 +358,6 @@ async function runInstall(io: CommandIO, json: boolean): Promise<ExitCode> {
     io.stdout.write(`Installing @cursor/sdk in ${pluginRoot}\n`);
   }
   const result = await installAndRecord(pluginRoot, {
-    source: "setup",
     onOutput: json ? undefined : (chunk) => io.stderr.write(chunk),
   });
 

--- a/plugins/cursor/scripts/lib/install.mts
+++ b/plugins/cursor/scripts/lib/install.mts
@@ -1,0 +1,214 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { readJson, writeJsonAtomic } from "./state.mjs";
+
+export const BOOTSTRAP_STATUS_FILENAME = ".bootstrap-status.json";
+export const BOOTSTRAP_SENTINEL_FILENAME = ".bootstrap-ok";
+
+export interface BootstrapStatus {
+  /** True when the most recent install completed and the SDK is loadable. */
+  ok: boolean;
+  /** Error message captured from the failing command (stderr tail or thrown reason). */
+  error?: string;
+  /** ISO timestamp of the most recent attempt. */
+  attemptedAt: string;
+  /** Wall-clock duration of the install in milliseconds, when measured. */
+  durationMs?: number;
+  /** Origin tag — `bootstrap` (SessionStart) vs `setup --install` (interactive). */
+  source?: "bootstrap" | "setup";
+  /** The npm command that was run, for the user to repeat manually. */
+  command?: string;
+}
+
+/**
+ * Resolve the plugin root from the env (set by Claude Code) or by walking up
+ * from this module's location. Used by both bootstrap.mjs and setup.
+ */
+export function resolvePluginRoot(): string {
+  const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
+  if (envRoot && envRoot.trim() !== "") return path.resolve(envRoot);
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.resolve(here, "..", "..");
+}
+
+function pluginNodeModules(pluginRoot: string): string {
+  return path.join(pluginRoot, "node_modules");
+}
+
+function statusPath(pluginRoot: string): string {
+  return path.join(pluginNodeModules(pluginRoot), BOOTSTRAP_STATUS_FILENAME);
+}
+
+function sentinelPath(pluginRoot: string): string {
+  return path.join(pluginNodeModules(pluginRoot), BOOTSTRAP_SENTINEL_FILENAME);
+}
+
+/**
+ * True when `@cursor/sdk` is resolvable. Checks the plugin's local
+ * `node_modules` first (the production layout written by bootstrap.mjs), then
+ * falls back to Node.js's normal resolution from this module's location, which
+ * picks up hoisted/monorepo installs (dev and test environments).
+ */
+export function isSdkInstalled(pluginRoot: string): boolean {
+  const direct = path.join(pluginNodeModules(pluginRoot), "@cursor", "sdk", "package.json");
+  if (fs.existsSync(direct)) return true;
+  try {
+    const require = createRequire(import.meta.url);
+    require.resolve("@cursor/sdk");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the bootstrap sentinel was written by a previous successful install. */
+export function hasBootstrapSentinel(pluginRoot: string): boolean {
+  return fs.existsSync(sentinelPath(pluginRoot));
+}
+
+export function readBootstrapStatus(pluginRoot: string): BootstrapStatus | undefined {
+  return readJson<BootstrapStatus>(statusPath(pluginRoot));
+}
+
+export function writeBootstrapStatus(pluginRoot: string, status: BootstrapStatus): void {
+  writeJsonAtomic(statusPath(pluginRoot), status);
+}
+
+export function writeBootstrapSentinel(pluginRoot: string): void {
+  fs.mkdirSync(pluginNodeModules(pluginRoot), { recursive: true });
+  fs.writeFileSync(sentinelPath(pluginRoot), new Date().toISOString(), "utf8");
+}
+
+export interface InstallOptions {
+  /** Per-attempt timeout in milliseconds. Defaults to 120s. */
+  timeoutMs?: number;
+  /** Tag stored on the resulting status. */
+  source?: "bootstrap" | "setup";
+  /** When provided, install output is teed to this stream (line-buffered). */
+  onOutput?: (chunk: string) => void;
+}
+
+export interface InstallResult {
+  ok: boolean;
+  error?: string;
+  durationMs: number;
+  command: string;
+}
+
+/**
+ * Run `npm install --omit=dev` in the plugin root. Captures stdout+stderr,
+ * forwards both to `onOutput` when provided, and resolves with a structured
+ * result. Never throws — the caller decides how to surface a failed install.
+ */
+export function runNpmInstall(
+  pluginRoot: string,
+  options: InstallOptions = {},
+): Promise<InstallResult> {
+  const command = "npm install --omit=dev";
+  const timeoutMs = options.timeoutMs ?? 120_000;
+  const start = Date.now();
+
+  return new Promise<InstallResult>((resolve) => {
+    let settled = false;
+    const finish = (result: InstallResult): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn("npm", ["install", "--omit=dev"], {
+        cwd: pluginRoot,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: process.env,
+      });
+    } catch (err) {
+      finish({
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        durationMs: Date.now() - start,
+        command,
+      });
+      return;
+    }
+
+    let stderrTail = "";
+    const collect = (chunk: Buffer): void => {
+      const text = chunk.toString("utf8");
+      stderrTail = (stderrTail + text).slice(-2048);
+      options.onOutput?.(text);
+    };
+    child.stdout?.on("data", (chunk: Buffer) => options.onOutput?.(chunk.toString("utf8")));
+    child.stderr?.on("data", collect);
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        /* best-effort */
+      }
+      finish({
+        ok: false,
+        error: `npm install timed out after ${timeoutMs}ms`,
+        durationMs: Date.now() - start,
+        command,
+      });
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      finish({
+        ok: false,
+        error: err.message,
+        durationMs: Date.now() - start,
+        command,
+      });
+    });
+
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        finish({ ok: true, durationMs: Date.now() - start, command });
+      } else {
+        const reason = signal
+          ? `npm install terminated by signal ${signal}`
+          : `npm install exited with code ${code}`;
+        const detail = stderrTail.trim();
+        finish({
+          ok: false,
+          error: detail ? `${reason}: ${detail}` : reason,
+          durationMs: Date.now() - start,
+          command,
+        });
+      }
+    });
+  });
+}
+
+/** Convenience: install + persist status + write sentinel on success. */
+export async function installAndRecord(
+  pluginRoot: string,
+  options: InstallOptions = {},
+): Promise<InstallResult> {
+  const result = await runNpmInstall(pluginRoot, options);
+  const status: BootstrapStatus = {
+    ok: result.ok,
+    attemptedAt: new Date().toISOString(),
+    durationMs: result.durationMs,
+    command: result.command,
+    ...(options.source ? { source: options.source } : {}),
+    ...(result.error ? { error: result.error } : {}),
+  };
+  try {
+    writeBootstrapStatus(pluginRoot, status);
+    if (result.ok) writeBootstrapSentinel(pluginRoot);
+  } catch {
+    /* status is best-effort; the install result is the primary signal */
+  }
+  return result;
+}

--- a/plugins/cursor/scripts/lib/install.mts
+++ b/plugins/cursor/scripts/lib/install.mts
@@ -10,24 +10,13 @@ export const BOOTSTRAP_STATUS_FILENAME = ".bootstrap-status.json";
 export const BOOTSTRAP_SENTINEL_FILENAME = ".bootstrap-ok";
 
 export interface BootstrapStatus {
-  /** True when the most recent install completed and the SDK is loadable. */
   ok: boolean;
-  /** Error message captured from the failing command (stderr tail or thrown reason). */
-  error?: string;
-  /** ISO timestamp of the most recent attempt. */
   attemptedAt: string;
-  /** Wall-clock duration of the install in milliseconds, when measured. */
+  error?: string;
   durationMs?: number;
-  /** Origin tag — `bootstrap` (SessionStart) vs `setup --install` (interactive). */
-  source?: "bootstrap" | "setup";
-  /** The npm command that was run, for the user to repeat manually. */
   command?: string;
 }
 
-/**
- * Resolve the plugin root from the env (set by Claude Code) or by walking up
- * from this module's location. Used by both bootstrap.mjs and setup.
- */
 export function resolvePluginRoot(): string {
   const envRoot = process.env.CLAUDE_PLUGIN_ROOT;
   if (envRoot && envRoot.trim() !== "") return path.resolve(envRoot);
@@ -48,10 +37,8 @@ function sentinelPath(pluginRoot: string): string {
 }
 
 /**
- * True when `@cursor/sdk` is resolvable. Checks the plugin's local
- * `node_modules` first (the production layout written by bootstrap.mjs), then
- * falls back to Node.js's normal resolution from this module's location, which
- * picks up hoisted/monorepo installs (dev and test environments).
+ * Direct `node_modules/@cursor/sdk` lookup first (the production layout written
+ * by bootstrap.mjs), then Node.js resolution for hoisted/monorepo installs.
  */
 export function isSdkInstalled(pluginRoot: string): boolean {
   const direct = path.join(pluginNodeModules(pluginRoot), "@cursor", "sdk", "package.json");
@@ -63,11 +50,6 @@ export function isSdkInstalled(pluginRoot: string): boolean {
   } catch {
     return false;
   }
-}
-
-/** True when the bootstrap sentinel was written by a previous successful install. */
-export function hasBootstrapSentinel(pluginRoot: string): boolean {
-  return fs.existsSync(sentinelPath(pluginRoot));
 }
 
 export function readBootstrapStatus(pluginRoot: string): BootstrapStatus | undefined {
@@ -84,11 +66,7 @@ export function writeBootstrapSentinel(pluginRoot: string): void {
 }
 
 export interface InstallOptions {
-  /** Per-attempt timeout in milliseconds. Defaults to 120s. */
   timeoutMs?: number;
-  /** Tag stored on the resulting status. */
-  source?: "bootstrap" | "setup";
-  /** When provided, install output is teed to this stream (line-buffered). */
   onOutput?: (chunk: string) => void;
 }
 
@@ -99,11 +77,6 @@ export interface InstallResult {
   command: string;
 }
 
-/**
- * Run `npm install --omit=dev` in the plugin root. Captures stdout+stderr,
- * forwards both to `onOutput` when provided, and resolves with a structured
- * result. Never throws — the caller decides how to surface a failed install.
- */
 export function runNpmInstall(
   pluginRoot: string,
   options: InstallOptions = {},
@@ -137,21 +110,22 @@ export function runNpmInstall(
       return;
     }
 
-    let stderrTail = "";
+    // npm puts diagnostics on both streams (ERR! lines on stderr, but progress
+    // and some failures on stdout); merge them so the persisted error tail
+    // doesn't drop one half.
+    let outputTail = "";
     const collect = (chunk: Buffer): void => {
       const text = chunk.toString("utf8");
-      stderrTail = (stderrTail + text).slice(-2048);
+      outputTail = (outputTail + text).slice(-2048);
       options.onOutput?.(text);
     };
-    child.stdout?.on("data", (chunk: Buffer) => options.onOutput?.(chunk.toString("utf8")));
+    child.stdout?.on("data", collect);
     child.stderr?.on("data", collect);
 
     const timer = setTimeout(() => {
       try {
         child.kill("SIGTERM");
-      } catch {
-        /* best-effort */
-      }
+      } catch {}
       finish({
         ok: false,
         error: `npm install timed out after ${timeoutMs}ms`,
@@ -178,7 +152,7 @@ export function runNpmInstall(
         const reason = signal
           ? `npm install terminated by signal ${signal}`
           : `npm install exited with code ${code}`;
-        const detail = stderrTail.trim();
+        const detail = outputTail.trim();
         finish({
           ok: false,
           error: detail ? `${reason}: ${detail}` : reason,
@@ -190,7 +164,6 @@ export function runNpmInstall(
   });
 }
 
-/** Convenience: install + persist status + write sentinel on success. */
 export async function installAndRecord(
   pluginRoot: string,
   options: InstallOptions = {},
@@ -201,14 +174,11 @@ export async function installAndRecord(
     attemptedAt: new Date().toISOString(),
     durationMs: result.durationMs,
     command: result.command,
-    ...(options.source ? { source: options.source } : {}),
     ...(result.error ? { error: result.error } : {}),
   };
   try {
     writeBootstrapStatus(pluginRoot, status);
     if (result.ok) writeBootstrapSentinel(pluginRoot);
-  } catch {
-    /* status is best-effort; the install result is the primary signal */
-  }
+  } catch {}
   return result;
 }

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -20,6 +20,23 @@ vi.mock("@cursor/sdk", async () => {
   };
 });
 
+const installMocks = vi.hoisted(() => ({
+  installAndRecord: vi.fn(),
+  isSdkInstalled: vi.fn(),
+  readBootstrapStatus: vi.fn(),
+}));
+
+vi.mock("@plugin/lib/install.mjs", async () => {
+  const actual =
+    await vi.importActual<typeof import("@plugin/lib/install.mjs")>("@plugin/lib/install.mjs");
+  return {
+    ...actual,
+    installAndRecord: installMocks.installAndRecord,
+    isSdkInstalled: installMocks.isSdkInstalled,
+    readBootstrapStatus: installMocks.readBootstrapStatus,
+  };
+});
+
 import { main as companionMain } from "@plugin/cursor-companion.mjs";
 import { setBackendForTesting } from "@plugin/lib/credentials.mjs";
 import { readGateConfig } from "@plugin/lib/gate.mjs";
@@ -45,6 +62,8 @@ beforeEach(() => {
     { id: "composer-2", displayName: "Composer 2", variants: [] },
     { id: "gpt-5", displayName: "GPT 5", variants: [] },
   ]);
+  installMocks.isSdkInstalled.mockReturnValue(true);
+  installMocks.readBootstrapStatus.mockReturnValue(undefined);
 });
 
 afterEach(() => {
@@ -180,5 +199,95 @@ describe("CLI: setup", () => {
     expect(await companionMain(argv("setup", "--logout", "--json"), io)).toBe(1);
     const parsed = JSON.parse(io.captured.stdout.join(""));
     expect(parsed.ok).toBe(false);
+  });
+
+  it("default report includes an SDK row marked ok when the SDK is installed", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("| SDK | ok |");
+  });
+
+  it("default report marks SDK fail and shows remediation when SDK is missing", async () => {
+    installMocks.isSdkInstalled.mockReturnValue(false);
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(1);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("| SDK | fail |");
+    expect(out).toContain("/cursor:setup --install");
+  });
+
+  it("default report surfaces a bootstrap failure error from .bootstrap-status.json", async () => {
+    installMocks.isSdkInstalled.mockReturnValue(false);
+    installMocks.readBootstrapStatus.mockReturnValue({
+      ok: false,
+      attemptedAt: "2026-05-03T00:00:00Z",
+      error: "ENETUNREACH: network unreachable",
+      source: "bootstrap",
+      command: "npm install --omit=dev",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(1);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("bootstrap failed: ENETUNREACH: network unreachable");
+  });
+
+  it("--json includes the sdk and bootstrap fields", async () => {
+    installMocks.isSdkInstalled.mockReturnValue(false);
+    installMocks.readBootstrapStatus.mockReturnValue({
+      ok: false,
+      attemptedAt: "2026-05-03T00:00:00Z",
+      error: "boom",
+      source: "bootstrap",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--json"), io)).toBe(1);
+    const report = JSON.parse(io.captured.stdout.join(""));
+    expect(report.sdk.ok).toBe(false);
+    expect(report.sdk.bootstrap.error).toBe("boom");
+    expect(report.sdk.remediation).toContain("--install");
+  });
+
+  it("--install runs the installer and reports success", async () => {
+    installMocks.installAndRecord.mockResolvedValue({
+      ok: true,
+      durationMs: 42,
+      command: "npm install --omit=dev",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--install"), io)).toBe(0);
+    expect(installMocks.installAndRecord).toHaveBeenCalledTimes(1);
+    expect(io.captured.stdout.join("")).toContain("Install succeeded");
+  });
+
+  it("--install reports failure with exit code 1", async () => {
+    installMocks.installAndRecord.mockResolvedValue({
+      ok: false,
+      durationMs: 7,
+      command: "npm install --omit=dev",
+      error: "exit code 1",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--install"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("Install failed");
+  });
+
+  it("--install --json emits structured output", async () => {
+    installMocks.installAndRecord.mockResolvedValue({
+      ok: true,
+      durationMs: 100,
+      command: "npm install --omit=dev",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--install", "--json"), io)).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(parsed.ok).toBe(true);
+    expect(parsed.command).toBe("npm install --omit=dev");
+  });
+
+  it("rejects --install together with --login", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--install", "--login"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
   });
 });

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -223,7 +223,6 @@ describe("CLI: setup", () => {
       ok: false,
       attemptedAt: "2026-05-03T00:00:00Z",
       error: "ENETUNREACH: network unreachable",
-      source: "bootstrap",
       command: "npm install --omit=dev",
     });
     const io = captureIO(workDir);
@@ -232,20 +231,30 @@ describe("CLI: setup", () => {
     expect(out).toContain("bootstrap failed: ENETUNREACH: network unreachable");
   });
 
+  it("a stale ok=false bootstrap status is overridden when the SDK is loadable", async () => {
+    installMocks.isSdkInstalled.mockReturnValue(true);
+    installMocks.readBootstrapStatus.mockReturnValue({
+      ok: false,
+      attemptedAt: "2026-05-01T00:00:00Z",
+      error: "old failure the user fixed manually",
+    });
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("| SDK | ok |");
+  });
+
   it("--json includes the sdk and bootstrap fields", async () => {
     installMocks.isSdkInstalled.mockReturnValue(false);
     installMocks.readBootstrapStatus.mockReturnValue({
       ok: false,
       attemptedAt: "2026-05-03T00:00:00Z",
       error: "boom",
-      source: "bootstrap",
     });
     const io = captureIO(workDir);
     expect(await companionMain(argv("setup", "--json"), io)).toBe(1);
     const report = JSON.parse(io.captured.stdout.join(""));
     expect(report.sdk.ok).toBe(false);
     expect(report.sdk.bootstrap.error).toBe("boom");
-    expect(report.sdk.remediation).toContain("--install");
   });
 
   it("--install runs the installer and reports success", async () => {

--- a/tests/unit/lib/install.test.mts
+++ b/tests/unit/lib/install.test.mts
@@ -1,0 +1,82 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  type BootstrapStatus,
+  hasBootstrapSentinel,
+  isSdkInstalled,
+  readBootstrapStatus,
+  resolvePluginRoot,
+  runNpmInstall,
+  writeBootstrapSentinel,
+  writeBootstrapStatus,
+} from "@plugin/lib/install.mjs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let pluginRoot: string;
+let savedEnv: string | undefined;
+
+beforeEach(() => {
+  pluginRoot = mkdtempSync(path.join(tmpdir(), "cursor-install-"));
+  savedEnv = process.env.CLAUDE_PLUGIN_ROOT;
+  process.env.CLAUDE_PLUGIN_ROOT = pluginRoot;
+});
+
+afterEach(() => {
+  rmSync(pluginRoot, { recursive: true, force: true });
+  if (savedEnv === undefined) delete process.env.CLAUDE_PLUGIN_ROOT;
+  else process.env.CLAUDE_PLUGIN_ROOT = savedEnv;
+});
+
+describe("install.mts", () => {
+  it("resolvePluginRoot returns CLAUDE_PLUGIN_ROOT when set", () => {
+    expect(resolvePluginRoot()).toBe(path.resolve(pluginRoot));
+  });
+
+  it("isSdkInstalled returns true when @cursor/sdk is in plugin node_modules", () => {
+    const sdkDir = path.join(pluginRoot, "node_modules", "@cursor", "sdk");
+    mkdirSync(sdkDir, { recursive: true });
+    writeFileSync(path.join(sdkDir, "package.json"), '{"name":"@cursor/sdk"}');
+    expect(isSdkInstalled(pluginRoot)).toBe(true);
+  });
+
+  it("isSdkInstalled returns true via Node.js resolution when not in plugin node_modules", () => {
+    // The repo has @cursor/sdk hoisted in the root node_modules; require.resolve
+    // from install.mts's location finds it even when pluginRoot is bare.
+    expect(isSdkInstalled(pluginRoot)).toBe(true);
+  });
+
+  it("writeBootstrapStatus + readBootstrapStatus round-trip", () => {
+    const status: BootstrapStatus = {
+      ok: false,
+      attemptedAt: "2026-05-03T00:00:00Z",
+      error: "boom",
+      durationMs: 12,
+      source: "bootstrap",
+      command: "npm install --omit=dev",
+    };
+    writeBootstrapStatus(pluginRoot, status);
+    expect(readBootstrapStatus(pluginRoot)).toEqual(status);
+  });
+
+  it("readBootstrapStatus returns undefined when the file is missing", () => {
+    expect(readBootstrapStatus(pluginRoot)).toBeUndefined();
+  });
+
+  it("writeBootstrapSentinel creates node_modules/.bootstrap-ok", () => {
+    expect(hasBootstrapSentinel(pluginRoot)).toBe(false);
+    writeBootstrapSentinel(pluginRoot);
+    expect(hasBootstrapSentinel(pluginRoot)).toBe(true);
+    const contents = readFileSync(path.join(pluginRoot, "node_modules", ".bootstrap-ok"), "utf8");
+    expect(contents).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("runNpmInstall returns a structured failure when npm exits non-zero", async () => {
+    // Bare temp dir with no package.json — npm install will exit non-zero.
+    const result = await runNpmInstall(pluginRoot, { timeoutMs: 30_000 });
+    expect(result.ok).toBe(false);
+    expect(result.command).toBe("npm install --omit=dev");
+    expect(typeof result.durationMs).toBe("number");
+    expect(typeof result.error).toBe("string");
+  }, 60_000);
+});

--- a/tests/unit/lib/install.test.mts
+++ b/tests/unit/lib/install.test.mts
@@ -1,9 +1,8 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   type BootstrapStatus,
-  hasBootstrapSentinel,
   isSdkInstalled,
   readBootstrapStatus,
   resolvePluginRoot,
@@ -52,7 +51,6 @@ describe("install.mts", () => {
       attemptedAt: "2026-05-03T00:00:00Z",
       error: "boom",
       durationMs: 12,
-      source: "bootstrap",
       command: "npm install --omit=dev",
     };
     writeBootstrapStatus(pluginRoot, status);
@@ -64,11 +62,10 @@ describe("install.mts", () => {
   });
 
   it("writeBootstrapSentinel creates node_modules/.bootstrap-ok", () => {
-    expect(hasBootstrapSentinel(pluginRoot)).toBe(false);
+    const sentinel = path.join(pluginRoot, "node_modules", ".bootstrap-ok");
+    expect(existsSync(sentinel)).toBe(false);
     writeBootstrapSentinel(pluginRoot);
-    expect(hasBootstrapSentinel(pluginRoot)).toBe(true);
-    const contents = readFileSync(path.join(pluginRoot, "node_modules", ".bootstrap-ok"), "utf8");
-    expect(contents).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    expect(readFileSync(sentinel, "utf8")).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 
   it("runNpmInstall returns a structured failure when npm exits non-zero", async () => {


### PR DESCRIPTION
Match codex-plugin-cc's "Install Codex (Recommended)" affordance: detect a
missing or failed @cursor/sdk install and prompt the user to remediate.

- bootstrap.mjs: persist a JSON status file (`node_modules/.bootstrap-status.json`)
  with `{ ok, error, attemptedAt, durationMs, command }` so SessionStart
  failures stop being invisible.
- /cursor:setup: add an "SDK" check row that combines a node_modules lookup
  with Node's resolution algorithm; fail rows include the bootstrap error
  and a remediation hint pointing at `--install`.
- /cursor:setup --install: reruns `npm install --omit=dev` in the plugin
  root, streams output, and writes the same status file. Mutually exclusive
  with --login/--logout.
- New `lib/install.mts` factors the install + status logic so bootstrap.mjs
  and setup share a contract via the on-disk JSON.
- Update commands/setup.md to document --install and the remediation flow.