### PR TITLE
fix: address gate UX, task result card, list scope, and cancel split-brain

### DIFF
--- a/plugins/cursor/commands/cancel.md
+++ b/plugins/cursor/commands/cancel.md
@@ -12,9 +12,15 @@ node ${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs cancel $ARGUMENTS
 
 Required: a job id.
 
-If the run is in-process, calls `run.cancel()` (capability-checked). If the
-run was started in `--background` mode by a different CLI invocation, the
-in-memory Run object is gone — the job record is marked cancelled with
-`reason: "run-not-active"`, but the underlying SDK run may still be live.
+**Clean cancel:** if the run is owned by this CLI process, calls
+`run.cancel()` (capability-checked) and the agent stops.
+
+**Split-brain limitation:** if the run was started in `--background` mode by a
+different CLI invocation, the in-memory Run object is gone. The job record is
+marked `cancelled` with `reason: "run-not-active"`, but the underlying SDK
+run may keep going to completion. The companion prints a warning to stderr
+when this happens and the JSON shape includes `"splitBrain": true`. To
+actually stop the work, use `/cursor:resume <agent-id>` to reattach and send
+a stop prompt — the agent id is on the job record (`/cursor:status <job-id>`).
 
 Exit code 0 on cancel, 1 on any failure with a reason printed to stderr.

--- a/plugins/cursor/commands/result.md
+++ b/plugins/cursor/commands/result.md
@@ -1,6 +1,6 @@
 ---
 description: Print a completed job's result text. Defaults to the most recent terminal job in the current workspace.
-argument-hint: '[<job-id>] [--log] [--json]'
+argument-hint: '[<job-id>] [--raw] [--log] [--json]'
 allowed-tools: Bash(node:*)
 disable-model-invocation: true
 ---
@@ -16,8 +16,14 @@ Without an argument, prints the most recent terminal (`completed` / `failed` /
 `/codex:result` uses. Pass a job id (from `/cursor:status`) to target a
 specific job.
 
+By default, task jobs render as a Markdown card with status, duration, agent
+id, fenced output, and resume hints (so the output is self-describing).
+Reviews keep their original structured formatting from the review command.
+
 Flags:
+- `--raw` — emit just the result text on stdout (no card / no header)
 - `--log` — print the streaming event log captured while the run was alive
 - `--json` — emit the full JobRecord
 
-If the resolved job hasn't finished, exits 1. Surface the output verbatim.
+If the resolved job hasn't finished, exits 1. Return the command stdout
+verbatim, exactly as-is. Do not paraphrase or rewrap.

--- a/plugins/cursor/commands/resume.md
+++ b/plugins/cursor/commands/resume.md
@@ -18,11 +18,17 @@ Usage:
 
 - `<agent-id> <prompt>` — resume a specific agent with a follow-up prompt
 - `--last <prompt>`     — resume the most recent task agent for this workspace
-- `--list`              — print known agent ids from the local job index
-- `--list --remote`     — query the SDK for durable agents (local runtime by
+- `--list`              — print known agent ids — merges this workspace's
+                          local job index with the SDK's durable agent list
+                          (local runtime). Soft-fails on SDK errors with a
+                          stderr footer.
+- `--list --local`      — only show this workspace's job index (skips the SDK)
+- `--list --remote`     — only show the SDK's durable agents (local runtime by
                           default; combine with `--cloud` for cloud-runtime
                           agents — that needs `CURSOR_API_KEY`)
-- `--limit <n>` and `--json` apply to `--list`
+- `--limit <n>` and `--json` apply to `--list`. The merged-mode JSON shape is
+  `{local: [...], remoteOnly: [...], remoteError: string | null}`. Pass
+  `--local --json` for the flat array of local rows.
 
 Inherits the same flags as `/cursor:task`: `--write`, `--background`, `--force`,
 `--cloud`, `--model <id>`, `--timeout <ms>`, `--json`.

--- a/plugins/cursor/commands/review.md
+++ b/plugins/cursor/commands/review.md
@@ -31,6 +31,15 @@ Execution mode rules:
   - `Wait for results`
   - `Run in background`
 
+Gate behavior (only one `AskUserQuestion` fires per `/cursor:review`):
+
+- The wait/background gate above is the only prompt this command issues.
+- To skip it entirely, pass `--wait` or `--background` explicitly.
+- `/cursor:task` has its own resume gate. Running these commands back-to-back
+  can produce two consecutive prompts (one from each command); pass the
+  suppressing flags (`--wait`/`--background` here, `--resume-last`/`--fresh`
+  on task) to skip them when chaining.
+
 Argument handling:
 - `--wait` and `--background` are execution-mode flags for Claude Code, not for the companion script. Strip them from the arguments before invoking the companion. The companion does not accept these flags.
 - Preserve all other user arguments exactly (`--staged`, `--scope`, `--base`, `--model`, `--timeout`, `--json`).

--- a/plugins/cursor/commands/task.md
+++ b/plugins/cursor/commands/task.md
@@ -24,7 +24,7 @@ Execution mode:
 - Otherwise, before starting Cursor, check for a resumable agent from this workspace by running:
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --list --json --limit 1 2>/dev/null
+node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --list --local --json --limit 1 2>/dev/null
 ```
 
 - If that command outputs a non-empty agent list (at least one agent ID), use `AskUserQuestion` exactly once to ask whether to continue the current Cursor thread or start a new one.
@@ -36,6 +36,16 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" resume --list -
 - If the user chooses continue, add `--resume-last` before routing to the subagent.
 - If the user chooses a new thread, do not add `--resume-last`.
 - If the helper reports no available agent, do not ask. Route normally.
+
+Gate behavior (only one `AskUserQuestion` fires per `/cursor:task`):
+
+- The resume gate above is the only prompt this command issues. Execution mode
+  defaults silently to foreground unless `--background` or `--wait` is set.
+- To skip the gate entirely, pass `--resume-last` (continue) or `--fresh`
+  (new thread). Both flags are honoured before any prompt is built.
+- `/cursor:review` has its own wait/background gate. Running these commands
+  back-to-back can produce two consecutive prompts (one from each command);
+  pass the suppressing flags above to skip them when chaining.
 
 Operating rules:
 

--- a/plugins/cursor/scripts/bundle/chunk-3FBBFC2X.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-3FBBFC2X.mjs
@@ -735,6 +735,7 @@ var TERMINAL_STATUSES = /* @__PURE__ */ new Set([
   "failed",
   "cancelled"
 ]);
+var RUN_NOT_ACTIVE_REASON = "run-not-active";
 var STALE_JOB_TTL_MS = 30 * 60 * 1e3;
 var JOB_ID_BYTES = 6;
 function newJobId(type) {
@@ -925,8 +926,8 @@ async function cancelJob(stateDir, jobId) {
   }
   const run = activeRuns.get(jobId);
   if (!run) {
-    const updated2 = markCancelled(stateDir, jobId, "run-not-active");
-    return { cancelled: true, reason: "run-not-active", job: updated2 };
+    const updated2 = markCancelled(stateDir, jobId, RUN_NOT_ACTIVE_REASON);
+    return { cancelled: true, reason: RUN_NOT_ACTIVE_REASON, job: updated2 };
   }
   const result = await cancelRun(run);
   if (!result.cancelled) {
@@ -1016,6 +1017,7 @@ export {
   toAgentEvents,
   redactError,
   TERMINAL_STATUSES,
+  RUN_NOT_ACTIVE_REASON,
   createJob,
   getJob,
   listJobs,

--- a/plugins/cursor/scripts/bundle/chunk-C2Y3PU5T.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-C2Y3PU5T.mjs
@@ -353,8 +353,8 @@ function renderTaskResultCard(job) {
   lines.push(`**Status:** ${statusBits.join(" \u2014 ")}`);
   if (job.agentId) lines.push(`**Agent:** \`${job.agentId}\``);
   if (job.runId) lines.push(`**Run:** \`${job.runId}\``);
-  if (job.metadata) {
-    const meta = job.metadata;
+  const meta = job.metadata;
+  if (meta) {
     if (meta.timedOut === true) {
       lines.push("**Note:** run exceeded its timeout and was cancelled by the plugin.");
     }

--- a/plugins/cursor/scripts/bundle/chunk-XYYKXIND.mjs
+++ b/plugins/cursor/scripts/bundle/chunk-XYYKXIND.mjs
@@ -14,7 +14,7 @@ import {
   resolveStateDir,
   resolveWorkspaceRoot,
   writeJsonAtomic
-} from "./chunk-B3GESHAJ.mjs";
+} from "./chunk-3FBBFC2X.mjs";
 
 // plugins/cursor/scripts/lib/args.mts
 var UsageError = class extends Error {
@@ -100,6 +100,11 @@ function bool(parsed, name) {
 }
 
 // plugins/cursor/scripts/lib/render.mts
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "0ms";
+  if (ms < 1e3) return `${Math.round(ms)}ms`;
+  return `${(ms / 1e3).toFixed(1)}s`;
+}
 function compactText(text) {
   return text.replace(/\s+/g, " ").trim();
 }
@@ -331,6 +336,52 @@ function jobAgentHandoffLines(agentId) {
     `- Continue from Claude Code: \`/cursor:resume ${agentId}\``,
     `- Continue from the Cursor CLI: \`cursor-agent resume ${agentId}\``
   ];
+}
+function renderTaskResultCard(job) {
+  const lines = [];
+  lines.push(`**Job:** \`${job.id}\` _(type: ${job.type})_`);
+  const statusBits = [`\`${job.status}\``];
+  if (typeof job.durationMs === "number") {
+    statusBits.push(`duration: ${formatDuration(job.durationMs)}`);
+  } else if (job.startedAt && job.finishedAt) {
+    const start = Date.parse(job.startedAt);
+    const finish = Date.parse(job.finishedAt);
+    if (Number.isFinite(start) && Number.isFinite(finish) && finish >= start) {
+      statusBits.push(`duration: ${formatDuration(finish - start)}`);
+    }
+  }
+  lines.push(`**Status:** ${statusBits.join(" \u2014 ")}`);
+  if (job.agentId) lines.push(`**Agent:** \`${job.agentId}\``);
+  if (job.runId) lines.push(`**Run:** \`${job.runId}\``);
+  if (job.metadata) {
+    const meta = job.metadata;
+    if (meta.timedOut === true) {
+      lines.push("**Note:** run exceeded its timeout and was cancelled by the plugin.");
+    }
+    if (meta.expired === true) {
+      lines.push("**Note:** SDK reported the run as expired (wedged local agent).");
+    }
+    if (typeof meta.cancelReason === "string" && meta.cancelReason) {
+      lines.push(`**Cancel reason:** \`${meta.cancelReason}\``);
+    }
+  }
+  const body = job.result ?? "";
+  lines.push("", "**Output:**", "", ...fenceCodeBlock(body));
+  if (job.error) {
+    lines.push("", "**Error:**", "", ...fenceCodeBlock(job.error));
+  }
+  const handoff = jobAgentHandoffLines(job.agentId);
+  if (handoff.length > 0) {
+    lines.push("", "**Next steps:**", ...handoff);
+  } else {
+    lines.push(
+      "",
+      "**Next steps:**",
+      "- No agent id was recorded for this job \u2014 start a new run with `/cursor:task`."
+    );
+  }
+  return `${lines.join("\n")}
+`;
 }
 function renderError(error) {
   return `error: ${redactError(error)}
@@ -603,6 +654,7 @@ export {
   renderJobTable,
   renderReviewResult,
   jobAgentHandoffLines,
+  renderTaskResultCard,
   renderError,
   loadPromptTemplate,
   interpolateTemplate,

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -18,7 +18,7 @@ import {
   renderTaskResultCard,
   runReview,
   setGateEnabled
-} from "./chunk-XYYKXIND.mjs";
+} from "./chunk-C2Y3PU5T.mjs";
 import {
   DEFAULT_MODEL,
   RUN_NOT_ACTIVE_REASON,

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -15,11 +15,13 @@ import {
   renderError,
   renderJobTable,
   renderStreamEvent,
+  renderTaskResultCard,
   runReview,
   setGateEnabled
-} from "./chunk-X7RMCJV4.mjs";
+} from "./chunk-XYYKXIND.mjs";
 import {
   DEFAULT_MODEL,
+  RUN_NOT_ACTIVE_REASON,
   TERMINAL_STATUSES,
   buildAgentOptionsFromFlags,
   cancelJob,
@@ -61,15 +63,30 @@ import {
   validateModel,
   whoami,
   writeJsonAtomic
-} from "./chunk-B3GESHAJ.mjs";
+} from "./chunk-3FBBFC2X.mjs";
 
 // plugins/cursor/scripts/commands/cancel.mts
 var HELP = `cursor-companion cancel <job-id> [--json] [--help]
 
-Cancel an active job. If the run is in-process, calls run.cancel() (when
-supported). Otherwise marks the persisted job as cancelled with reason
-"run-not-active" \u2014 the underlying SDK run may still complete.
+Cancel an active job. If the run was started in this CLI process, calls
+run.cancel() (capability-checked) and the job stops cleanly.
+
+LIMITATION: when the job was started in a different CLI process (e.g. via
+\`/cursor:task --background\` from a previous Claude Code turn), the in-memory
+Run object is not reachable and we cannot signal the SDK to stop. The job
+record is marked cancelled with reason="${RUN_NOT_ACTIVE_REASON}" but the
+underlying SDK run may keep going to completion. Track that run via
+\`/cursor:resume <agent-id>\` if you need to stop it.
 `;
+function runNotActiveHint(agentId) {
+  const resumeTarget = agentId ?? "<agent-id>";
+  return [
+    "warning: this CLI process did not own the in-memory Run object, so the",
+    "underlying SDK run was NOT signalled. The job record is marked cancelled",
+    "but the Cursor agent may keep working until it finishes on its own.",
+    `Use \`/cursor:resume ${resumeTarget}\` to reattach and observe / send a stop prompt.`
+  ].join("\n");
+}
 async function runCancel(args, io) {
   const parsed = parseArgs(args, {
     long: { json: "boolean", help: "boolean" },
@@ -85,14 +102,20 @@ async function runCancel(args, io) {
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   const stateDir = resolveStateDir(workspaceRoot);
   const result = await cancelJob(stateDir, jobId);
+  const splitBrain = result.cancelled && result.reason === RUN_NOT_ACTIVE_REASON;
   if (bool(parsed, "json")) {
-    io.stdout.write(`${JSON.stringify(result, null, 2)}
+    const payload = { ...result, splitBrain };
+    io.stdout.write(`${JSON.stringify(payload, null, 2)}
 `);
     return result.cancelled ? 0 : 1;
   }
   if (result.cancelled) {
     io.stdout.write(`cancelled: ${jobId}${result.reason ? ` (${result.reason})` : ""}
 `);
+    if (splitBrain) {
+      io.stderr.write(`${runNotActiveHint(result.job?.agentId)}
+`);
+    }
     return 0;
   }
   io.stderr.write(`could not cancel ${jobId}: ${result.reason ?? "unknown"}
@@ -101,16 +124,25 @@ async function runCancel(args, io) {
 }
 
 // plugins/cursor/scripts/commands/result.mts
-var HELP2 = `cursor-companion result [<job-id>] [--log] [--json] [--help]
+var HELP2 = `cursor-companion result [<job-id>] [--raw] [--log] [--json] [--help]
 
 Print a completed job's result text. Without a job id, defaults to the most
-recent terminal job for the current workspace. With --log, print the
-streaming log captured while the run was alive. With --json, emit the full
-JobRecord.
+recent terminal job for the current workspace.
+
+By default tasks render as a Markdown card (status, duration, agent id, fenced
+output, and resume hints) so the result is self-describing. Pass --raw to get
+the unwrapped output text on stdout \u2014 useful for piping into other tools.
+Reviews always render through the structured review formatter and ignore --raw.
+
+flags:
+  --raw   Emit just the result text on stdout (no card, no header)
+  --log   Print the streaming log captured while the run was alive
+  --json  Emit the full JobRecord
+  --help, -h
 `;
 async function runResult(args, io) {
   const parsed = parseArgs(args, {
-    long: { log: "boolean", json: "boolean", help: "boolean" },
+    long: { raw: "boolean", log: "boolean", json: "boolean", help: "boolean" },
     short: { h: "help" }
   });
   if (bool(parsed, "help")) {
@@ -158,15 +190,24 @@ async function runResult(args, io) {
 `);
     return 1;
   }
-  io.stdout.write(job.result);
-  if (!job.result.endsWith("\n")) io.stdout.write("\n");
-  const handoff = jobAgentHandoffLines(job.agentId);
-  if (handoff.length > 0) {
-    io.stderr.write(`
+  if (bool(parsed, "raw")) {
+    io.stdout.write(job.result);
+    if (!job.result.endsWith("\n")) io.stdout.write("\n");
+    const handoff = jobAgentHandoffLines(job.agentId);
+    if (handoff.length > 0) {
+      io.stderr.write(`
 Continue this Cursor agent:
 ${handoff.join("\n")}
 `);
+    }
+    return 0;
   }
+  if (job.type === "review" || job.type === "adversarial-review") {
+    io.stdout.write(job.result);
+    if (!job.result.endsWith("\n")) io.stdout.write("\n");
+    return 0;
+  }
+  io.stdout.write(renderTaskResultCard(job));
   return 0;
 }
 
@@ -249,18 +290,22 @@ function runAgentTaskBackground(opts) {
 // plugins/cursor/scripts/commands/resume.mts
 var HELP3 = `cursor-companion resume <agent-id> <prompt> [flags]
 cursor-companion resume --last <prompt> [flags]
-cursor-companion resume --list [--limit <n>] [--json]
+cursor-companion resume --list [--local|--remote] [--limit <n>] [--json]
 
 Reattach to an existing Cursor agent and continue the conversation. The agent
 keeps its prior context, so follow-up prompts are cheaper than starting fresh.
 
 flags:
   --last               Resume the most recent task agent (no agent-id needed)
-  --list               Print known agent ids from this workspace, then exit
-  --remote             With --list: query the SDK for durable agents instead
-                       of the local job index. Combine with --cloud to list
-                       cloud-runtime agents (requires CURSOR_API_KEY).
-  --limit <n>          With --list: cap the number of rows (default 10)
+  --list               Print known agent ids \u2014 merges this workspace's local
+                       index with the SDK's durable agent list (local runtime).
+                       Soft-fails on SDK errors with a footer note. Use
+                       --local or --remote to scope to one source.
+  --local              With --list: only show this workspace's job index
+  --remote             With --list: only show the SDK's durable agents
+                       (combine with --cloud to list cloud-runtime agents \u2014
+                       requires CURSOR_API_KEY)
+  --limit <n>          With --list: cap the number of rows per source (default 10)
   --write              Allow file modifications (default: read-only)
   --background         Start the run and exit, returning the job id
   --force              Expire any wedged active local run before sending
@@ -278,6 +323,7 @@ function parseFlags(args) {
     long: {
       last: "boolean",
       list: "boolean",
+      local: "boolean",
       remote: "boolean",
       limit: "string",
       write: "boolean",
@@ -295,10 +341,12 @@ function parseFlags(args) {
   const last = bool(parsed, "last");
   const list = bool(parsed, "list");
   const json = bool(parsed, "json");
+  const local = bool(parsed, "local");
   const remote = bool(parsed, "remote");
   const cloud = bool(parsed, "cloud");
   if (list) {
     if (last) throw new UsageError("--list and --last are mutually exclusive");
+    if (local && remote) throw new UsageError("--local and --remote are mutually exclusive");
     let limit = DEFAULT_LIST_LIMIT;
     const limitArg = optionalString(parsed, "limit");
     if (limitArg !== void 0) {
@@ -309,9 +357,11 @@ function parseFlags(args) {
     if (cloud && !remote) {
       throw new UsageError("--list --cloud requires --remote (cloud listing goes through the SDK)");
     }
-    return { kind: "list", limit, json, remote, cloud };
+    const source = local ? "local" : remote ? "remote" : "merged";
+    return { kind: "list", limit, json, source, cloud };
   }
   if (remote) throw new UsageError("--remote requires --list");
+  if (local) throw new UsageError("--local requires --list");
   if (optionalString(parsed, "limit") !== void 0) {
     throw new UsageError("--limit requires --list");
   }
@@ -396,6 +446,64 @@ ${separator}
 ${body}
 `;
 }
+async function runList(flags, workspaceRoot, io) {
+  if (flags.source === "remote") {
+    const rows = await listRemoteAgents(
+      flags.cloud ? { runtime: "cloud", limit: flags.limit } : { cwd: workspaceRoot, limit: flags.limit }
+    );
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(rows, null, 2)}
+`);
+    } else {
+      io.stdout.write(renderRemoteListText(rows));
+    }
+    return 0;
+  }
+  const stateDir = resolveStateDir(workspaceRoot);
+  const localRows = findRecentTaskAgents(stateDir, flags.limit);
+  if (flags.source === "local") {
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(localRows, null, 2)}
+`);
+    } else {
+      io.stdout.write(renderListText(localRows));
+    }
+    return 0;
+  }
+  let remoteRows = [];
+  let remoteError;
+  try {
+    remoteRows = await listRemoteAgents({ cwd: workspaceRoot, limit: flags.limit });
+  } catch (err) {
+    remoteError = err instanceof Error ? err.message : String(err);
+  }
+  const seenLocal = new Set(localRows.map((r) => r.agentId));
+  const remoteOnly = remoteRows.filter((r) => !seenLocal.has(r.agentId));
+  if (flags.json) {
+    io.stdout.write(
+      `${JSON.stringify({ local: localRows, remoteOnly, remoteError: remoteError ?? null }, null, 2)}
+`
+    );
+    return 0;
+  }
+  io.stdout.write(renderListText(localRows));
+  if (remoteOnly.length > 0) {
+    io.stdout.write(`
+Additional durable agents reported by the SDK (${remoteOnly.length}):
+`);
+    io.stdout.write(renderRemoteListText(remoteOnly));
+  } else if (!remoteError && localRows.length > 0) {
+    io.stdout.write("\n(no additional durable agents reported by the SDK)\n");
+  }
+  if (remoteError) {
+    io.stderr.write(
+      `
+note: SDK agent list failed (${remoteError}); showing local index only. Pass --local to suppress this lookup.
+`
+    );
+  }
+  return 0;
+}
 async function runResume(args, io) {
   let flags;
   try {
@@ -410,27 +518,7 @@ async function runResume(args, io) {
   const cwd = io.cwd();
   const workspaceRoot = resolveWorkspaceRoot(cwd);
   if (flags.kind === "list") {
-    if (flags.remote) {
-      const rows2 = await listRemoteAgents(
-        flags.cloud ? { runtime: "cloud", limit: flags.limit } : { cwd: workspaceRoot, limit: flags.limit }
-      );
-      if (flags.json) {
-        io.stdout.write(`${JSON.stringify(rows2, null, 2)}
-`);
-      } else {
-        io.stdout.write(renderRemoteListText(rows2));
-      }
-      return 0;
-    }
-    const stateDir2 = resolveStateDir(workspaceRoot);
-    const rows = findRecentTaskAgents(stateDir2, flags.limit);
-    if (flags.json) {
-      io.stdout.write(`${JSON.stringify(rows, null, 2)}
-`);
-    } else {
-      io.stdout.write(renderListText(rows));
-    }
-    return 0;
+    return runList(flags, workspaceRoot, io);
   }
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));
   let agentId;

--- a/plugins/cursor/scripts/bundle/session-lifecycle-hook.mjs
+++ b/plugins/cursor/scripts/bundle/session-lifecycle-hook.mjs
@@ -11,7 +11,7 @@ import {
   resolveStateDir,
   resolveWorkspaceRoot,
   writeSession
-} from "./chunk-B3GESHAJ.mjs";
+} from "./chunk-3FBBFC2X.mjs";
 
 // plugins/cursor/scripts/session-lifecycle-hook.mts
 var SESSION_END_KEEP_ENV = "CURSOR_PLUGIN_KEEP_BACKGROUND_JOBS";

--- a/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
+++ b/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
@@ -5,7 +5,7 @@ import {
   parseReview,
   readGateConfig,
   renderReviewResult
-} from "./chunk-XYYKXIND.mjs";
+} from "./chunk-C2Y3PU5T.mjs";
 import {
   parseHookPayload,
   readHookStdinSync

--- a/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
+++ b/plugins/cursor/scripts/bundle/stop-review-gate-hook.mjs
@@ -5,7 +5,7 @@ import {
   parseReview,
   readGateConfig,
   renderReviewResult
-} from "./chunk-X7RMCJV4.mjs";
+} from "./chunk-XYYKXIND.mjs";
 import {
   parseHookPayload,
   readHookStdinSync
@@ -16,7 +16,7 @@ import {
   oneShot,
   resolveStateDir,
   resolveWorkspaceRoot
-} from "./chunk-B3GESHAJ.mjs";
+} from "./chunk-3FBBFC2X.mjs";
 
 // plugins/cursor/scripts/stop-review-gate-hook.mts
 var SCHEMA = `{

--- a/plugins/cursor/scripts/commands/cancel.mts
+++ b/plugins/cursor/scripts/commands/cancel.mts
@@ -1,15 +1,31 @@
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, parseArgs, UsageError } from "../lib/args.mjs";
-import { cancelJob } from "../lib/job-control.mjs";
+import { cancelJob, RUN_NOT_ACTIVE_REASON } from "../lib/job-control.mjs";
 import { resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const HELP = `cursor-companion cancel <job-id> [--json] [--help]
 
-Cancel an active job. If the run is in-process, calls run.cancel() (when
-supported). Otherwise marks the persisted job as cancelled with reason
-"run-not-active" — the underlying SDK run may still complete.
+Cancel an active job. If the run was started in this CLI process, calls
+run.cancel() (capability-checked) and the job stops cleanly.
+
+LIMITATION: when the job was started in a different CLI process (e.g. via
+\`/cursor:task --background\` from a previous Claude Code turn), the in-memory
+Run object is not reachable and we cannot signal the SDK to stop. The job
+record is marked cancelled with reason="${RUN_NOT_ACTIVE_REASON}" but the
+underlying SDK run may keep going to completion. Track that run via
+\`/cursor:resume <agent-id>\` if you need to stop it.
 `;
+
+function runNotActiveHint(agentId: string | undefined): string {
+  const resumeTarget = agentId ?? "<agent-id>";
+  return [
+    "warning: this CLI process did not own the in-memory Run object, so the",
+    "underlying SDK run was NOT signalled. The job record is marked cancelled",
+    "but the Cursor agent may keep working until it finishes on its own.",
+    `Use \`/cursor:resume ${resumeTarget}\` to reattach and observe / send a stop prompt.`,
+  ].join("\n");
+}
 
 export async function runCancel(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   const parsed = parseArgs(args, {
@@ -28,12 +44,18 @@ export async function runCancel(args: readonly string[], io: CommandIO): Promise
   const stateDir = resolveStateDir(workspaceRoot);
 
   const result = await cancelJob(stateDir, jobId);
+  const splitBrain = result.cancelled && result.reason === RUN_NOT_ACTIVE_REASON;
+
   if (bool(parsed, "json")) {
-    io.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    const payload = { ...result, splitBrain };
+    io.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
     return result.cancelled ? 0 : 1;
   }
   if (result.cancelled) {
     io.stdout.write(`cancelled: ${jobId}${result.reason ? ` (${result.reason})` : ""}\n`);
+    if (splitBrain) {
+      io.stderr.write(`${runNotActiveHint(result.job?.agentId)}\n`);
+    }
     return 0;
   }
   io.stderr.write(`could not cancel ${jobId}: ${result.reason ?? "unknown"}\n`);

--- a/plugins/cursor/scripts/commands/result.mts
+++ b/plugins/cursor/scripts/commands/result.mts
@@ -1,21 +1,30 @@
 import type { CommandIO, ExitCode } from "../cursor-companion.mjs";
 import { bool, parseArgs } from "../lib/args.mjs";
 import { getJob, listJobs, TERMINAL_STATUSES } from "../lib/job-control.mjs";
-import { jobAgentHandoffLines } from "../lib/render.mjs";
+import { jobAgentHandoffLines, renderTaskResultCard } from "../lib/render.mjs";
 import { readJobLog, resolveStateDir } from "../lib/state.mjs";
 import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
-const HELP = `cursor-companion result [<job-id>] [--log] [--json] [--help]
+const HELP = `cursor-companion result [<job-id>] [--raw] [--log] [--json] [--help]
 
 Print a completed job's result text. Without a job id, defaults to the most
-recent terminal job for the current workspace. With --log, print the
-streaming log captured while the run was alive. With --json, emit the full
-JobRecord.
+recent terminal job for the current workspace.
+
+By default tasks render as a Markdown card (status, duration, agent id, fenced
+output, and resume hints) so the result is self-describing. Pass --raw to get
+the unwrapped output text on stdout — useful for piping into other tools.
+Reviews always render through the structured review formatter and ignore --raw.
+
+flags:
+  --raw   Emit just the result text on stdout (no card, no header)
+  --log   Print the streaming log captured while the run was alive
+  --json  Emit the full JobRecord
+  --help, -h
 `;
 
 export async function runResult(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   const parsed = parseArgs(args, {
-    long: { log: "boolean", json: "boolean", help: "boolean" },
+    long: { raw: "boolean", log: "boolean", json: "boolean", help: "boolean" },
     short: { h: "help" },
   });
   if (bool(parsed, "help")) {
@@ -64,13 +73,27 @@ export async function runResult(args: readonly string[], io: CommandIO): Promise
     else io.stderr.write(`no result for job ${jobId} (status: ${job.status})\n`);
     return 1;
   }
-  io.stdout.write(job.result);
-  if (!job.result.endsWith("\n")) io.stdout.write("\n");
-  // Surface handoff hints on stderr so the result text on stdout stays
-  // clean for downstream consumers (pipes, --json, programmatic callers).
-  const handoff = jobAgentHandoffLines(job.agentId);
-  if (handoff.length > 0) {
-    io.stderr.write(`\nContinue this Cursor agent:\n${handoff.join("\n")}\n`);
+
+  if (bool(parsed, "raw")) {
+    io.stdout.write(job.result);
+    if (!job.result.endsWith("\n")) io.stdout.write("\n");
+    // Even in raw mode, surface handoff hints on stderr so users can find the
+    // resume command without reparsing — stderr stays out of stdin pipelines.
+    const handoff = jobAgentHandoffLines(job.agentId);
+    if (handoff.length > 0) {
+      io.stderr.write(`\nContinue this Cursor agent:\n${handoff.join("\n")}\n`);
+    }
+    return 0;
   }
+
+  // Reviews already get their own structured card from `runReview`; reprint the
+  // raw result here so re-reading via `/cursor:result <id>` matches the original.
+  if (job.type === "review" || job.type === "adversarial-review") {
+    io.stdout.write(job.result);
+    if (!job.result.endsWith("\n")) io.stdout.write("\n");
+    return 0;
+  }
+
+  io.stdout.write(renderTaskResultCard(job));
   return 0;
 }

--- a/plugins/cursor/scripts/commands/resume.mts
+++ b/plugins/cursor/scripts/commands/resume.mts
@@ -22,18 +22,22 @@ import { resolveWorkspaceRoot } from "../lib/workspace.mjs";
 
 const HELP = `cursor-companion resume <agent-id> <prompt> [flags]
 cursor-companion resume --last <prompt> [flags]
-cursor-companion resume --list [--limit <n>] [--json]
+cursor-companion resume --list [--local|--remote] [--limit <n>] [--json]
 
 Reattach to an existing Cursor agent and continue the conversation. The agent
 keeps its prior context, so follow-up prompts are cheaper than starting fresh.
 
 flags:
   --last               Resume the most recent task agent (no agent-id needed)
-  --list               Print known agent ids from this workspace, then exit
-  --remote             With --list: query the SDK for durable agents instead
-                       of the local job index. Combine with --cloud to list
-                       cloud-runtime agents (requires CURSOR_API_KEY).
-  --limit <n>          With --list: cap the number of rows (default 10)
+  --list               Print known agent ids — merges this workspace's local
+                       index with the SDK's durable agent list (local runtime).
+                       Soft-fails on SDK errors with a footer note. Use
+                       --local or --remote to scope to one source.
+  --local              With --list: only show this workspace's job index
+  --remote             With --list: only show the SDK's durable agents
+                       (combine with --cloud to list cloud-runtime agents —
+                       requires CURSOR_API_KEY)
+  --limit <n>          With --list: cap the number of rows per source (default 10)
   --write              Allow file modifications (default: read-only)
   --background         Start the run and exit, returning the job id
   --force              Expire any wedged active local run before sending
@@ -46,11 +50,13 @@ flags:
 
 const DEFAULT_LIST_LIMIT = 10;
 
+type ListSource = "merged" | "local" | "remote";
+
 interface ListFlags {
   kind: "list";
   limit: number;
   json: boolean;
-  remote: boolean;
+  source: ListSource;
   cloud: boolean;
 }
 
@@ -77,6 +83,7 @@ function parseFlags(args: readonly string[]): ResumeFlags {
     long: {
       last: "boolean",
       list: "boolean",
+      local: "boolean",
       remote: "boolean",
       limit: "string",
       write: "boolean",
@@ -96,11 +103,13 @@ function parseFlags(args: readonly string[]): ResumeFlags {
   const list = bool(parsed, "list");
   const json = bool(parsed, "json");
 
+  const local = bool(parsed, "local");
   const remote = bool(parsed, "remote");
   const cloud = bool(parsed, "cloud");
 
   if (list) {
     if (last) throw new UsageError("--list and --last are mutually exclusive");
+    if (local && remote) throw new UsageError("--local and --remote are mutually exclusive");
     let limit = DEFAULT_LIST_LIMIT;
     const limitArg = optionalString(parsed, "limit");
     if (limitArg !== undefined) {
@@ -111,10 +120,12 @@ function parseFlags(args: readonly string[]): ResumeFlags {
     if (cloud && !remote) {
       throw new UsageError("--list --cloud requires --remote (cloud listing goes through the SDK)");
     }
-    return { kind: "list", limit, json, remote, cloud };
+    const source: ListSource = local ? "local" : remote ? "remote" : "merged";
+    return { kind: "list", limit, json, source, cloud };
   }
 
   if (remote) throw new UsageError("--remote requires --list");
+  if (local) throw new UsageError("--local requires --list");
 
   if (optionalString(parsed, "limit") !== undefined) {
     throw new UsageError("--limit requires --list");
@@ -204,6 +215,71 @@ export function renderRemoteListText(rows: RemoteAgentRow[], now: number = Date.
   return `${header}\n${separator}\n${body}\n`;
 }
 
+async function runList(flags: ListFlags, workspaceRoot: string, io: CommandIO): Promise<ExitCode> {
+  if (flags.source === "remote") {
+    const rows = await listRemoteAgents(
+      flags.cloud
+        ? { runtime: "cloud", limit: flags.limit }
+        : { cwd: workspaceRoot, limit: flags.limit },
+    );
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+    } else {
+      io.stdout.write(renderRemoteListText(rows));
+    }
+    return 0;
+  }
+
+  const stateDir = resolveStateDir(workspaceRoot);
+  const localRows = findRecentTaskAgents(stateDir, flags.limit);
+
+  if (flags.source === "local") {
+    if (flags.json) {
+      io.stdout.write(`${JSON.stringify(localRows, null, 2)}\n`);
+    } else {
+      io.stdout.write(renderListText(localRows));
+    }
+    return 0;
+  }
+
+  // Merged view (default): union local index with the SDK's local-runtime
+  // durable agents, deduplicated by agentId. Local entries win on conflict
+  // because they carry job-id + summary that the SDK list lacks. SDK errors
+  // are non-fatal — most users care about local agents and the remote query
+  // is an enrichment.
+  let remoteRows: RemoteAgentRow[] = [];
+  let remoteError: string | undefined;
+  try {
+    remoteRows = await listRemoteAgents({ cwd: workspaceRoot, limit: flags.limit });
+  } catch (err) {
+    remoteError = err instanceof Error ? err.message : String(err);
+  }
+  const seenLocal = new Set(localRows.map((r) => r.agentId));
+  const remoteOnly = remoteRows.filter((r) => !seenLocal.has(r.agentId));
+
+  if (flags.json) {
+    io.stdout.write(
+      `${JSON.stringify({ local: localRows, remoteOnly, remoteError: remoteError ?? null }, null, 2)}\n`,
+    );
+    return 0;
+  }
+
+  io.stdout.write(renderListText(localRows));
+  if (remoteOnly.length > 0) {
+    io.stdout.write(`\nAdditional durable agents reported by the SDK (${remoteOnly.length}):\n`);
+    io.stdout.write(renderRemoteListText(remoteOnly));
+  } else if (!remoteError && localRows.length > 0) {
+    io.stdout.write("\n(no additional durable agents reported by the SDK)\n");
+  }
+  if (remoteError) {
+    io.stderr.write(
+      `\nnote: SDK agent list failed (${remoteError}); showing local index only. ` +
+        "Pass --local to suppress this lookup.\n",
+    );
+  }
+  return 0;
+}
+
 export async function runResume(args: readonly string[], io: CommandIO): Promise<ExitCode> {
   let flags: ResumeFlags;
   try {
@@ -220,27 +296,7 @@ export async function runResume(args: readonly string[], io: CommandIO): Promise
   const workspaceRoot = resolveWorkspaceRoot(cwd);
 
   if (flags.kind === "list") {
-    if (flags.remote) {
-      const rows = await listRemoteAgents(
-        flags.cloud
-          ? { runtime: "cloud", limit: flags.limit }
-          : { cwd: workspaceRoot, limit: flags.limit },
-      );
-      if (flags.json) {
-        io.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
-      } else {
-        io.stdout.write(renderRemoteListText(rows));
-      }
-      return 0;
-    }
-    const stateDir = resolveStateDir(workspaceRoot);
-    const rows = findRecentTaskAgents(stateDir, flags.limit);
-    if (flags.json) {
-      io.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
-    } else {
-      io.stdout.write(renderListText(rows));
-    }
-    return 0;
+    return runList(flags, workspaceRoot, io);
   }
 
   const stateDir = ensureStateDir(resolveStateDir(workspaceRoot));

--- a/plugins/cursor/scripts/lib/job-control.mts
+++ b/plugins/cursor/scripts/lib/job-control.mts
@@ -24,6 +24,14 @@ export const TERMINAL_STATUSES: ReadonlySet<JobStatus> = new Set([
   "cancelled",
 ]);
 
+/**
+ * Reason stamped on a cancelled job when the in-memory `Run` is not reachable
+ * from this process — typically because a previous CLI invocation started it
+ * in `--background` mode. Exported so `cancel` can detect this case and warn
+ * loudly that the SDK run may still be live.
+ */
+export const RUN_NOT_ACTIVE_REASON = "run-not-active";
+
 const STALE_JOB_TTL_MS = 30 * 60 * 1000;
 
 const JOB_ID_BYTES = 6; // 12 hex chars — short, collision-resistant enough for ~50 retained jobs
@@ -351,8 +359,8 @@ export async function cancelJob(stateDir: string, jobId: string): Promise<Cancel
 
   const run = activeRuns.get(jobId);
   if (!run) {
-    const updated = markCancelled(stateDir, jobId, "run-not-active");
-    return { cancelled: true, reason: "run-not-active", job: updated };
+    const updated = markCancelled(stateDir, jobId, RUN_NOT_ACTIVE_REASON);
+    return { cancelled: true, reason: RUN_NOT_ACTIVE_REASON, job: updated };
   }
 
   const result = await cancelRun(run);

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -415,8 +415,8 @@ export function renderTaskResultCard(job: JobRecord): string {
   if (job.agentId) lines.push(`**Agent:** \`${job.agentId}\``);
   if (job.runId) lines.push(`**Run:** \`${job.runId}\``);
 
-  if (job.metadata) {
-    const meta = job.metadata as Record<string, unknown>;
+  const meta = job.metadata;
+  if (meta) {
     if (meta.timedOut === true) {
       lines.push("**Note:** run exceeded its timeout and was cancelled by the plugin.");
     }

--- a/plugins/cursor/scripts/lib/render.mts
+++ b/plugins/cursor/scripts/lib/render.mts
@@ -1,7 +1,7 @@
 import type { AgentEvent } from "./cursor-agent.mjs";
 import { TERMINAL_STATUSES } from "./job-control.mjs";
 import { redactError } from "./redact.mjs";
-import type { JobIndexEntry } from "./state.mjs";
+import type { JobIndexEntry, JobRecord } from "./state.mjs";
 
 /**
  * Format a duration in milliseconds for terminal display. Sub-second values
@@ -388,6 +388,65 @@ export function jobAgentHandoffLines(agentId: string | undefined): string[] {
     `- Continue from Claude Code: \`/cursor:resume ${agentId}\``,
     `- Continue from the Cursor CLI: \`cursor-agent resume ${agentId}\``,
   ];
+}
+
+/**
+ * Wrap a task job's raw output in a header card so users see status, duration,
+ * and the agent-id handoff alongside the model reply. Mirrors what
+ * `renderReviewResult` does for reviews. The `result` body is fenced (no markup
+ * passthrough) — Cursor output frequently contains its own backticks/markdown.
+ */
+export function renderTaskResultCard(job: JobRecord): string {
+  const lines: string[] = [];
+  lines.push(`**Job:** \`${job.id}\` _(type: ${job.type})_`);
+
+  const statusBits: string[] = [`\`${job.status}\``];
+  if (typeof job.durationMs === "number") {
+    statusBits.push(`duration: ${formatDuration(job.durationMs)}`);
+  } else if (job.startedAt && job.finishedAt) {
+    const start = Date.parse(job.startedAt);
+    const finish = Date.parse(job.finishedAt);
+    if (Number.isFinite(start) && Number.isFinite(finish) && finish >= start) {
+      statusBits.push(`duration: ${formatDuration(finish - start)}`);
+    }
+  }
+  lines.push(`**Status:** ${statusBits.join(" — ")}`);
+
+  if (job.agentId) lines.push(`**Agent:** \`${job.agentId}\``);
+  if (job.runId) lines.push(`**Run:** \`${job.runId}\``);
+
+  if (job.metadata) {
+    const meta = job.metadata as Record<string, unknown>;
+    if (meta.timedOut === true) {
+      lines.push("**Note:** run exceeded its timeout and was cancelled by the plugin.");
+    }
+    if (meta.expired === true) {
+      lines.push("**Note:** SDK reported the run as expired (wedged local agent).");
+    }
+    if (typeof meta.cancelReason === "string" && meta.cancelReason) {
+      lines.push(`**Cancel reason:** \`${meta.cancelReason}\``);
+    }
+  }
+
+  const body = job.result ?? "";
+  lines.push("", "**Output:**", "", ...fenceCodeBlock(body));
+
+  if (job.error) {
+    lines.push("", "**Error:**", "", ...fenceCodeBlock(job.error));
+  }
+
+  const handoff = jobAgentHandoffLines(job.agentId);
+  if (handoff.length > 0) {
+    lines.push("", "**Next steps:**", ...handoff);
+  } else {
+    lines.push(
+      "",
+      "**Next steps:**",
+      "- No agent id was recorded for this job — start a new run with `/cursor:task`.",
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
 }
 
 /**

--- a/tests/cli/cancel.test.mts
+++ b/tests/cli/cancel.test.mts
@@ -25,13 +25,16 @@ afterEach(() => {
 });
 
 describe("CLI: cancel", () => {
-  it("cancels a running job (no active run) with reason=run-not-active", async () => {
+  it("cancels a running job (no active run) with reason=run-not-active and a stderr warning", async () => {
     const job = createJob(stateDir, { type: "task", prompt: "do thing" });
     markRunning(stateDir, job.id, { agentId: "a-1", runId: "r-1" });
 
     const io = captureIO(workDir);
     expect(await companionMain(argv("cancel", job.id), io)).toBe(0);
     expect(io.captured.stdout.join("")).toContain("run-not-active");
+    const stderr = io.captured.stderr.join("");
+    expect(stderr).toContain("did not own the in-memory Run");
+    expect(stderr).toContain("/cursor:resume a-1");
   });
 
   it("refuses to cancel a completed job (exit 1, reason='job is completed')", async () => {
@@ -59,6 +62,7 @@ describe("CLI: cancel", () => {
     const parsed = JSON.parse(io.captured.stdout.join(""));
     expect(parsed.cancelled).toBe(true);
     expect(parsed.reason).toBe("run-not-active");
+    expect(parsed.splitBrain).toBe(true);
     expect(parsed.job.id).toBe(job.id);
     expect(parsed.job.status).toBe("cancelled");
   });

--- a/tests/cli/result.test.mts
+++ b/tests/cli/result.test.mts
@@ -1,0 +1,109 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { main as companionMain } from "@plugin/cursor-companion.mjs";
+import { createJob, markFinished, markRunning } from "@plugin/lib/job-control.mjs";
+import { ensureStateDir, resolveStateDir } from "@plugin/lib/state.mjs";
+import { argv, captureIO } from "@test/helpers/io.mjs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+let workDir: string;
+let stateRoot: string;
+let stateDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(path.join(tmpdir(), "cursor-result-cwd-"));
+  stateRoot = mkdtempSync(path.join(tmpdir(), "cursor-result-state-"));
+  process.env.CURSOR_PLUGIN_STATE_ROOT = stateRoot;
+  stateDir = ensureStateDir(resolveStateDir(workDir));
+});
+
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+  rmSync(stateRoot, { recursive: true, force: true });
+  delete process.env.CURSOR_PLUGIN_STATE_ROOT;
+});
+
+function seedCompletedTask(prompt: string, output: string, agentId = "agent-card") {
+  const job = createJob(stateDir, { type: "task", prompt });
+  markRunning(stateDir, job.id, { agentId, runId: `${agentId}-r` });
+  markFinished(stateDir, job.id, {
+    status: "finished",
+    output,
+    toolCalls: [],
+    agentId,
+    runId: `${agentId}-r`,
+    durationMs: 1234,
+  });
+  return job.id;
+}
+
+describe("CLI: result", () => {
+  it("renders the task result card by default with status, duration, agent id, and next steps", async () => {
+    const jobId = seedCompletedTask("refactor auth", "the work output");
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result", jobId), io)).toBe(0);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain(`**Job:** \`${jobId}\``);
+    expect(out).toContain("**Status:**");
+    expect(out).toContain("`completed`");
+    expect(out).toContain("duration: 1.2s");
+    expect(out).toContain("**Agent:** `agent-card`");
+    expect(out).toContain("the work output");
+    expect(out).toContain("**Next steps:**");
+    expect(out).toContain("/cursor:resume agent-card");
+  });
+
+  it("--raw emits just the result text on stdout and a stderr handoff hint", async () => {
+    const jobId = seedCompletedTask("noop", "PURE OUTPUT", "agent-raw");
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result", jobId, "--raw"), io)).toBe(0);
+    const stdout = io.captured.stdout.join("");
+    expect(stdout.trim()).toBe("PURE OUTPUT");
+    expect(stdout).not.toContain("**Job:**");
+    expect(io.captured.stderr.join("")).toContain("/cursor:resume agent-raw");
+  });
+
+  it("review jobs render their result verbatim (review formatter wins)", async () => {
+    const job = createJob(stateDir, { type: "review", prompt: "review" });
+    markRunning(stateDir, job.id, { agentId: "agent-rev", runId: "r-rev" });
+    markFinished(stateDir, job.id, {
+      status: "finished",
+      output: "**Verdict:** approve\n",
+      toolCalls: [],
+      agentId: "agent-rev",
+      runId: "r-rev",
+    });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result", job.id), io)).toBe(0);
+    const stdout = io.captured.stdout.join("");
+    expect(stdout).toContain("**Verdict:** approve");
+    expect(stdout).not.toContain("**Job:**");
+    expect(stdout).not.toContain("**Next steps:**");
+  });
+
+  it("--json emits the full JobRecord and skips the card", async () => {
+    const jobId = seedCompletedTask("jsonable", "out");
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result", jobId, "--json"), io)).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(parsed.id).toBe(jobId);
+    expect(parsed.result).toBe("out");
+  });
+
+  it("missing job exits 1 with diagnostic", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result", "task-doesnotexist"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("job not found");
+  });
+
+  it("no terminal jobs in workspace exits 1 with hint", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("result"), io)).toBe(1);
+    expect(io.captured.stderr.join("")).toContain("no terminal jobs in this workspace yet");
+  });
+});

--- a/tests/cli/resume.test.mts
+++ b/tests/cli/resume.test.mts
@@ -110,35 +110,111 @@ describe("CLI: resume", () => {
     expect(sdkMocks.agentResume).not.toHaveBeenCalled();
   });
 
-  it("--list prints recent agent ids and skips the SDK", async () => {
+  it("--list --local prints recent agent ids and skips the SDK", async () => {
     seedAgent("alpha", "agent-alpha");
     await new Promise((r) => setTimeout(r, 5));
     seedAgent("beta", "agent-beta");
 
     const io = captureIO(workDir);
-    expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
+    expect(await companionMain(argv("resume", "--list", "--local"), io)).toBe(0);
     const out = io.captured.stdout.join("");
     expect(out).toContain("AGENT-ID");
     expect(out).toContain("agent-alpha");
     expect(out).toContain("agent-beta");
     expect(sdkMocks.agentResume).not.toHaveBeenCalled();
+    expect(sdkMocks.agentList).not.toHaveBeenCalled();
   });
 
-  it("--list --json emits the structured rows", async () => {
+  it("--list --local --json emits a flat array of local rows", async () => {
     seedAgent("alpha", "agent-alpha");
 
     const io = captureIO(workDir);
-    expect(await companionMain(argv("resume", "--list", "--json"), io)).toBe(0);
+    expect(await companionMain(argv("resume", "--list", "--local", "--json"), io)).toBe(0);
     const parsed = JSON.parse(io.captured.stdout.join(""));
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed[0].agentId).toBe("agent-alpha");
     expect(parsed[0].summary).toBe("alpha");
   });
 
-  it("--list with no jobs prints '(no resumable agents)'", async () => {
+  it("--list (default) merges local with SDK durable agents not in the local index", async () => {
+    seedAgent("alpha", "agent-alpha");
+    sdkMocks.agentList.mockResolvedValue({
+      items: [
+        {
+          agentId: "agent-alpha", // dup with local — should be filtered
+          name: "dup",
+          summary: "dup",
+          lastModified: 1_700_000_000_000,
+        },
+        {
+          agentId: "agent-only-sdk",
+          name: "Remote A",
+          summary: "From the SDK",
+          lastModified: 1_700_000_000_000,
+        },
+      ],
+    });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
+    expect(sdkMocks.agentList).toHaveBeenCalledTimes(1);
+    const out = io.captured.stdout.join("");
+    expect(out).toContain("agent-alpha");
+    expect(out).toContain("agent-only-sdk");
+    expect(out).toContain("Additional durable agents reported by the SDK (1)");
+  });
+
+  it("--list (default) soft-fails when SDK list throws and notes it on stderr", async () => {
+    seedAgent("alpha", "agent-alpha");
+    sdkMocks.agentList.mockRejectedValue(new Error("network down"));
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
+    expect(io.captured.stdout.join("")).toContain("agent-alpha");
+    expect(io.captured.stderr.join("")).toContain("SDK agent list failed");
+    expect(io.captured.stderr.join("")).toContain("network down");
+  });
+
+  it("--list --json emits the merged structured shape", async () => {
+    seedAgent("alpha", "agent-alpha");
+    sdkMocks.agentList.mockResolvedValue({
+      items: [
+        {
+          agentId: "agent-only-sdk",
+          name: "x",
+          summary: "y",
+          lastModified: 1,
+        },
+      ],
+    });
+
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--json"), io)).toBe(0);
+    const parsed = JSON.parse(io.captured.stdout.join(""));
+    expect(Array.isArray(parsed.local)).toBe(true);
+    expect(parsed.local[0].agentId).toBe("agent-alpha");
+    expect(Array.isArray(parsed.remoteOnly)).toBe(true);
+    expect(parsed.remoteOnly[0].agentId).toBe("agent-only-sdk");
+    expect(parsed.remoteError).toBeNull();
+  });
+
+  it("--list with no local jobs prints '(no resumable agents)'", async () => {
+    sdkMocks.agentList.mockResolvedValue({ items: [] });
     const io = captureIO(workDir);
     expect(await companionMain(argv("resume", "--list"), io)).toBe(0);
     expect(io.captured.stdout.join("")).toContain("(no resumable agents)");
+  });
+
+  it("--list --local --remote is rejected", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--list", "--local", "--remote"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("mutually exclusive");
+  });
+
+  it("--local without --list is rejected", async () => {
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("resume", "--local", "agent-x", "go"), io)).toBe(2);
+    expect(io.captured.stderr.join("")).toContain("--local requires --list");
   });
 
   it("--write flips the policy and is reflected in the prompt", async () => {


### PR DESCRIPTION
- /cursor:result: tasks now render as a Markdown card with status, duration,
  agent id, fenced output, and resume hints (mirrors the review card). Add
  a `--raw` flag for downstream consumers that want the unwrapped output.
- /cursor:resume --list: default to a merged view that surfaces this
  workspace's local index plus any extra durable agents the SDK reports.
  Add `--local` for explicit local-only (preserved old behavior). The merged
  JSON shape becomes `{local, remoteOnly, remoteError}`; pass `--local --json`
  for the flat array. Soft-fail on SDK errors with a stderr footer.
- /cursor:cancel: when the in-memory Run is owned by a different process,
  print a loud stderr warning (and emit `splitBrain: true` in --json) so
  users understand the SDK run may keep going. Hint at `/cursor:resume <id>`
  with the actual agent id pulled from the cancelled job record.
- task.md / review.md: document gate behavior so users chaining the two
  commands know each issues at most one prompt and how to suppress it.