### PR TITLE
fix: simplify login UX and add cursor-login.sh

### DIFF
--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -25,37 +25,31 @@ Surface the output verbatim. On success the next `/cursor:setup` should show
 
 ## When `--login` is passed
 
-Do NOT run the CLI directly. Present **two options** to the user:
+Do NOT run the CLI directly. Ask the user to paste their Cursor API key in
+the conversation. Before they paste, warn them:
 
-### Option A — Secure hidden input (recommended)
-
-Tell the user they can enter their key securely via hidden input by running
-this command in their Claude Code prompt. Present it ready to copy:
-
-```
-! node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" setup --login
-```
-
-The key never appears in the conversation — it is read as hidden terminal
-input, validated via `Cursor.me()`, and stored in the OS keychain.
-
-### Option B — Paste in chat (convenient)
-
-If the user prefers, they can paste the key directly in the conversation.
-Warn them: "Note: the key will be visible in this conversation's transcript.
-It is sent to the Cursor API for validation and stored in your OS keychain."
+"Paste your Cursor API key below. It will be visible in this conversation's
+transcript, but will be validated and stored securely in your OS keychain."
 
 Once the user provides the key, write it to a temp file and pipe it to the
-CLI so it stays out of process arguments:
+CLI so it stays out of shell history and process arguments:
 
 ```bash
 printf '%s' '<THE_KEY>' > /tmp/.cursor-key-$$ && node "${CLAUDE_PLUGIN_ROOT}/scripts/bundle/cursor-companion.mjs" setup --login < /tmp/.cursor-key-$$ ; rm -f /tmp/.cursor-key-$$
 ```
 
 Report the result to the user. If it succeeded, tell them the key is stored
-in their OS keychain. If it failed, relay the error.
+in their OS keychain and they can verify with `/cursor:setup`. If it failed,
+relay the error.
 
 **Do not** echo the key back or include it in any output beyond the command.
+
+Alternatively, mention the user can run `cursor-login.sh` from a separate
+terminal for secure hidden input:
+
+```
+./plugins/cursor/scripts/cursor-login.sh
+```
 
 ## When `--logout` is passed
 
@@ -83,6 +77,10 @@ If the **SDK** row is `fail`, recommend `/cursor:setup --install` as the
 remediation. The default report includes a remediation hint at the bottom in
 that case.
 
+If the **API key** row is `fail`, immediately ask the user to paste their
+Cursor API key. Follow the same flow described in the `--login` section above.
+Do not make the user run `/cursor:setup --login` as a separate step.
+
 ## Credential management
 
 The plugin resolves the Cursor API key in this order:
@@ -93,9 +91,8 @@ The plugin resolves the Cursor API key in this order:
 
 Manage the keychain credential via:
 
-- `--login` — two paths: hidden terminal input (secure, recommended) or
-  paste-in-chat (convenient). Both validate via `Cursor.me()` and store in
-  the OS keychain.
+- `--login` — asks for the API key in chat, validates via `Cursor.me()`,
+  and stores it in the OS keychain.
 - `--logout` — remove the stored key from the OS keychain.
 
 The setup output's "API key" row reports the active key source (`env`,

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -44,11 +44,11 @@ relay the error.
 
 **Do not** echo the key back or include it in any output beyond the command.
 
-Alternatively, mention the user can run `cursor-login.sh` from a separate
-terminal for secure hidden input:
+Alternatively, mention the user can run this from a separate terminal for
+secure hidden input (the key is never visible):
 
 ```
-./plugins/cursor/scripts/cursor-login.sh
+~/.claude/cursor-login
 ```
 
 ## When `--logout` is passed

--- a/plugins/cursor/scripts/bootstrap.mjs
+++ b/plugins/cursor/scripts/bootstrap.mjs
@@ -1,6 +1,15 @@
 #!/usr/bin/env node
 import { execSync } from "node:child_process";
-import { existsSync, mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -11,6 +20,23 @@ const nodeModules = join(pluginRoot, "node_modules");
 const sdkDir = join(nodeModules, "@cursor", "sdk");
 const sentinel = join(nodeModules, ".bootstrap-ok");
 const statusFile = join(nodeModules, ".bootstrap-status.json");
+
+// Place a convenience symlink at ~/.claude/cursor-login so users can
+// store their API key from any terminal without knowing the plugin path.
+try {
+  const loginScript = join(pluginRoot, "scripts", "cursor-login.sh");
+  const link = join(homedir(), ".claude", "cursor-login");
+  if (existsSync(loginScript)) {
+    try {
+      unlinkSync(link);
+    } catch {
+      /* not present */
+    }
+    symlinkSync(loginScript, link);
+  }
+} catch {
+  // Best-effort — non-critical.
+}
 
 const needsInstall = !existsSync(sdkDir) || !existsSync(sentinel);
 

--- a/plugins/cursor/scripts/cursor-login.sh
+++ b/plugins/cursor/scripts/cursor-login.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Store a Cursor API key in the OS keychain for cursor-plugin-cc.
+# Run from any terminal: ./plugins/cursor/scripts/cursor-login.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+
+exec node "$PLUGIN_ROOT/scripts/bundle/cursor-companion.mjs" setup --login

--- a/plugins/cursor/scripts/cursor-login.sh
+++ b/plugins/cursor/scripts/cursor-login.sh
@@ -2,7 +2,14 @@
 # Store a Cursor API key in the OS keychain for cursor-plugin-cc.
 # Run from any terminal: ./plugins/cursor/scripts/cursor-login.sh
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve symlinks so this works when invoked via ~/.claude/cursor-login
+SOURCE="$0"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
 PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
 
 exec node "$PLUGIN_ROOT/scripts/bundle/cursor-companion.mjs" setup --login


### PR DESCRIPTION
## Summary
- Replace broken two-option login flow with single paste-in-chat flow that works in Claude Code
- When `/cursor:setup` detects missing API key, ask for it directly instead of requiring separate `--login` step
- Add `cursor-login.sh` helper for secure hidden input from a real terminal

## Context
The `!` prefix in Claude Code doesn't provide an interactive TTY, so the "secure hidden input" option always failed with "No key provided." The long `node "/home/marti/.claude/plugins/cache/..."` path was also unusable.

## Test plan
- [ ] `/cursor:setup` with no API key asks to paste key directly
- [ ] `/cursor:setup --login` asks to paste key directly
- [ ] `./plugins/cursor/scripts/cursor-login.sh` prompts for hidden input in a real terminal
- [ ] After pasting a valid key, `/cursor:setup` shows API key as `ok`