### PR TITLE
chore: bump Cursor SDK to 1.0.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
-        "@cursor/sdk": "^1.0.11",
+        "@cursor/sdk": "^1.0.12",
         "@napi-rs/keyring": "^1.3.0"
       },
       "devDependencies": {
@@ -216,9 +216,9 @@
       }
     },
     "node_modules/@cursor/sdk": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.11.tgz",
-      "integrity": "sha512-DkTwOAuao9wIeUioaM0aQi6hkWLC8oLAnqlR4HR9hn5xytd9A4cEB2fZpSHd8pJ2YRN0VJVkxnggxLRNT7ghuQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.12.tgz",
+      "integrity": "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
@@ -232,17 +232,17 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@cursor/sdk-darwin-arm64": "1.0.11",
-        "@cursor/sdk-darwin-x64": "1.0.11",
-        "@cursor/sdk-linux-arm64": "1.0.11",
-        "@cursor/sdk-linux-x64": "1.0.11",
-        "@cursor/sdk-win32-x64": "1.0.11"
+        "@cursor/sdk-darwin-arm64": "1.0.12",
+        "@cursor/sdk-darwin-x64": "1.0.12",
+        "@cursor/sdk-linux-arm64": "1.0.12",
+        "@cursor/sdk-linux-x64": "1.0.12",
+        "@cursor/sdk-win32-x64": "1.0.12"
       }
     },
     "node_modules/@cursor/sdk-darwin-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.11.tgz",
-      "integrity": "sha512-jbbdt4k1Wjjzsye9kfJtn7nPHd1QgBtOA1tbmLVbXIVb5UeAu+q7uT/8aggm8qN8R151m/GNW2ntK29+Q8y/XQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.12.tgz",
+      "integrity": "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==",
       "cpu": [
         "arm64"
       ],
@@ -253,9 +253,9 @@
       ]
     },
     "node_modules/@cursor/sdk-darwin-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.11.tgz",
-      "integrity": "sha512-2352S+tGbaDgj2qb3oNN2FUG5250cn3cD+aKluETFd7jI7Pm3ctwInFN+/NWWnzwftibjKnwcc8ghm9q4xYfWg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.12.tgz",
+      "integrity": "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==",
       "cpu": [
         "x64"
       ],
@@ -266,9 +266,9 @@
       ]
     },
     "node_modules/@cursor/sdk-linux-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.11.tgz",
-      "integrity": "sha512-SGnwU1caprU6L7XCMUH48pyGdrZz1YQhPNUzrUyixHpdfM951KJmAQyuW9Hj2J4J3C1PG4XwIYRHsGN8/EOF2g==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.12.tgz",
+      "integrity": "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==",
       "cpu": [
         "arm64"
       ],
@@ -279,9 +279,9 @@
       ]
     },
     "node_modules/@cursor/sdk-linux-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.11.tgz",
-      "integrity": "sha512-zzVwEMc9ykyyFgxaXwfiB0Nuqnp0PkKqiWSt6Iubmi7ADY87dtVS67qwtmVQ+FJVA7iXV+c7LY2sQ2qfQ4aP2w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.12.tgz",
+      "integrity": "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==",
       "cpu": [
         "x64"
       ],
@@ -292,9 +292,9 @@
       ]
     },
     "node_modules/@cursor/sdk-win32-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.11.tgz",
-      "integrity": "sha512-iWvGDFhpW+C6/zah7feY3oURozJxQ78qjld+9ejOaRuuC6p33Q6D/3l6Ihst18lEH9WSjEJClydDFUbm7aPf5A==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.12.tgz",
+      "integrity": "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "vitest": "^4.1.5"
   },
   "dependencies": {
-    "@cursor/sdk": "^1.0.11",
+    "@cursor/sdk": "^1.0.12",
     "@napi-rs/keyring": "^1.3.0"
   },
   "overrides": {

--- a/plugins/cursor/package-lock.json
+++ b/plugins/cursor/package-lock.json
@@ -6,9 +6,8 @@
   "packages": {
     "": {
       "name": "@cursor-plugin-cc/cursor",
-      "version": "0.1.0",
       "dependencies": {
-        "@cursor/sdk": "^1.0.11",
+        "@cursor/sdk": "^1.0.12",
         "@napi-rs/keyring": "^1.3.0"
       }
     },
@@ -53,9 +52,9 @@
       }
     },
     "node_modules/@cursor/sdk": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.11.tgz",
-      "integrity": "sha512-DkTwOAuao9wIeUioaM0aQi6hkWLC8oLAnqlR4HR9hn5xytd9A4cEB2fZpSHd8pJ2YRN0VJVkxnggxLRNT7ghuQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk/-/sdk-1.0.12.tgz",
+      "integrity": "sha512-jGx0wFY1N9uIdIKr303CfM6m/dLXmRCUnU/0yNP/oiOpkBXqgqaThGbgYbcOeVrYonMZc/DZJ9EydXOEPJLcbg==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@bufbuild/protobuf": "1.10.0",
@@ -69,17 +68,17 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@cursor/sdk-darwin-arm64": "1.0.11",
-        "@cursor/sdk-darwin-x64": "1.0.11",
-        "@cursor/sdk-linux-arm64": "1.0.11",
-        "@cursor/sdk-linux-x64": "1.0.11",
-        "@cursor/sdk-win32-x64": "1.0.11"
+        "@cursor/sdk-darwin-arm64": "1.0.12",
+        "@cursor/sdk-darwin-x64": "1.0.12",
+        "@cursor/sdk-linux-arm64": "1.0.12",
+        "@cursor/sdk-linux-x64": "1.0.12",
+        "@cursor/sdk-win32-x64": "1.0.12"
       }
     },
     "node_modules/@cursor/sdk-darwin-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.11.tgz",
-      "integrity": "sha512-jbbdt4k1Wjjzsye9kfJtn7nPHd1QgBtOA1tbmLVbXIVb5UeAu+q7uT/8aggm8qN8R151m/GNW2ntK29+Q8y/XQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-arm64/-/sdk-darwin-arm64-1.0.12.tgz",
+      "integrity": "sha512-AOFx+aX+4SntAeC66YncHACXk5duxp+HzDrxxF4Tl93N6nLjHaHEKSAXbt87ivL34MCHop4v/3c70QzBhamB2g==",
       "cpu": [
         "arm64"
       ],
@@ -90,9 +89,9 @@
       ]
     },
     "node_modules/@cursor/sdk-darwin-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.11.tgz",
-      "integrity": "sha512-2352S+tGbaDgj2qb3oNN2FUG5250cn3cD+aKluETFd7jI7Pm3ctwInFN+/NWWnzwftibjKnwcc8ghm9q4xYfWg==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-darwin-x64/-/sdk-darwin-x64-1.0.12.tgz",
+      "integrity": "sha512-/ZDAYFUrnPd8hAGRky9ZGcROqZSZ2b5W+aEjTdINzLhJ8x5ZNXtjaz0ZYSHabOn2BeErjXgTcq+4bX2/To4C1A==",
       "cpu": [
         "x64"
       ],
@@ -103,9 +102,9 @@
       ]
     },
     "node_modules/@cursor/sdk-linux-arm64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.11.tgz",
-      "integrity": "sha512-SGnwU1caprU6L7XCMUH48pyGdrZz1YQhPNUzrUyixHpdfM951KJmAQyuW9Hj2J4J3C1PG4XwIYRHsGN8/EOF2g==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-arm64/-/sdk-linux-arm64-1.0.12.tgz",
+      "integrity": "sha512-kAxNqiB3dPtlW9fVjjIZEdbIGEGLA9moOM3zYwsXh8J1Qw942nJYMGDGR4o8x0zglwZ24a1JpovvZamrCaC3Yw==",
       "cpu": [
         "arm64"
       ],
@@ -116,9 +115,9 @@
       ]
     },
     "node_modules/@cursor/sdk-linux-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.11.tgz",
-      "integrity": "sha512-zzVwEMc9ykyyFgxaXwfiB0Nuqnp0PkKqiWSt6Iubmi7ADY87dtVS67qwtmVQ+FJVA7iXV+c7LY2sQ2qfQ4aP2w==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-linux-x64/-/sdk-linux-x64-1.0.12.tgz",
+      "integrity": "sha512-RmBiBCPKMZC5McDerGk2Rk4P47xz2A+uzRoRgH6sMoOjklc33ry11iAZC0D5F5xH85chgY878086A/Q8+XrAuA==",
       "cpu": [
         "x64"
       ],
@@ -129,9 +128,9 @@
       ]
     },
     "node_modules/@cursor/sdk-win32-x64": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.11.tgz",
-      "integrity": "sha512-iWvGDFhpW+C6/zah7feY3oURozJxQ78qjld+9ejOaRuuC6p33Q6D/3l6Ihst18lEH9WSjEJClydDFUbm7aPf5A==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@cursor/sdk-win32-x64/-/sdk-win32-x64-1.0.12.tgz",
+      "integrity": "sha512-uH4shdHrKOdtNLapy1uuScJ9lL2Pc8zc9I9ZKC6b6bx+0UX6xLAqjPP7dqVPfO6D9u61yLq1Hs86XOLs5ZVkPA==",
       "cpu": [
         "x64"
       ],

--- a/plugins/cursor/package.json
+++ b/plugins/cursor/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "scripts/bundle/cursor-companion.mjs",
   "dependencies": {
-    "@cursor/sdk": "^1.0.11",
+    "@cursor/sdk": "^1.0.12",
     "@napi-rs/keyring": "^1.3.0"
   },
   "overrides": {


### PR DESCRIPTION
## Summary

- Bump `@cursor/sdk` from `1.0.11` to `1.0.12` in the root project and bundled plugin package.
- Refresh both lockfiles for the SDK's platform optional packages.

## Verification

- `npm run check`
- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm audit --omit=dev`
- `npm audit --omit=dev --prefix plugins/cursor`


Made with [Cursor](https://cursor.com)