### PR TITLE
docs: add changelog-backed release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,13 +71,25 @@ jobs:
             RANGE="HEAD"
           fi
 
+          CHANGELOG_BODY="$(
+            awk -v version="${{ steps.version.outputs.version }}" '
+              $0 ~ "^## v" version "([[:space:]-]|$)" { capture=1; next }
+              capture && /^## / { exit }
+              capture { print }
+            ' CHANGELOG.md | sed '/./,$!d'
+          )"
+
           {
             echo 'body<<RELEASE_EOF'
-            echo "## What's Changed"
-            echo ""
-            git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges
-            echo ""
-            echo ""
+            if [ -n "$CHANGELOG_BODY" ]; then
+              printf '%s\n\n' "$CHANGELOG_BODY"
+            else
+              echo "## What's Changed"
+              echo ""
+              git log "$RANGE" --pretty=format:"- %s (%h)" --no-merges
+              echo ""
+              echo ""
+            fi
             echo "**Full changelog**: https://github.com/${{ github.repository }}/compare/${PREV_TAG:-$(git rev-list --max-parents=0 HEAD | head -1)}...${{ github.ref_name }}"
             echo 'RELEASE_EOF'
           } >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+## v1.0.1 - 2026-05-03
+
+### Added
+
+- Added `~/.claude/cursor-login` as a convenience helper for local, masked API-key entry.
+- Added explicit plugin manifest versioning so installed plugins update only when the release version changes.
+- Added release workflow validation that requires the `v*` tag to match `plugins/cursor/.claude-plugin/plugin.json`.
+
+### Changed
+
+- Improved `/cursor:setup --login` typing feedback by showing `*` per character with working backspace.
+- Updated setup onboarding to strongly recommend `CURSOR_API_KEY` or `~/.claude/cursor-login` instead of pasting API keys into Claude Code chat.
+- Updated README quick start with a simple copy/edit/paste command for setting `CURSOR_API_KEY`.
+- Bumped `@cursor/sdk` from `1.0.11` to `1.0.12`.
+
+### Fixed
+
+- Fixed `~/.claude/cursor-login` symlink resolution so the helper works when invoked through the bootstrap-created symlink.
+
+## v1.0.0 - 2026-05-03
+
+### Added
+
+- Initial 1.0.0 release of the Cursor plugin for Claude Code.


### PR DESCRIPTION
## Summary

- Add `CHANGELOG.md` with detailed entries for `v1.0.1` and the initial `v1.0.0` release.
- Update the release workflow to use the matching changelog section for GitHub release notes, falling back to commit subjects when no section exists.
- Manually updated the already-created `v1.0.1` GitHub release notes to include the fuller changelog summary.

## Verification

- `npm run check`


Made with [Cursor](https://cursor.com)