### PR TITLE
fix: improve keychain API key onboarding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": { "name": "cursor-plugin-cc" },
   "metadata": {
     "description": "Cursor plugin for Claude Code — delegation and code review.",
-    "version": "1.0.1"
+    "version": "1.0.2"
   },
   "plugins": [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented here.
 
+## v1.0.2 - 2026-05-03
+
+### Changed
+
+- Made `~/.claude/cursor-login` the primary recommended setup path for storing the Cursor API key in the OS keychain.
+- Clarified the README and `/cursor:setup` guidance with explicit keychain and environment-variable commands.
+- Improved `--login` failure output with keychain troubleshooting, including WSL/Linux Secret Service package guidance.
+
 ## v1.0.1 - 2026-05-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ Use [Cursor](https://cursor.com) as a second AI agent from inside [Claude Code](
 
 **Set up your API key once:**
 
-Recommended: add `CURSOR_API_KEY` to your shell profile once, then start a new
-Claude Code session. Copy this command, replace `YOUR_CURSOR_API_KEY_HERE` with
-your actual Cursor API key, then paste it into your normal terminal:
+Recommended: store the key in your OS keychain with the local helper. Run this
+from a normal terminal (outside Claude Code); it prompts with masked input and
+keeps the key out of Claude Code chat:
+
+```bash
+~/.claude/cursor-login
+```
+
+If you prefer an environment variable, copy this command, replace
+`YOUR_CURSOR_API_KEY_HERE` with your actual Cursor API key, then paste it into
+your normal terminal:
 
 ```bash
 echo 'export CURSOR_API_KEY="YOUR_CURSOR_API_KEY_HERE"' >> ~/.bashrc
@@ -41,11 +49,10 @@ echo 'export CURSOR_API_KEY="YOUR_CURSOR_API_KEY_HERE"' >> ~/.bashrc
 
 Use `~/.zshrc` instead of `~/.bashrc` in the command if you use zsh.
 
-If you prefer OS keychain storage, run the local helper from a normal terminal.
-It prompts locally with masked input and keeps the key out of Claude Code chat:
+If keychain storage fails on WSL/Linux, install Secret Service support and retry:
 
 ```bash
-~/.claude/cursor-login
+sudo apt-get install gnome-keyring libsecret-tools dbus-user-session
 ```
 
 > [!WARNING]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-plugin-cc",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@cursor/sdk": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-plugin-cc",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "private": true,
   "description": "Claude Code plugin that delegates work to Cursor's AI agent via @cursor/sdk.",
   "license": "MIT",

--- a/plugins/cursor/.claude-plugin/plugin.json
+++ b/plugins/cursor/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor",
   "description": "Use Cursor from Claude Code to review code or delegate tasks.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": { "name": "N3RDMJ" }
 }

--- a/plugins/cursor/commands/setup.md
+++ b/plugins/cursor/commands/setup.md
@@ -32,9 +32,9 @@ warning and recommend one of the local setup paths:
 are comfortable with it being visible in the session transcript and sent through
 Claude Code's normal prompt flow. The safer options are:
 
-1. Set it once in your shell profile as `CURSOR_API_KEY`, then restart Claude Code.
-2. Run `~/.claude/cursor-login` from a separate terminal, which prompts locally
-   with masked input and stores the key in the OS keychain."
+1. Run `~/.claude/cursor-login` from a separate terminal, which prompts locally
+   with masked input and stores the key in the OS keychain.
+2. Set it once in your shell profile as `CURSOR_API_KEY`, then restart Claude Code."
 
 Show the script command as the recommended `--login` path:
 
@@ -42,8 +42,8 @@ Show the script command as the recommended `--login` path:
 ~/.claude/cursor-login
 ```
 
-If the user wants the environment-variable path, give them a readable command
-they can copy, replace the placeholder value in, and run in their normal
+If the user wants the environment-variable path instead, give them a readable
+command they can copy, replace the placeholder value in, and run in their normal
 terminal:
 
 ```bash
@@ -88,9 +88,9 @@ that case.
 If the **API key** row is `fail`, do **not** immediately ask the user to paste
 their Cursor API key. Recommend the set-once options first:
 
-1. `CURSOR_API_KEY` in their shell profile, then restart Claude Code.
-2. `~/.claude/cursor-login` in a separate terminal for local masked input and OS
+1. `~/.claude/cursor-login` in a separate terminal for local masked input and OS
    keychain storage.
+2. `CURSOR_API_KEY` in their shell profile, then restart Claude Code.
 
 Mention paste-in-chat only as a last resort, with the strong warning from the
 `--login` section.
@@ -105,10 +105,10 @@ The plugin resolves the Cursor API key in this order:
 
 Manage the keychain credential via:
 
-- `CURSOR_API_KEY` — recommended set-once path. Add it to a shell profile or a
-  local environment manager before starting Claude Code.
-- `--login` — local OS-keychain storage. Prefer `~/.claude/cursor-login` from a
-  separate terminal so the key is entered locally with masked input.
+- `--login` — recommended set-once keychain path. Prefer `~/.claude/cursor-login`
+  from a separate terminal so the key is entered locally with masked input.
+- `CURSOR_API_KEY` — environment-variable fallback. Add it to a shell profile or
+  a local environment manager before starting Claude Code.
 - `--logout` — remove the stored key from the OS keychain.
 
 The setup output's "API key" row reports the active key source (`env`,

--- a/plugins/cursor/scripts/bundle/cursor-companion.mjs
+++ b/plugins/cursor/scripts/bundle/cursor-companion.mjs
@@ -938,10 +938,28 @@ async function readHiddenInput(io) {
     stdin.on("data", onData);
   });
 }
+function keychainUnavailableMessage(detail) {
+  const lines = [
+    "Could not store the Cursor API key in the OS keychain.",
+    "",
+    "Recommended:",
+    "  1. Run the local keychain helper from a normal terminal:",
+    "     ~/.claude/cursor-login",
+    "  2. If keychain storage is not available, use CURSOR_API_KEY instead:",
+    `     echo 'export CURSOR_API_KEY="YOUR_CURSOR_API_KEY_HERE"' >> ~/.bashrc`,
+    "",
+    "On WSL/Linux, the keychain backend requires Secret Service. Install it with:",
+    "  sudo apt-get install gnome-keyring libsecret-tools dbus-user-session"
+  ];
+  if (detail) {
+    lines.push("", `Underlying error: ${detail}`);
+  }
+  return lines.join("\n");
+}
 async function runLogin(io, json) {
   const backend = detectBackend();
   if (!backend) {
-    const msg = "No supported keychain backend on this platform. Use CURSOR_API_KEY env instead.";
+    const msg = keychainUnavailableMessage("No supported keychain backend on this platform.");
     if (json) {
       io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}
 `);
@@ -978,7 +996,19 @@ async function runLogin(io, json) {
     }
     return 1;
   }
-  await storeApiKey(key);
+  try {
+    await storeApiKey(key);
+  } catch (err) {
+    const msg = keychainUnavailableMessage(errorMessage(err));
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}
+`);
+    } else {
+      io.stderr.write(`${msg}
+`);
+    }
+    return 1;
+  }
   if (json) {
     io.stdout.write(
       `${JSON.stringify({ ok: true, source: "keychain", backend: backend.name, apiKeyName })}

--- a/plugins/cursor/scripts/commands/setup.mts
+++ b/plugins/cursor/scripts/commands/setup.mts
@@ -317,10 +317,29 @@ async function readHiddenInput(io: CommandIO): Promise<string> {
   });
 }
 
+function keychainUnavailableMessage(detail?: string): string {
+  const lines = [
+    "Could not store the Cursor API key in the OS keychain.",
+    "",
+    "Recommended:",
+    "  1. Run the local keychain helper from a normal terminal:",
+    "     ~/.claude/cursor-login",
+    "  2. If keychain storage is not available, use CURSOR_API_KEY instead:",
+    "     echo 'export CURSOR_API_KEY=\"YOUR_CURSOR_API_KEY_HERE\"' >> ~/.bashrc",
+    "",
+    "On WSL/Linux, the keychain backend requires Secret Service. Install it with:",
+    "  sudo apt-get install gnome-keyring libsecret-tools dbus-user-session",
+  ];
+  if (detail) {
+    lines.push("", `Underlying error: ${detail}`);
+  }
+  return lines.join("\n");
+}
+
 async function runLogin(io: CommandIO, json: boolean): Promise<ExitCode> {
   const backend = detectBackend();
   if (!backend) {
-    const msg = "No supported keychain backend on this platform. Use CURSOR_API_KEY env instead.";
+    const msg = keychainUnavailableMessage("No supported keychain backend on this platform.");
     if (json) {
       io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
     } else {
@@ -354,7 +373,17 @@ async function runLogin(io: CommandIO, json: boolean): Promise<ExitCode> {
     return 1;
   }
 
-  await storeApiKey(key);
+  try {
+    await storeApiKey(key);
+  } catch (err) {
+    const msg = keychainUnavailableMessage(errorMessage(err));
+    if (json) {
+      io.stdout.write(`${JSON.stringify({ ok: false, error: msg })}\n`);
+    } else {
+      io.stderr.write(`${msg}\n`);
+    }
+    return 1;
+  }
 
   if (json) {
     io.stdout.write(

--- a/tests/cli/setup.test.mts
+++ b/tests/cli/setup.test.mts
@@ -186,6 +186,16 @@ describe("CLI: setup", () => {
     expect(io.captured.stderr.join("")).toContain("mutually exclusive");
   });
 
+  it("--login explains keychain setup alternatives when no backend is available", async () => {
+    setBackendForTesting(null);
+    const io = captureIO(workDir);
+    expect(await companionMain(argv("setup", "--login"), io)).toBe(1);
+    const err = io.captured.stderr.join("");
+    expect(err).toContain("~/.claude/cursor-login");
+    expect(err).toContain("CURSOR_API_KEY");
+    expect(err).toContain("gnome-keyring");
+  });
+
   it("--logout fails gracefully when no backend", async () => {
     setBackendForTesting(null);
     const io = captureIO(workDir);


### PR DESCRIPTION
## Summary

- Make `~/.claude/cursor-login` the primary recommended API-key setup path in the README and `/cursor:setup` instructions.
- Add clearer keychain failure output with local helper, env-var fallback, and WSL/Linux Secret Service install guidance.
- Bump plugin/package metadata to `1.0.2` and add the changelog entry.

## Verification

- `npm run check`
- `npm run typecheck`
- `npm run build`
- `npm test`


Made with [Cursor](https://cursor.com)